### PR TITLE
 remove depenedency from std::vector from metric::Matrix, issue #80

### DIFF
--- a/modules/space/matrix.cpp
+++ b/modules/space/matrix.cpp
@@ -8,44 +8,105 @@ Copyright (c) 2019  Panda Team
 #ifndef _METRIC_SPACE_MATRIX_CPP
 #define _METRIC_SPACE_MATRIX_CPP
 #include "matrix.hpp"
+#include <stdexcept>
+#include <type_traits>
 
 namespace metric {
 
-/*** constructor: with a vector data records **/
-template <typename recType, typename Metric, typename distType>
-Matrix<recType, Metric, distType>::Matrix(const std::vector<recType>& p, Metric d)
-    : metric_(d)
-    , D_(p.size())
-    , data_(p)
-
-{
-    for (size_t i = 0; i < D_.columns(); ++i) {
-        D_(i, i) = 0;
-        for (size_t j = i + 1; j < D_.rows(); ++j) {
-            auto distance = metric_(p[i], p[j]);
-            D_(i, j) = distance;
-        }
-    }
-}
-
-template <typename recType, typename Metric, typename distType>
-distType Matrix<recType, Metric, distType>::operator()(size_t i, size_t j) const
+template <typename recType, typename Metric>
+auto Matrix<recType, Metric>::operator()(size_t i, size_t j) const -> distType
 {
     return D_(i, j);
 }
 
-template <typename recType, typename Metric, typename distType>
-recType Matrix<recType, Metric, distType>::operator[](size_t id) const
+template <typename recType, typename Metric>
+recType Matrix<recType, Metric>::operator[](size_t id) const
 {
     return (data_(id));
 }
 
-template <typename recType, typename Metric, typename distType>
-size_t Matrix<recType, Metric, distType>::size() const
+template <typename recType, typename Metric>
+size_t Matrix<recType, Metric>::size() const
 {
     return data_.size();
 }
 
-}  // namespace metric
+template <typename recType, typename Metric>
+std::size_t Matrix<recType, Metric>::insert(const recType& item)
+{
+    std::size_t old_size = D_.rows();
+    D_.resize(old_size + 1, true);
+    for (std::size_t i = 0; i < old_size; i++) {
+        D_(i, old_size) = metric_(data_[i], item);
+    }
+    data_.push_back(item);
+    return old_size;
+}
 
