### PR TITLE
Fix link error for wavelet.hpp

### DIFF
--- a/modules/transform/wavelet.cpp
+++ b/modules/transform/wavelet.cpp
@@ -335,7 +335,7 @@ Container idwt(Container a, Container d, int waveletType, int lx)
 }
 
 
-int wmaxlev(int sizeX, int waveletType)
+static int wmaxlev(int sizeX, int waveletType)
 {
     std::vector<double> F = dbwavf<std::vector<double>>(waveletType, double(1.0));
     auto [Lo_D, Hi_D, Lo_R, Hi_R] = orthfilt(F);

--- a/modules/transform/wavelet.hpp
+++ b/modules/transform/wavelet.hpp
@@ -261,7 +261,7 @@ Container idwt(Container a, Container d, int waveletType, int lx); // overload a
  * @param waveletType 
  * @return
  */
-int wmaxlev(int sizeX, int waveletType);
+static int wmaxlev(int sizeX, int waveletType);
 
 ///**
 // * @brief


### PR DESCRIPTION
Here we fix a linkage problem when we include `wavlet.hpp` into two different .cpp classess.