### PR TITLE
Add a note about minimum memory requirements

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -22,6 +22,8 @@ $ sudo apt install libpqxx-dev postgresql-server-dev-all
 ```
 ### Build
 
+If you are building it from inside a virtual machine, make sure to provision at least **2 GiB of virtual memory** for the build process to succeed.
+
 ```
   $ mkdir build
   $ cd build


### PR DESCRIPTION
On the Ubuntu 18.04 box, the build process crashes with an out-of-memory error if less than 2 GiB of virtual memory is provisioned in VirtualBox.