### PR TITLE
Don't build examples with the main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,5 @@ endif()
 find_package(Boost REQUIRED unit_test_framework)
 include_directories(${Boost_INCLUDE_DIR})
 
-add_subdirectory(examples)
 enable_testing()
 add_subdirectory(tests)


### PR DESCRIPTION
In the current state, the CMake configuration fails because `examples` doesn't contain a `CMakeLists.txt` file. This fix removes the offending line.

An alternative would be to add `CMakeLists.txt` to `examples` directory. However, the majority of examples require CMake 3.12, whereas the main project requires CMake 3.10. Aside from that, some CMake configurations, such as `distance_examples/CMakeLists.txt` is broken.