### PR TITLE
Iss80 fix

### DIFF
--- a/examples/correlation_examples/CMakeLists.txt
+++ b/examples/correlation_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(correlation_examples)
 

--- a/examples/dnn_examples/CMakeLists.txt
+++ b/examples/dnn_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 project(dnn_example)
 
 find_package(BLAS)

--- a/examples/ensemble_examples/CMakeLists.txt
+++ b/examples/ensemble_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(ensemble_examples)
 

--- a/examples/laplacians_example/CMakeLists.txt
+++ b/examples/laplacians_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(laplacians_examples)
 

--- a/examples/laplacians_example/sparsification_test.cpp
+++ b/examples/laplacians_example/sparsification_test.cpp
@@ -38,7 +38,7 @@ void sparsification_test()
 
     blaze::CompressedMatrix<double, blaze::columnMajor> Gp = metric::power(G, 15);
 
-    blaze::CompressedMatrix<double, blaze::columnMajor> Gsparse = metric::sparsify(Gp, 1.0F);
+    blaze::CompressedMatrix<double, blaze::columnMajor> Gsparse = metric::sparsify_effective_resistance(Gp, 1.0F);
 
     std::cout << "Dimension:" << Gp.rows() << "\n";
 

--- a/examples/mapping_examples/quantized_mappers/clustering/KMedoids_example.cpp
+++ b/examples/mapping_examples/quantized_mappers/clustering/KMedoids_example.cpp
@@ -22,7 +22,7 @@ int main()
 		   {5.81414000000000, 8.14015000000000, 3.22950000000000, 139.539000000000, 139.539000000000},
 		   {2.57927000000000, 2.63399000000000, 2.46802000000000, 61.9026000000000, 61.9026000000000} };
 
-	metric::Matrix<std::vector<float>, metric::Euclidian<float>, float> matrix(data);
+	metric::Matrix<std::vector<float>, metric::Euclidian<float>> matrix(data);
 	auto[assignments, seeds, counts] = metric::kmedoids(matrix, 4);
 	// out:
 

--- a/examples/space_examples/CMakeLists.txt
+++ b/examples/space_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(Boost_DEBUG on)  
 find_package(Boost)

--- a/examples/transform_examples/CMakeLists.txt
+++ b/examples/transform_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(transform_examples)
 
@@ -31,5 +31,7 @@ foreach(exampleSrc ${EXAMPLE_SRCS})
 	target_link_libraries(${exampleName} ${ZLIB_LIBRARIES})
 	target_link_libraries(${exampleName} Threads::Threads)
 	set_target_properties(${exampleName} PROPERTIES CXX_STANDARD 17)
-
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+	    target_link_libraries(${exampleName} stdc++fs)
+	endif()
 endforeach(exampleSrc)

--- a/examples/transform_examples/dwt_benchmark.cpp
+++ b/examples/transform_examples/dwt_benchmark.cpp
@@ -5,7 +5,7 @@
 #include <random>
 
 //#include "transform/wavelet.hpp"
-#include "transform/energy_encoder.cpp"
+#include "../../modules/transform/energy_encoder.cpp"
 
 
 template <typename T>

--- a/examples/transform_examples/energy_encoder_example.cpp
+++ b/examples/transform_examples/energy_encoder_example.cpp
@@ -1,5 +1,5 @@
 
-#include "transform/energy_encoder.cpp"
+#include "../../modules/transform/energy_encoder.cpp"
 
 #include <iostream>
 

--- a/examples/transform_examples/wav_compressor.cpp
+++ b/examples/transform_examples/wav_compressor.cpp
@@ -11,7 +11,18 @@
 #include <unordered_map>
 #include <cstring>
 #include <chrono>
+#ifdef __GNUC__
+  #if __GNUC_PREREQ(8,0)
+	#include <filesystem>
+        namespace fs = std::filesystem;
+  #else
+	#include <experimental/filesystem>
+        namespace fs = std::experimental::filesystem;
+  #endif
+#else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
 //#include <experimental/filesystem> // edited by Max F
 #include <boost/iostreams/filter/zlib.hpp>
 #include <boost/program_options.hpp>
