### PR TITLE
Add Python metric contract checks

### DIFF
--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -35,6 +35,13 @@ The core tests cover:
 - entropy regression values when LAPACK is available
 - promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, and entropy when LAPACK is available
 
+The Python core wheel path covers:
+
+- importability of the revived Python facade modules
+- `Space`, `FiniteMetricSpace`, and operator helper behavior
+- metric contract checks for built-in edit distance, NumPy record callables, and structured record callables
+- promoted Python examples for strings and structured records
+
 ## Extended and Historical Tests
 
 The full historical suite is still in-tree and can be explored with `METRIC_BUILD_TESTS=ON`, but it is not a revival release gate yet. It contains broad mapping, transform, DNN, image-processing, wrapper, and legacy utility coverage that requires additional restoration work before it can be treated as a supported signal.

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -13,6 +13,23 @@ class RevivalApiTest(unittest.TestCase):
         self.records = ["cat", "cot", "coat", "dog"]
         self.metric = Edit()
 
+    def assertMetricContracts(self, records, metric, places=7):
+        for lhs in records:
+            self.assertAlmostEqual(metric(lhs, lhs), 0.0, places=places)
+
+            for rhs in records:
+                lhs_rhs = metric(lhs, rhs)
+                rhs_lhs = metric(rhs, lhs)
+
+                self.assertGreaterEqual(lhs_rhs, 0.0)
+                self.assertAlmostEqual(lhs_rhs, rhs_lhs, places=places)
+
+                for through in records:
+                    self.assertLessEqual(
+                        metric(lhs, through),
+                        lhs_rhs + metric(rhs, through) + 10 ** -places,
+                    )
+
     def test_metric_concepts_are_importable(self):
         self.assertIn("Edit", available())
         self.assertIs(MatrixSpace, FiniteMetricSpace)
@@ -57,6 +74,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(range_neighbors(self.records, self.metric, "cut", 1), [(0, 1), (1, 1)])
         self.assertEqual(pairwise_distance_matrix(self.records, self.metric)[0][1], 1)
 
+    def test_edit_metric_satisfies_metric_contracts(self):
+        self.assertMetricContracts(self.records, self.metric)
+
     def test_space_facade_exposes_intent_names(self):
         space = Space(self.records, self.metric)
 
@@ -78,6 +98,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(space.nearest(np.array([3.0, 4.0])), (1, 0.0))
         self.assertEqual(range_neighbors(records, euclidean, np.array([3.0, 4.0]), 0.0), [(1, 0.0)])
         self.assertAlmostEqual(pairwise_distance_matrix(records, euclidean)[1][2], 5.0)
+        self.assertMetricContracts(records, euclidean)
 
     def test_structured_records_use_domain_metric_callable(self):
         records = [
@@ -108,6 +129,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertGreater(space.distance(0, 2), 10.0)
         self.assertEqual(space.neighbors(query, 2)[0][0], 0)
         self.assertAlmostEqual(pairwise_distance_matrix(records, structured_record_distance)[0][1], 0.25)
+        self.assertMetricContracts(records, structured_record_distance)
 
 
 if __name__ == "__main__":

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,8 @@ The tests tree separates the revived core gate from broader historical coverage.
 
 `tests/downstream_consumer/` verifies the installed CMake package with `find_package(panda_metric)`. It is part of the C++ core CI gate.
 
+The Python core CI gate under `python/tests/core/` covers the revived Python facade, promoted Python examples, custom metric callables, and metric contract checks for built-in, NumPy, and structured-record metrics.
+
 ## Historical and Extended Tests
 
 The other test folders preserve broader historical coverage:


### PR DESCRIPTION
## Summary
- add Python core contract assertions for non-negativity, identity, symmetry, and triangle inequality
- cover the built-in edit metric, NumPy record callables, and structured record callables
- document Python core test coverage in the testing docs

## Verification
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `build/python-venv/bin/python python/examples/metric_space/string_edit_space.py`
- `build/python-venv/bin/python python/examples/metric_space/structured_record_space.py`
- `ruby scripts/check_markdown_links.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `git diff --check`