### PR TITLE
Make Tree::operator[] constant

### DIFF
--- a/modules/space/tree.cpp
+++ b/modules/space/tree.cpp
@@ -757,7 +757,7 @@ std::vector<RecType> Tree<RecType, Metric>::toVector()
 }
 
 template <class RecType, class Metric>
-RecType Tree<RecType, Metric>::operator[](size_t id)
+RecType Tree<RecType, Metric>::operator[](size_t id) const
 {
     auto p = index_map.find(id);
     if(p == index_map.end()) {

--- a/modules/space/tree.hpp
+++ b/modules/space/tree.hpp
@@ -222,7 +222,7 @@ public:
      * @return data record with ID == id
      * @throws std::runtime_error when tree has no element with ID
      */
-    RecType operator[](size_t id);
+    RecType operator[](size_t id) const;
 
     /*** Nearest Neighbour search ***/
 


### PR DESCRIPTION
Just support the good practice to use `const` as often as possible. 