### PR TITLE
[codex] Prepare metric-space release metadata

### DIFF
--- a/.github/workflows/python-core.yml
+++ b/.github/workflows/python-core.yml
@@ -67,6 +67,6 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: metric-py-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: metric-space-${{ matrix.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] - Revival draft
+## [0.3.0] - 2026-06-19
 
 ### API Changes
 
@@ -30,6 +30,7 @@
 - Add optional `METRIC_FETCH_DEPS` FetchContent fallback for core dependencies.
 - Add install/export support verified by a downstream `find_package(panda_metric)` consumer.
 - Add `python/pyproject.toml` with PEP 621 project metadata, modern Python version metadata, and core-wheel CI for CPython 3.10 through 3.14.
+- Rename the public Python distribution to `metric-space`; the import package remains `metric`.
 - Add release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, C++ core checks, and downstream CMake consumer evidence.
 
 ### Documentation and Examples
@@ -54,7 +55,7 @@
 - The target intent facade for `groups`, `embed`, `map`, `reduce`, `denoise`, `outliers`, and `compare` remains roadmap API until backed by stable strategies, result contracts, examples, and CI.
 - Mapping and transform algorithms remain beta or compatibility surfaces; `metric.mappings` and `metric.transforms` only expose installed legacy names.
 - The default Python core wheel intentionally exposes a narrow revived surface; broader legacy bindings require separate restoration.
-- Public relaunch still requires external actions: repository metadata update, remote CI matrix evidence, Pages activation, release artifact workflow run from the final tag, final package-name decision, PyPI publishing, a release tag, and final release notes.
+- Public relaunch still requires external actions: release tag creation, release artifact workflow run from that final tag, GitHub release publication, and PyPI publishing for `metric-space`.
 
 ## [0.2.1] - 2022-05-16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.19)
 #endif()
 #cmake_policy(SET CMP0076 NEW)
 
-project(panda_metric VERSION 0.2.0 LANGUAGES CXX)
+project(panda_metric VERSION 0.3.0 LANGUAGES CXX)
 
 # CCache
 # set(METRIC_USE_CCACHE ON)

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -1,6 +1,6 @@
 # Revival Status
 
-This page tracks the current execution status of [REVIVAL_PLAN.md](../REVIVAL_PLAN.md). It is not a replacement for the plan; it records which revival requirements are locally implemented and which release actions still require external repository or package-index state.
+This page tracks the current execution status of [REVIVAL_PLAN.md](../REVIVAL_PLAN.md). It is not a replacement for the plan; it records which revival requirements are implemented on `master` and which release actions still require package-index or release publication state.
 
 ## Local Revival Scope
 
@@ -65,19 +65,21 @@ git diff --check
 
 The Python package currently uses `pyproject.toml` for the PEP 517 build-system declaration and PEP 621 project metadata. `setup.py` registers the CMake extension build hook and the source-distribution hook that includes the required C++ metric headers in the Python sdist. `scikit-build-core` remains a candidate for a later packaging simplification, but it is not adopted in this revival slice because the current bridge already builds the core wheel and preserves the existing extension layout.
 
-The package name is currently `metric-py`. A public relaunch still needs an explicit package-name decision before publishing to PyPI.
+The public Python distribution name is `metric-space`. The import package remains `metric`.
 
-PyPI name availability was checked on 2026-06-19 with `python -m pip index versions`:
+PyPI name availability was checked on 2026-06-19 with the official PyPI JSON API:
 
 - `metric` exists on PyPI and should not be used for this relaunch.
-- `metric-py` had no matching visible distribution.
+- `metric-py` exists on PyPI as version `0.0.6`, points at the historical `panda-official/metric` repository, and should not be reused unless package ownership and continuity are deliberately restored.
 - `metric-space` had no matching visible distribution.
 - `metric-space-numerics` had no matching visible distribution.
 - `panda-metric` and `panda_metric` had no matching visible distribution.
 
-The current local package metadata stays on `metric-py` until the release owner chooses whether continuity or clearer public naming is more important.
+The release metadata therefore uses `metric-space` to avoid colliding with both the unrelated `metric` project and the historical `metric-py` distribution.
 
 ## External State Checked
+
+The revival branch landed through [pull request #326](https://github.com/metric-space-ai/metric/pull/326), merged into `master` as commit `c1bc86f035e132617a111bbf91577f92070ff22e`.
 
 The GitHub repository metadata was checked on 2026-06-19 with `gh repo view metric-space-ai/metric`.
 
@@ -85,21 +87,29 @@ The GitHub repository metadata was checked on 2026-06-19 with `gh repo view metr
 - homepage: <https://metric-space-ai.github.io/metric/>
 - topics: `algorithms`, `cpp`, `finite-metric-spaces`, `metric-space`, `numerical-computing`, `python`
 
-GitHub Pages was checked on 2026-06-19 with `gh api repos/metric-space-ai/metric/pages`. Pages is public and built at <https://metric-space-ai.github.io/metric/>, currently from the legacy `gh-pages` source branch. The new checked-in Pages workflow remains local until the revival branch is committed and pushed.
+GitHub Pages was checked on 2026-06-19 with `gh api repos/metric-space-ai/metric/pages`. Pages is public, uses `build_type: workflow`, and is built at <https://metric-space-ai.github.io/metric/>.
 
-GitHub Actions workflows were checked on 2026-06-19 with `gh api repos/metric-space-ai/metric/actions/workflows`. The remote repository currently exposes only the pre-revival workflows. The new revival workflows become remote release evidence only after these local workflow files are committed and pushed.
+GitHub Actions was checked on 2026-06-19 with `gh run list --repo metric-space-ai/metric --branch master`. The following `master` runs completed successfully on commit `c1bc86f035e132617a111bbf91577f92070ff22e`:
+
+- Core C++ smoke
+- Python core wheel
+- Docs and formatting
+- Pages
+- Dependency Graph
+
+The manual release-artifact rehearsal was checked on 2026-06-19 with `gh run view 27798350044`. It completed successfully on `master` and uploaded:
+
+- `metric-source-archive`
+- `metric-python-artifacts`
 
 ## External Release Work
 
 These plan items cannot be proven by local files alone and remain external release actions:
 
-- keep the GitHub repository description, homepage, and topics aligned with the finite metric-space framing
-- switch or confirm GitHub Pages publishing for the checked-in `docs/site/` artifact after the revival branch lands
-- run the new GitHub Actions matrix on Linux, macOS, and Windows in the repository
-- run `.github/workflows/release-artifacts.yml` from the final release tag
-- choose the final public Python package name from the checked candidates or another owner-approved name
-- publish release wheels to PyPI
-- finalize the [CHANGELOG.md](../CHANGELOG.md) revival draft into release notes using the template in [release-checklist.md](release-checklist.md)
+- create the final `v0.3.0` release tag from `master`
+- run `.github/workflows/release-artifacts.yml` from that final release tag
+- publish the GitHub release using the [CHANGELOG.md](../CHANGELOG.md) `0.3.0` entry as release notes
+- publish the `metric-space` Python source distribution and wheel to PyPI after confirming package ownership or Trusted Publishing
 
 ## Historical Code Policy
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,9 @@
-# METRIC-PY
+# METRIC Python Package
 
 Python bindings for METRIC metric-space numerics.
+
+The public Python distribution name is `metric-space`. The import package remains
+`metric`.
 
 The revived core package exposes the project concepts explicitly:
 
@@ -16,6 +19,12 @@ The same objects are also available as convenience imports from `metric` for sho
 # Installation
 
 The Python package is in revival. The current supported CPython targets for the core wheel are 3.10, 3.11, 3.12, 3.13, and 3.14.
+
+After the release is published, install the core package with:
+
+```shell
+python -m pip install metric-space
+```
 
 Packaging now uses `pyproject.toml` with isolated PEP 517 builds and PEP 621 project metadata. `setup.py` provides the CMake extension build hook and the source-distribution hook that carries the required C++ headers into the Python sdist. The build prefers the `pybind11` package from the build environment (`pybind11>=3.0.0`) and falls back to a current FetchContent copy when no CMake package is available.
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -10,7 +10,7 @@ The revived core API is organized around explicit finite metric spaces:
 Legacy compiled extension names remain available when their modules are present.
 """
 
-__version__ = "0.0.6"
+__version__ = "0.3.0"
 
 try:
     from metric._impl.metric import *

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,8 +9,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "metric-py"
-version = "0.0.6"
+name = "metric-space"
+version = "0.3.0"
 description = "Python bindings and helpers for finite metric-space numerics"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Switch the Python distribution metadata from `metric-py` to `metric-space`.
- Align the CMake/Python release version to `0.3.0` for the revival release cut.
- Update release status and changelog notes with the current remote evidence and remaining publication steps.

## Rationale

The current `metric-py==0.0.6` metadata is not publishable as-is: PyPI already has a historical `metric-py` release at `0.0.6` pointing to `panda-official/metric`. The revival plan listed `metric-space` as a clearer public name, and the PyPI JSON API currently returns no visible distribution for it.

## Validation

- `python3.12 -m build ./python --sdist --outdir build/revival-release-status/wheelhouse`
- `CMAKE_COMMON_VARIABLES=-DMETRIC_PYTHON_USE_BLAS=OFF ... pip wheel metric_space-0.3.0.tar.gz --no-deps`
- Installed built wheel and verified `importlib.metadata.version("metric-space") == "0.3.0"` and `metric.__version__ == "0.3.0"`.
- `python python/examples/metric_space/string_edit_space.py`
- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s python/tests/core -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- workflow YAML parse
- `git diff --check`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core`