+template <typename recType, typename Metric>
+template <typename Container,
+          typename>
+std::vector<std::size_t>
+Matrix<recType, Metric>::insert(const Container& items)
+{
+    std::vector<std::size_t> ids;
+    ids.reserve(items.size());
+    for (auto& i : items) {
+        auto id = insert(i);
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+// unimplemented stuff
+template <typename recType, typename Metric>
+std::pair<std::size_t, bool> Matrix<recType, Metric>::insert_if(const recType& p, distType threshold)
+{
+    //    throw std::runtime_error("not implemented yet");
+    return std::pair { 0, false };
+}
+template <typename recType, typename Metric>
+template <typename Container, typename>
+std::vector<std::pair<std::size_t, bool>> Matrix<recType, Metric>::insert_if(const Container& p, distType threshold)
+{
+    //    throw std::runtime_error("not implemented yet");
+    return std::vector<std::pair<std::size_t, bool>> {};
+}
+
+template <typename recType, typename Metric>
+bool Matrix<recType, Metric>::erase(std::size_t id)
+{
+    //    throw std::runtime_error("not implemented yet");
+    return false;
+}
+
+template <typename recType, typename Metric>
+void Matrix<recType, Metric>::set(std::size_t id, const recType& p)
+{
+    //    throw std::runtime_error("not implemented yet");
+}
+
+template <typename recType, typename Metric>
+std::size_t Matrix<recType, Metric>::nn(const recType& p) const
+{
+    //    throw std::runtime_error("not implemented yet");
+    return 0;
+}
+
+template <typename recType, typename Metric>
+auto Matrix<recType, Metric>::knn(const recType& p, unsigned k) const -> std::vector<std::pair<std::size_t, distType>>
+{
+    //    throw std::runtime_error("not implemented yet");
+    return std::vector<std::pair<std::size_t, distType>> {};
+}
+
+template <typename recType, typename Metric>
+auto Matrix<recType, Metric>::rnn(const recType& p, distType distance) const
+    -> std::vector<std::pair<std::size_t, distType>>
+{
+    //    throw std::runtime_error("not implemented yet");
+    return std::vector<std::pair<std::size_t, distType>> {};
+}
+
+}  // namespace metric
 #endif

--- a/modules/space/matrix.hpp
+++ b/modules/space/matrix.hpp
@@ -47,7 +47,7 @@ public:
     /**
      * @brief Construct a new Matrix with set of data records
      *
-     * @param p vector of data records
+     * @param p random access container of data records
      * @param d metric object to use as distance
      */
     template <typename Container,
@@ -85,9 +85,8 @@ public:
     /**
      * @brief append set of data records to the matrix
      *
-     * @param p vector of the new data records
+     * @param p random access container with new data records
      * @return vector of ID of inserted node
-     * @return false if operation is unsuccesful
      */
     template <typename Container,
         typename = std::enable_if<

--- a/modules/space/matrix.hpp
+++ b/modules/space/matrix.hpp
@@ -11,7 +11,7 @@ Copyright (c) 2018 Michael Welsch
 #define _METRIC_SPACE_MATRIX_HPP
 
 #include "../distance.hpp"
-
+#include <type_traits>
 namespace metric {
 
 /**
@@ -20,10 +20,11 @@ namespace metric {
  * @brief distance matrix
  *
  */
-template <typename recType, typename Metric = metric::Euclidian<typename recType::value_type>,
-    typename distType = float>
+template <typename recType, typename Metric>
 class Matrix {
 public:
+    using distType = typename Metric::distance_type;
+    
     /*** Constructors ***/
 
     /**
@@ -31,7 +32,7 @@ public:
      *
      * @param d metric object to use as distance
      */
-    Matrix(Metric d = Metric());
+    explicit Matrix(Metric d = Metric()):metric_(d) {}
 
     /**
      * @brief Construct a new Matrix with one data record
@@ -39,7 +40,9 @@ public:
      * @param p data record
      * @param d metric object to use as distance
      */
-    Matrix(const recType& p, Metric d = Metric());
+    explicit Matrix(const recType& p, Metric d = Metric()): metric_(d) {
+        insert(p);
+    }
 
     /**
      * @brief Construct a new Matrix with set of data records
@@ -47,8 +50,14 @@ public:
      * @param p vector of data records
      * @param d metric object to use as distance
      */
-
-    Matrix(const std::vector<recType>& p, Metric d = Metric());
+    template <typename Container,
+              typename =  std::enable_if<
+                  std::is_same<recType, typename std::decay<decltype(std::declval<Container>().operator[](0))>::type>::value>>
+    explicit Matrix(const Container& p, Metric d = Metric())
+        : metric_(d)
+    {
+        insert(p);
+    }
 
     /**
      * @brief Destroy the Matrix object
@@ -56,45 +65,48 @@ public:
      */
     ~Matrix() {};
 
-    /*** Access Operations ***/
-
     /**
      * @brief append data record to the matrix
      *
      * @param p data record
-     * @return true if append is successful
-     * @return false if operation is unsuccesful
+     * @return ID of inserted node
      */
-    bool append(const recType& p);
+    std::size_t insert(const recType& p);
 
     /**
      * @brief append data record into the Matrix only if distance bigger than a treshold
      *
      * @param p data record
      * @param treshold distance threshold
-     * @return true if operation is successful
-     * @return false if operation is unsuccesful
+     * @return pair consist of ID and result of insertion
      */
-    bool append_if(const recType& p, distType treshold);
+    std::pair<std::size_t, bool> insert_if(const recType& p, distType treshold);
 
     /**
      * @brief append set of data records to the matrix
      *
      * @param p vector of the new data records
-     * @return true if append is successful
+     * @return vector of ID of inserted node
      * @return false if operation is unsuccesful
      */
-    bool append(const std::vector<recType>& p);
+    template <typename Container,
+        typename = std::enable_if<
+            std::is_same<recType, typename std::decay<decltype(std::declval<Container>().operator[](0))>::type>
+            ::value>>
+    std::vector<std::size_t> insert(const Container& p);
 
     /**
      * @brief append data records into the Matrix only if distance bigger than a treshold
      *
      * @param p set of data records
      * @param treshold distance threshold
-     * @return true if operation is successful
-     * @return false if operation is unsuccesful
+     * @return vector of pairs consists of ID and result of insertion
      */
-    bool append_if(const std::vector<recType>& p, distType treshold);
+    template <typename Container,
+              typename = std::enable_if<
+                  std::is_same<recType, typename std::decay<decltype(std::declval<Container>().operator[](0))>::type>
+                  ::value>>
+    std::vector<std::pair<std::size_t, bool>> insert_if(const Container& p, distType treshold);
 
     /**
      * @brief erase data record from Matrix by ID
@@ -110,18 +122,18 @@ public:
      *
      * @param id ID of data record
      * @param p  new data record
-     * @return true if operation successful
-     * @return false if operation unsucessful
      */
-    bool set(size_t id, const recType& p);
+    void set(size_t id, const recType& p);
 
     /**
      * @brief access a data record by ID
      *
      * @param id data record ID
      * @return data record with ID == id
+     * @throws std::runtime_error when matrix has no element with ID
      */
     recType operator[](size_t id) const;
+    
 
     /**
      * @brief access a distance by two IDs
@@ -140,6 +152,33 @@ public:
      * @return amount of data records
      */
     size_t size() const;
+
+    /**
+     * @brief find nearest neighbour of data record
+     *
+     * @param p searching data record
+     * @return ID of nearest neighbour to p
+     */
+    std::size_t nn(const recType & p) const;
+
+    /**
+     * @brief find  K nearest neighbours of data record
+     *
+     * @param p searching data record
+     * @param k amount of nearest neighbours
+     * @return vector of pair of node ID and distance to searching point
+     */
+    std::vector<std::pair<std::size_t, distType>> knn(const recType & p, unsigned k = 10) const;
+
+    /**
+     * @brief find all nearest neighbour in range [0;distance]
+     *
+     * @param p searching point
+     * @param distance max distance to searching point
+     * @return vector of pair of node ID and distance to searching point
+     */
+
+    std::vector<std::pair<std::size_t, distType>> rnn(const recType & p, distType distance = 1.0) const;
 
 private:
     /*** Properties ***/

--- a/tests/space_tests/space_matrix_tests.cpp
+++ b/tests/space_tests/space_matrix_tests.cpp
@@ -1,0 +1,43 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2020 Panda Team
+*/
+
+#include <boost/test/tools/old/interface.hpp>
+#include <stdexcept>
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE space_matrix_test
+#include <boost/test/unit_test.hpp>
+
+#include "modules/space.hpp"
+
+BOOST_AUTO_TEST_CASE(matrix_constructor) {
+    // create empty matrix
+    metric::Matrix<std::vector<float>, metric::Euclidian<float>> m;
+    BOOST_TEST(m.size() == 0);
+
+    // create matrix with initial values
+    metric::Matrix<std::vector<float>, metric::Euclidian<float>> m1(std::vector<float>{1});
+    BOOST_TEST(m1.size() == 1);
+
+    std::vector<std::vector<float>> data = {{1}, {2}, {3}};
+    metric::Matrix<std::vector<float>, metric::Euclidian<float>> m2(data);
+    BOOST_TEST(m2.size() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(matrix_insert) {
+    metric::Matrix<float, metric::Euclidian<float>> m;
+    BOOST_TEST(m.size() == 0);
+    std::size_t id1 = m.insert(1.0);
+    BOOST_TEST(id1 == 0);
+    BOOST_TEST(m.size() == 1);
+
+    std::vector<float> d = {1,2,3,4};
+    auto ids = m.insert(d);
+    BOOST_TEST(m.size() == 5);
+    std::vector<std::size_t> ids_eta = {1, 2, 3, 4};
+    BOOST_CHECK_EQUAL_COLLECTIONS(ids.begin(), ids.end(), ids_eta.begin(),ids_eta.end());
+}


### PR DESCRIPTION
remove strong dependency of std::vector from metric::Matrix, issue #80.
declare public API of the metric::Matrix class, preparation for solving issue #37