### PR TITLE
Add structured Python metric-space example

### DIFF
--- a/.github/workflows/python-core.yml
+++ b/.github/workflows/python-core.yml
@@ -54,9 +54,12 @@ jobs:
         shell: bash
         run: python -m pip install wheelhouse/*.whl
 
-      - name: Run metric-space smoke example
+      - name: Run metric-space smoke examples
         shell: bash
-        run: python python/examples/metric_space/string_edit_space.py
+        run: |
+          for example in python/examples/metric_space/*.py; do
+            python "$example"
+          done
 
       - name: Run core Python API tests
         shell: bash

--- a/docs/examples/structured-data.md
+++ b/docs/examples/structured-data.md
@@ -4,6 +4,8 @@ Structured records often have a more meaningful native distance than a vector em
 
 Promoted examples that currently run in the core CI path:
 
+- [string_edit_space.py](../../python/examples/metric_space/string_edit_space.py): Python strings compared with edit distance
+- [structured_record_space.py](../../python/examples/metric_space/structured_record_space.py): Python structured records compared with a domain metric callable
 - [metric_space_strings.cpp](../../examples/core/metric_space_strings.cpp): strings compared with edit distance
 - [custom_metric_space.cpp](../../examples/core/custom_metric_space.cpp): strings compared with a custom padded Hamming metric
 - [time_series_twed_space.cpp](../../examples/core/time_series_twed_space.cpp): process curves compared with TWED

--- a/python/examples/metric_space/structured_record_space.py
+++ b/python/examples/metric_space/structured_record_space.py
@@ -1,0 +1,37 @@
+from metric import Space
+from metric.operators import pairwise_distance_matrix
+
+
+def structured_record_distance(lhs, rhs):
+    status_penalty = 0.0 if lhs["status"] == rhs["status"] else 10.0
+    temperature_penalty = abs(lhs["temperature_c"] - rhs["temperature_c"]) / 10.0
+    event_penalty = padded_hamming(lhs["events"], rhs["events"])
+    return status_penalty + temperature_penalty + event_penalty
+
+
+def padded_hamming(lhs, rhs):
+    width = max(len(lhs), len(rhs))
+    padded_lhs = tuple(lhs) + (None,) * (width - len(lhs))
+    padded_rhs = tuple(rhs) + (None,) * (width - len(rhs))
+    return sum(left != right for left, right in zip(padded_lhs, padded_rhs))
+
+
+def main():
+    records = [
+        {"id": "pump-a", "status": "ok", "temperature_c": 62.0, "events": ("start", "load", "idle")},
+        {"id": "pump-b", "status": "ok", "temperature_c": 64.5, "events": ("start", "load", "idle")},
+        {"id": "valve-c", "status": "warn", "temperature_c": 82.0, "events": ("start", "alarm", "manual")},
+        {"id": "pump-d", "status": "ok", "temperature_c": 61.0, "events": ("start", "load", "stop")},
+    ]
+    query = {"status": "ok", "temperature_c": 63.0, "events": ("start", "load", "idle")}
+
+    space = Space(records, structured_record_distance)
+    nearest_id, nearest_distance = space.nearest(query)
+
+    print("nearest structured record =", records[nearest_id]["id"], nearest_distance)
+    print("distance(pump-a, valve-c) =", space.distance(0, 2))
+    print("pairwise rows =", len(pairwise_distance_matrix(records, structured_record_distance)))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -79,6 +79,36 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(range_neighbors(records, euclidean, np.array([3.0, 4.0]), 0.0), [(1, 0.0)])
         self.assertAlmostEqual(pairwise_distance_matrix(records, euclidean)[1][2], 5.0)
 
+    def test_structured_records_use_domain_metric_callable(self):
+        records = [
+            {"id": "pump-a", "status": "ok", "temperature_c": 62.0, "events": ("start", "load", "idle")},
+            {"id": "pump-b", "status": "ok", "temperature_c": 64.5, "events": ("start", "load", "idle")},
+            {"id": "valve-c", "status": "warn", "temperature_c": 82.0, "events": ("start", "alarm", "manual")},
+            {"id": "pump-d", "status": "ok", "temperature_c": 61.0, "events": ("start", "load", "stop")},
+        ]
+        query = {"status": "ok", "temperature_c": 63.0, "events": ("start", "load", "idle")}
+
+        def padded_hamming(lhs, rhs):
+            width = max(len(lhs), len(rhs))
+            padded_lhs = tuple(lhs) + (None,) * (width - len(lhs))
+            padded_rhs = tuple(rhs) + (None,) * (width - len(rhs))
+            return sum(left != right for left, right in zip(padded_lhs, padded_rhs))
+
+        def structured_record_distance(lhs, rhs):
+            status_penalty = 0.0 if lhs["status"] == rhs["status"] else 10.0
+            temperature_penalty = abs(lhs["temperature_c"] - rhs["temperature_c"]) / 10.0
+            event_penalty = padded_hamming(lhs["events"], rhs["events"])
+            return status_penalty + temperature_penalty + event_penalty
+
+        space = Space(records, structured_record_distance)
+
+        nearest_id, nearest_distance = space.nearest(query)
+        self.assertEqual(records[nearest_id]["id"], "pump-a")
+        self.assertAlmostEqual(nearest_distance, 0.1)
+        self.assertGreater(space.distance(0, 2), 10.0)
+        self.assertEqual(space.neighbors(query, 2)[0][0], 0)
+        self.assertAlmostEqual(pairwise_distance_matrix(records, structured_record_distance)[0][1], 0.25)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a promoted Python example for structured, non-vector records using a domain metric callable
- run all `python/examples/metric_space/*.py` examples in Python core CI
- add core API coverage for structured record metrics and document the promoted Python examples

## Verification
- `build/python-venv/bin/python python/examples/metric_space/string_edit_space.py`
- `build/python-venv/bin/python python/examples/metric_space/structured_record_space.py`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/python-core.yml"); puts "python workflow YAML parsed"'`
- `ruby scripts/check_markdown_links.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `git diff --check`