@@ -56,7 +67,7 @@ void compress_file(const std::string& file_name, std::string out_name, Compresso
         8, boost::iostreams::zlib::huffman_only);
     std::vector<char> v = compressor.compress(boost::iostreams::zlib_compressor(zp));
     if(out_name.empty()) {
-        out_name = std::filesystem::path(file_name).filename().string() + ".z";
+        out_name = fs::path(file_name).filename().string() + ".z";
         //out_name = std::experimental::filesystem::path(file_name).filename().string() + ".z"; // edited by Max F, Jan, 9, 2020
     }
 

--- a/examples/transform_examples/wavelet_example.cpp
+++ b/examples/transform_examples/wavelet_example.cpp
@@ -4,10 +4,10 @@
 
 //#include "../../modules/transform.hpp"
 //#include "transform/wavelet.hpp"
-#include "transform/wavelet.hpp"
+#include "../../modules/transform/wavelet.hpp"
 
 #include "assets/helpers.cpp"
-#include "modules/utils/visualizer.hpp"
+#include "../../modules/utils/visualizer.hpp"
 
 //#include "transform/helper_functions.cpp" // TODO remove
 

--- a/modules/mapping/affprop.hpp
+++ b/modules/mapping/affprop.hpp
@@ -35,9 +35,9 @@ namespace metric {
  * @param damp
  * @return
 */
-template <typename recType, typename Metric, typename T>
+    template <typename recType, typename Metric, typename T = typename Metric::distance_type>
 std::tuple<std::vector<std::size_t>, std::vector<std::size_t>, std::vector<std::size_t>> affprop(
-    const Matrix<recType, Metric, T>& DM, T preference = 0.5, int maxiter = 200, T tol = 1.0e-6, T damp = 0.5)
+    const Matrix<recType, Metric>& DM, T preference = 0.5, int maxiter = 200, T tol = 1.0e-6, T damp = 0.5)
 {
 
     // check arguments

--- a/modules/mapping/dbscan.cpp
+++ b/modules/mapping/dbscan.cpp
@@ -71,7 +71,7 @@ namespace dbscan_details {
 
 // main algorithm
 template <typename recType, typename Metric, typename T>
-std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> dbscan(const Matrix<recType, Metric, T>& DM,
+std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> dbscan(const Matrix<recType, Metric>& DM,
                                                                         T eps, std::size_t minpts)
 {
 

--- a/modules/mapping/dbscan.hpp
+++ b/modules/mapping/dbscan.hpp
@@ -35,7 +35,7 @@ namespace metric {
  *          size of corresponding cluster.
  */
 template <typename recType, typename Metric, typename T>
-std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> dbscan(const metric::Matrix<recType, Metric, T>& dm, T eps, std::size_t minpts);
+std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> dbscan(const metric::Matrix<recType, Metric>& dm, T eps, std::size_t minpts);
 
 }  // namespace metric
 

--- a/modules/mapping/kmedoids.cpp
+++ b/modules/mapping/kmedoids.cpp
@@ -16,8 +16,8 @@ Copyright (c) 2018 M.Welsch
 
 namespace metric {
 namespace kmedoids_details {
-    template <typename recType, typename Metric, typename T>
-    T update_cluster(const metric::Matrix<recType, Metric, T>& DM, std::vector<int>& seeds,
+    template <typename recType, typename Metric, typename T = typename metric::Matrix<recType, Metric>::distType >
+    T update_cluster(const metric::Matrix<recType, Metric>& DM, std::vector<int>& seeds,
         std::vector<int>& assignments, std::vector<int>& sec_nearest, std::vector<int>& counts)
     {
 
@@ -52,13 +52,14 @@ namespace kmedoids_details {
         return total_distance;
     }
 
-    template <typename recType, typename Metric, typename T>
-    void init_medoids(int k, const metric::Matrix<recType, Metric, T>& DM, std::vector<int>& seeds,
+    template <typename recType, typename Metric>
+    void init_medoids(int k, const metric::Matrix<recType, Metric>& DM, std::vector<int>& seeds,
         std::vector<int>& assignments, std::vector<int>& sec_nearest, std::vector<int>& counts)
     {
         seeds.clear();
         // find first object: object minimum distance to others
         int first_medoid = 0;
+        using T = typename metric::Matrix<recType,Metric>::distType;
         T min_dissim = std::numeric_limits<T>::max();
         for (int i = 0; i < DM.size(); i++) {
             T total = 0;
@@ -97,8 +98,8 @@ namespace kmedoids_details {
         }
     }
 
-    template <typename recType, typename Metric, typename T>
-    T cost(int i, int h, const metric::Matrix<recType, Metric, T>& DM, std::vector<int>& seeds,
+    template <typename recType, typename Metric, typename T = typename metric::Matrix<recType, Metric>::distType>
+    T cost(int i, int h, const metric::Matrix<recType, Metric>& DM, std::vector<int>& seeds,
         std::vector<int>& assignments, std::vector<int>& sec_nearest)
     {
         T total = 0;
@@ -128,7 +129,7 @@ namespace kmedoids_details {
 
 template <typename recType, typename Metric, typename T>
 std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> kmedoids(
-    const metric::Matrix<recType, Metric, T>& DM, int k)
+    const metric::Matrix<recType, Metric>& DM, int k)
 {
 
     // check arguments
@@ -231,7 +232,7 @@ std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> kmedoids_(const
     T epsilon = 1e-15;  /// Normalized sensitivity for convergence
 
     // set initianl medoids
-    metric::Matrix<std::vector<T>> dm(D);
+    metric::Matrix<std::vector<T>, metric::Euclidian<T>> dm(D);
     kmedoids_details::init_medoids(k, dm, seeds, assignments, sec_nearest, counts);
 
     T tolerance = epsilon * Dsum / (D[0].size() * D.size());

--- a/modules/mapping/kmedoids.hpp
+++ b/modules/mapping/kmedoids.hpp
@@ -20,9 +20,9 @@ namespace metric {
  * @param k 
  * @return 
  */
-template <typename recType, typename Metric, typename T>
+    template <typename recType, typename Metric, typename T = typename Metric::distance_type>
 std::tuple<std::vector<int>, std::vector<int>, std::vector<int>> kmedoids(
-    const metric::Matrix<recType, Metric, T>& DM, int k);
+    const metric::Matrix<recType, Metric>& DM, int k);
 
 }  // namespace metric
 

--- a/modules/transform/energy_encoder.cpp
+++ b/modules/transform/energy_encoder.cpp
@@ -11,7 +11,7 @@
 
 //#include <cstddef>
 #include <stack>
-#include "transform/wavelet.hpp"
+#include "../../modules/transform/wavelet.hpp"
 
 namespace metric {
 

--- a/modules/utils/pattern_compressor.cpp
+++ b/modules/utils/pattern_compressor.cpp
@@ -14,7 +14,7 @@ Copyright(c) 2019 PANDA Team
 #include <boost/iostreams/filtering_stream.hpp>
 
 //#include <blaze/math/CompressedVector.h>
-#include "3rdparty/blaze/math/CompressedVector.h"  // edited by Max F, Jan, 9, 2020
+#include "../../3rdparty/blaze/math/CompressedVector.h"  // edited by Max F, Jan, 9, 2020
 
 #include <stdexcept>
 

--- a/tests/sparsification_tests/sparsification_tests.cpp
+++ b/tests/sparsification_tests/sparsification_tests.cpp
@@ -7,8 +7,8 @@
 */
 #include "modules/utils/graph/sparsify.hpp"
 
-#define BOOST_TEST_MAIN
-
+#define BOOST_TEST_MODULE sparsification_tests
+#define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE(kruskal_empty_graph)


### PR DESCRIPTION
- Update mapping module according to new metric::Matrix  interface
- fix other compilation errors in examples and tests

build checked on Ubuntu 18.04(gcc-7.4), 19.10 (gcc-9.2), and Arch(gcc-9.2), all tests passed.