### PR TITLE
[codex] Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,146 @@
+name: Publish Python package
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to publish from, usually a release tag.
+        required: true
+        default: v0.3.0
+      publish:
+        description: Upload checked distributions to the configured package index.
+        required: true
+        type: boolean
+        default: false
+      repository_url:
+        description: Python package index upload endpoint.
+        required: true
+        default: https://upload.pypi.org/legacy/
+      skip_existing:
+        description: Pass --skip-existing to twine upload.
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build source distribution
+        shell: bash
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build ./python --sdist --outdir dist
+          python -m twine check dist/*.tar.gz
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: metric-space-pypi-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  wheels:
+    name: ${{ matrix.os }} wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        env:
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_SKIP: "*-musllinux_* *-manylinux_i686 *-win32"
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_ARCHS_MACOS: auto
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ENVIRONMENT: CMAKE_COMMON_VARIABLES="-DMETRIC_PYTHON_USE_BLAS=OFF"
+          CIBW_TEST_COMMAND: "python {project}/examples/metric_space/string_edit_space.py && python -B -m unittest discover -s {project}/tests/core -v"
+        with:
+          package-dir: ./python
+          output-dir: wheelhouse
+
+      - name: Check wheels
+        shell: bash
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check wheelhouse/*.whl
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: metric-space-pypi-wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  publish:
+    name: Publish checked distributions
+    needs:
+      - sdist
+      - wheels
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          pattern: metric-space-pypi-*
+          path: dist
+          merge-multiple: true
+
+      - name: Check distribution set
+        shell: bash
+        run: |
+          set -euo pipefail
+          find dist -maxdepth 1 -type f -print | sort
+          sdist_count="$(find dist -maxdepth 1 -name '*.tar.gz' | wc -l | tr -d ' ')"
+          wheel_count="$(find dist -maxdepth 1 -name '*.whl' | wc -l | tr -d ' ')"
+          test "$sdist_count" = "1"
+          test "$wheel_count" = "15"
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      - name: Upload to package index
+        shell: bash
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_REPOSITORY_URL: ${{ inputs.repository_url }}
+          SKIP_EXISTING: ${{ inputs.skip_existing }}
+        run: |
+          set -euo pipefail
+          test -n "$TWINE_USERNAME"
+          test -n "$TWINE_PASSWORD"
+
+          upload_args=(upload --repository-url "$TWINE_REPOSITORY_URL")
+          if [ "$SKIP_EXISTING" = "true" ]; then
+            upload_args+=(--skip-existing)
+          fi
+
+          python -m twine "${upload_args[@]}" dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Packaging and Build
+
+- Add a manual PyPI publishing workflow that builds a checked source distribution and cibuildwheel-generated CPython 3.10 through 3.14 wheels before uploading with repository PyPI credentials.
+
 ## [0.3.0] - 2026-06-19
 
 ### API Changes

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,6 +20,7 @@ This checklist defines the minimum release gates for METRIC.
 - core C++ CI passes on Linux, macOS, and Windows
 - C++ install/export consumer passes with `find_package(panda_metric)`
 - Python wheel CI passes on supported CPython versions
+- PyPI publishing workflow builds and checks supported wheels before upload
 - release artifact workflow passes for the release tag
 - promoted C++ and Python examples run in CI
 - docs and formatting CI passes
@@ -77,11 +78,23 @@ python -m build ./python --sdist --outdir wheelhouse
 METRIC_PYTHON_USE_BLAS=OFF python -m pip wheel wheelhouse/*.tar.gz --no-deps -w wheelhouse
 ```
 
+PyPI publishing workflow:
+
+```shell
+gh workflow run publish-python.yml \
+  --repo metric-space-ai/metric \
+  -f ref=v0.3.0 \
+  -f publish=false
+```
+
+Use `publish=true` only after confirming the target package index, credentials, and package ownership.
+
 ## Artifacts
 
 - source archive from the release tag, produced by `.github/workflows/release-artifacts.yml`
 - C++ install/export smoke evidence from CI
 - Python wheel artifacts for supported CPython versions
+- PyPI-compatible wheels from `.github/workflows/publish-python.yml`
 - Python source distribution artifact
 - public Pages artifact from `docs/site/`
 - release notes

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -24,6 +24,7 @@ The current local tree implements the first revival slice:
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
+- manual PyPI publishing workflow for checked sdist and cibuildwheel wheel artifacts
 - manual-only legacy workflows for broad historical coverage
 
 ## Current Local Verification
@@ -113,7 +114,7 @@ The final release tag and GitHub release were checked on 2026-06-19:
 - tag CI runs for docs/formatting, C++ core smoke, and Python core wheels completed successfully
 - the release assets include `metric-v0.3.0.tar.gz`, `metric_space-0.3.0.tar.gz`, and `metric_space-0.3.0-cp312-cp312-linux_x86_64.whl`
 
-The remaining external release action is to publish the `metric-space` Python source distribution and wheel to PyPI after confirming package ownership or Trusted Publishing. The repository still contains only a legacy manual TestPyPI workflow, and no local Twine credentials were present during the 2026-06-19 release check.
+The remaining external release action is to publish the `metric-space` Python source distribution and wheels to PyPI after confirming package ownership or Trusted Publishing. The repository has a manual PyPI publishing workflow backed by repository PyPI credentials; no local Twine credentials were present during the 2026-06-19 release check.
 
 ## Historical Code Policy
 

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -11,6 +11,7 @@ The required PR and release gates are intentionally small, reproducible, and cro
 - `.github/workflows/docs-and-format.yml`: revived-file whitespace checks, Markdown local-link checks, and workflow YAML parsing.
 - `.github/workflows/pages.yml`: static Pages artifact for `docs/site/`.
 - `.github/workflows/release-artifacts.yml`: tag/manual artifact build for source archive, Python sdist, Python wheel built from that sdist, C++ core test, and downstream CMake consumer evidence.
+- `.github/workflows/publish-python.yml`: manual PyPI publishing path that builds a checked sdist and cibuildwheel wheels for CPython 3.10 through 3.14 before upload.
 
 The corresponding local commands are listed in [release-checklist.md](release-checklist.md).
 


### PR DESCRIPTION
## Summary
- add a manual PyPI publishing workflow using cibuildwheel for CPython 3.10 through 3.14 wheels
- keep publishing gated behind an explicit `publish=true` workflow input and existing repository PyPI credentials
- document the PyPI workflow in release and CI docs

## Verification
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `ruby scripts/check_markdown_links.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `git diff --check`
- local Python 3.12 sdist build + `twine check`
- local Python 3.12 wheel build from sdist + `twine check`
- local wheel install, smoke example, and `python -B -m unittest discover -s python/tests/core -v`