### PR TITLE
Add Trusted Publishing option for PyPI

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -12,6 +12,14 @@ on:
         required: true
         type: boolean
         default: false
+      auth_method:
+        description: Authentication method for publish=true uploads.
+        required: true
+        type: choice
+        default: password
+        options:
+          - password
+          - trusted-publishing
       repository_url:
         description: Python package index upload endpoint.
         required: true
@@ -110,6 +118,9 @@ jobs:
     if: ${{ inputs.publish }}
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download distributions
@@ -136,7 +147,8 @@ jobs:
           python -m pip install --upgrade twine
           python -m twine check dist/*
 
-      - name: Upload to package index
+      - name: Upload to package index with password credentials
+        if: ${{ inputs.auth_method == 'password' }}
         shell: bash
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
@@ -154,3 +166,11 @@ jobs:
           fi
 
           python -m twine "${upload_args[@]}" dist/*
+
+      - name: Upload to package index with Trusted Publishing
+        if: ${{ inputs.auth_method == 'trusted-publishing' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: ${{ inputs.repository_url }}
+          skip-existing: ${{ inputs.skip_existing }}

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -89,6 +89,23 @@ gh workflow run publish-python.yml \
 
 Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.1` and `publish=true`.
 
+For Trusted Publishing, configure PyPI with:
+
+- owner: `metric-space-ai`
+- repository: `metric`
+- workflow: `publish-python.yml`
+- environment: `pypi`
+
+Then run:
+
+```shell
+gh workflow run publish-python.yml \
+  --repo metric-space-ai/metric \
+  -f ref=v0.3.1 \
+  -f publish=true \
+  -f auth_method=trusted-publishing
+```
+
 ## Artifacts
 
 - source archive from the release tag, produced by `.github/workflows/release-artifacts.yml`

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -125,7 +125,7 @@ PyPI publishing moved to the `v0.3.1` packaging patch release so Linux wheels us
 - publish run `27801491154` rebuilt and checked the same distribution set successfully, but the final Twine upload failed with `HTTPError: 403 Forbidden` from `https://upload.pypi.org/legacy/`
 - PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` after the failed upload, so no visible `metric-space` release was published
 
-The remaining external release action is to update or replace the repository PyPI credentials, or switch the workflow to PyPI Trusted Publishing, then rerun `.github/workflows/publish-python.yml` with `ref=v0.3.1` and `publish=true`. No local Twine credentials were present during the 2026-06-19 release check.
+The remaining external release action is to update or replace the repository PyPI credentials, or configure PyPI Trusted Publishing for owner `metric-space-ai`, repository `metric`, workflow `publish-python.yml`, and environment `pypi`. The workflow supports both repository-secret password uploads and Trusted Publishing uploads; after PyPI access is fixed, rerun `.github/workflows/publish-python.yml` with `ref=v0.3.1`, `publish=true`, and the appropriate `auth_method`. No local Twine credentials were present during the 2026-06-19 release check.
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- add a manual `auth_method` choice for PyPI publishing
- keep the existing repository-secret password path
- add a PyPI Trusted Publishing path through `pypa/gh-action-pypi-publish@release/v1`
- document the required PyPI publisher configuration and rerun command

## Verification
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/publish-python.yml"); puts "publish workflow YAML parsed"'`
- `ruby scripts/check_markdown_links.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `git diff --check`