### PR TITLE
Run promoted Python examples in release gates

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -87,7 +87,7 @@ jobs:
           CIBW_ARCHS_MACOS: auto
           CIBW_ARCHS_WINDOWS: AMD64
           CIBW_ENVIRONMENT: CMAKE_COMMON_VARIABLES="-DMETRIC_PYTHON_USE_BLAS=OFF"
-          CIBW_TEST_COMMAND: "python {project}/python/examples/metric_space/string_edit_space.py && python -B -m unittest discover -s {project}/python/tests/core -v"
+          CIBW_TEST_COMMAND: "python {project}/python/examples/metric_space/string_edit_space.py && python {project}/python/examples/metric_space/structured_record_space.py && python -B -m unittest discover -s {project}/python/tests/core -v"
         with:
           package-dir: ./python
           output-dir: wheelhouse

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -50,7 +50,9 @@ jobs:
         shell: bash
         run: |
           python -m pip install dist/python/*.whl
-          python python/examples/metric_space/string_edit_space.py
+          for example in python/examples/metric_space/*.py; do
+            python "$example"
+          done
           PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s python/tests/core -v
 
       - name: Verify C++ core

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -58,6 +58,7 @@ Python wheel verification:
 python -m pip wheel ./python --no-deps -w wheelhouse
 python -m pip install --force-reinstall wheelhouse/*.whl
 python python/examples/metric_space/string_edit_space.py
+python python/examples/metric_space/structured_record_space.py
 ```
 
 Docs and formatting verification:

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -18,7 +18,7 @@ The current local tree implements the first revival slice:
 - Python core facade modules under `metric.metrics`, `metric.spaces`, and `metric.operators`
 - Python beta compatibility bridge modules under `metric.mappings` and `metric.transforms`
 - promoted C++ examples under `examples/core/`
-- promoted Python example under `python/examples/metric_space/`
+- promoted Python examples under `python/examples/metric_space/`
 - C++ smoke and contract tests under `tests/core_smoke/`
 - Python core API tests under `python/tests/core/`
 - documentation for concepts, APIs, examples, stability, testing, and release gates
@@ -54,6 +54,7 @@ python -m build ./python --sdist --outdir build/wheelhouse-revival
 METRIC_PYTHON_USE_BLAS=OFF python -m pip wheel build/wheelhouse-revival/*.tar.gz --no-deps -w build/wheelhouse-revival
 python -m pip install --force-reinstall build/wheelhouse-revival/*.whl
 PYTHONDONTWRITEBYTECODE=1 python python/examples/metric_space/string_edit_space.py
+PYTHONDONTWRITEBYTECODE=1 python python/examples/metric_space/structured_record_space.py
 PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s python/tests/core -v
 
 ruby scripts/check_revival_whitespace.rb

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -7,7 +7,7 @@ This page defines which checks are release gates during the revival and which ch
 The required PR and release gates are intentionally small, reproducible, and cross-platform:
 
 - `.github/workflows/core-cpp.yml`: C++ core configure, build, core tests, promoted examples, install, and downstream `find_package(panda_metric)` consumer on Linux, macOS, and Windows.
-- `.github/workflows/python-core.yml`: Python core wheel build on Linux, macOS, and Windows for supported CPython versions, followed by the metric-space example and core Python API tests.
+- `.github/workflows/python-core.yml`: Python core wheel build on Linux, macOS, and Windows for supported CPython versions, followed by the promoted metric-space examples and core Python API tests.
 - `.github/workflows/docs-and-format.yml`: revived-file whitespace checks, Markdown local-link checks, and workflow YAML parsing.
 - `.github/workflows/pages.yml`: static Pages artifact for `docs/site/`.
 - `.github/workflows/release-artifacts.yml`: tag/manual artifact build for source archive, Python sdist, Python wheel built from that sdist, C++ core test, and downstream CMake consumer evidence.


### PR DESCRIPTION
## Summary
- run all promoted Python examples when verifying release artifacts
- include the structured record example in cibuildwheel tests for PyPI publishing
- update release/testing docs to reflect multiple promoted Python examples

## Verification
- `build/python-venv/bin/python python/examples/metric_space/string_edit_space.py`
- `build/python-venv/bin/python python/examples/metric_space/structured_record_space.py`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `ruby scripts/check_markdown_links.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `git diff --check`