### PR TITLE
Add intrinsic dimension diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### API Changes
 
-- Keep the Python core API surface unchanged while expanding its contract coverage.
+- Add `metric::operators::intrinsic_dimension` and `metric.intrinsic_dimension` as expansion-dimension diagnostics for finite metric spaces.
 
 ### Algorithm Changes
 
 - Add Python core metric-contract checks for non-negativity, identity, symmetry, and triangle inequality across built-in edit distance, NumPy record callables, and structured-record callables.
+- Add C++ and Python regression coverage for intrinsic-dimension estimates.
 
 ### Packaging and Build
 
@@ -20,6 +21,7 @@
 ### Documentation and Examples
 
 - Add a promoted Python structured-record metric-space example using dictionaries and a domain metric callable.
+- Add a promoted C++ intrinsic-dimension example and documentation.
 - Document the promoted Python examples in the structured-data examples guide.
 - Update testing and release-gate docs to describe Python core metric-contract coverage and multiple promoted Python examples.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::pairwise_distance_matrix`
 - `metric::operators::nearest_neighbors`
 - `metric::operators::range_neighbors`
+- `metric::operators::intrinsic_dimension`
 - `metric::MatrixSpace`
 - `metric::GraphSpace`
 - `metric::TreeSpace`
@@ -178,6 +179,7 @@ Examples:
 - [Time-Series Space With TWED](docs/examples/time-series-twed.md)
 - [Histogram Space With EMD](docs/examples/histogram-emd.md)
 - [Entropy Diagnostics](docs/examples/entropy-diagnostics.md)
+- [Intrinsic Dimension Diagnostic](docs/examples/intrinsic-dimension.md)
 - [Correlation Between Metric Spaces](docs/examples/correlation-between-spaces.md)
 - [Industrial Anomaly Workflow](docs/examples/industrial-anomaly-workflow.md)
 

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -65,9 +65,10 @@ std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
 auto distances = metric::operators::pairwise_distance_matrix(records, metric::Edit<std::string>{});
 auto nearest = metric::operators::nearest_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 2);
 auto close = metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
+auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, and `range_neighbors`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, and `intrinsic_dimension`. `intrinsic_dimension` returns an expansion-dimension estimate based on neighborhood growth; it is a finite-space diagnostic, not an exact manifold dimension.
 
 ## Custom Metrics
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, and range neighbors
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -46,12 +46,15 @@ space.rnn(query, radius=1)
 ## Operators
 
 ```python
-from metric.operators import nearest_neighbors, pairwise_distance_matrix, range_neighbors
+from metric.operators import intrinsic_dimension, nearest_neighbors, pairwise_distance_matrix, range_neighbors
 
 distances = pairwise_distance_matrix(records, Edit())
 neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
 close = range_neighbors(records, Edit(), "cut", radius=1)
+dimension = intrinsic_dimension(records, Edit())
 ```
+
+`intrinsic_dimension` returns an expansion-dimension estimate based on finite-space neighborhood growth. Treat it as a diagnostic that depends on the metric, sample density, duplicates, and available radii.
 
 ## Custom Metrics
 

--- a/docs/examples/intrinsic-dimension.md
+++ b/docs/examples/intrinsic-dimension.md
@@ -1,0 +1,44 @@
+# Intrinsic Dimension Diagnostic
+
+Intrinsic-dimension diagnostics estimate how quickly neighborhoods grow inside a finite metric space. They are useful when deciding whether a tree, graph, or dense matrix representation is likely to fit the geometry.
+
+The revived core exposes a small expansion-dimension estimate:
+
+```text
+max_x,r log2(|B(x, 2r)| / |B(x, r)|)
+```
+
+This is a finite-space diagnostic, not an exact manifold dimension. It depends on the metric, sample density, duplicate records, and the radii available in the dataset.
+
+The promoted C++ example [metric_space_intrinsic_dimension.cpp](../../examples/core/metric_space_intrinsic_dimension.cpp) runs in the core CI path and asserts a deterministic regression value for a small line metric.
+
+## Current C++ Shape
+
+```cpp
+#include <metric/operators.hpp>
+
+#include <vector>
+
+struct AbsoluteDistance {
+    auto operator()(int lhs, int rhs) const -> int
+    {
+        return lhs > rhs ? lhs - rhs : rhs - lhs;
+    }
+};
+
+std::vector<int> records = {0, 1, 2, 3, 4};
+double estimate = metric::operators::intrinsic_dimension(records, AbsoluteDistance{});
+```
+
+## Current Python Shape
+
+```python
+from metric import intrinsic_dimension
+
+records = [0, 1, 2, 3, 4]
+
+def absolute_distance(lhs, rhs):
+    return abs(lhs - rhs)
+
+estimate = intrinsic_dimension(records, absolute_distance)
+```

--- a/docs/examples/structured-data.md
+++ b/docs/examples/structured-data.md
@@ -12,6 +12,7 @@ Promoted examples that currently run in the core CI path:
 - [histogram_emd_space.cpp](../../examples/core/histogram_emd_space.cpp): histograms compared with Earth mover distance
 - [explicit_space_representations.cpp](../../examples/core/explicit_space_representations.cpp): one finite metric space represented as matrix, tree, and graph structures
 - [metric_space_entropy.cpp](../../examples/core/metric_space_entropy.cpp): entropy diagnostics over numeric and string records
+- [metric_space_intrinsic_dimension.cpp](../../examples/core/metric_space_intrinsic_dimension.cpp): expansion-dimension diagnostic over a finite line metric
 - [metric_space_correlation.cpp](../../examples/core/metric_space_correlation.cpp): MGC correlation between paired records with different metric types
 
 ## Pattern
@@ -19,7 +20,7 @@ Promoted examples that currently run in the core CI path:
 1. Choose the record type.
 2. Choose or implement the metric.
 3. Build an implicit or explicit finite metric space.
-4. Run operators such as nearest-neighbor search, entropy, correlation, or graph construction.
+4. Run operators such as nearest-neighbor search, entropy, intrinsic dimension, correlation, or graph construction.
 5. Promote only examples that run in CI as stable examples.
 
 For a concrete custom callable example, see [Custom Metric Example](custom-metric.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Time-Series Space With TWED](examples/time-series-twed.md)
 - [Histogram Space With EMD](examples/histogram-emd.md)
 - [Entropy Diagnostics](examples/entropy-diagnostics.md)
+- [Intrinsic Dimension Diagnostic](examples/intrinsic-dimension.md)
 - [Correlation Between Metric Spaces](examples/correlation-between-spaces.md)
 - [Industrial Anomaly Workflow](examples/industrial-anomaly-workflow.md)
 

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -21,6 +21,7 @@ The current local tree implements the first revival slice:
 - promoted Python examples under `python/examples/metric_space/`
 - C++ smoke and contract tests under `tests/core_smoke/`
 - Python core API and metric-contract tests under `python/tests/core/`
+- intrinsic-dimension diagnostics in C++ and Python core operator helpers
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence

--- a/docs/site/docs.html
+++ b/docs/site/docs.html
@@ -366,13 +366,13 @@
             METRIC separates the current revived core from the target engine facade. Promoted examples use the CI-tested core while the intent-first facade is restored.
           </p>
           <ul>
-            <li><strong>Core Revival API:</strong> metrics, C++ `metric::Metric`, C++ `Space::from_records`, C++ `metric::operators`, Python `Space`, `FiniteMetricSpace`, `MatrixSpace`, explicit C++ representations, and nearest-neighbor helpers.</li>
+            <li><strong>Core Revival API:</strong> metrics, C++ `metric::Metric`, C++ `Space::from_records`, C++ `metric::operators`, Python `Space`, `FiniteMetricSpace`, `MatrixSpace`, explicit C++ representations, nearest-neighbor helpers, and intrinsic-dimension diagnostics.</li>
             <li><strong>Target Engine API:</strong> broader intent methods, strategies, runtime policies, and result objects.</li>
             <li><strong>Compatibility API:</strong> lower-level compatibility names such as `metric::Matrix`, `metric::Tree`, and `metric::KNNGraph`.</li>
             <li><strong>Extension API:</strong> custom metrics, representations, strategies, neural modules, and diagnostics.</li>
           </ul>
           <p>
-            Stable revival surface means CI-backed metrics, typed C++ metric callables, minimal C++ and Python Space facades, explicit spaces, C++ and Python operator helpers, nearest-neighbor helpers, entropy and MGC examples, and install/export support. Python `metric.mappings` and `metric.transforms` are beta compatibility bridges. Mapping modules, transforms, neural approximators, industrial demos, and broad historical examples stay beta or experimental until deterministic tests and promoted examples cover them.
+            Stable revival surface means CI-backed metrics, typed C++ metric callables, minimal C++ and Python Space facades, explicit spaces, C++ and Python operator helpers, nearest-neighbor helpers, intrinsic-dimension diagnostics, entropy and MGC examples, and install/export support. Python `metric.mappings` and `metric.transforms` are beta compatibility bridges. Mapping modules, transforms, neural approximators, industrial demos, and broad historical examples stay beta or experimental until deterministic tests and promoted examples cover them.
           </p>
           <p>
             The repository keeps a path-based module status matrix in <a href="https://github.com/metric-space-ai/metric/blob/master/docs/stability.md">docs/stability.md</a>, separating Core Revival APIs from compatibility, beta, experimental, and historical code.

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -529,7 +529,7 @@
           <div class="grid">
             <div class="tile"><strong>Find</strong><p>Use nearest-neighbor helpers and explicit representations for local structure.</p></div>
             <div class="tile"><strong>Represent</strong><p>Use matrix, graph, and tree spaces when a workflow needs cached or sparse structure.</p></div>
-            <div class="tile"><strong>Transform</strong><p>Use entropy, MGC, and mapping modules where the current core exposes tested operators.</p></div>
+            <div class="tile"><strong>Transform</strong><p>Use intrinsic-dimension diagnostics, entropy, MGC, and mapping modules where the current core exposes tested operators.</p></div>
           </div>
           <pre><code>from metric import Edit, Space
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, and `range_neighbors`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, and pairwise-distance helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, and intrinsic-dimension helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, and pairwise-distance helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, and intrinsic-dimension helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -62,7 +62,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Core C++ facade | `metric/concepts.hpp`, `metric/space.hpp`, `metric/operators.hpp`, `metric/metric.hpp` | Core Revival | Promoted API, covered by core CI, safe for new examples. |
 | Core C++ spaces | `metric/space/matrix.hpp`, `metric/space/knn_graph.hpp`, `metric/space/tree.hpp` | Core Revival / Expert | Stable as explicit representations; lower-level names remain compatibility APIs. |
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
-| Core diagnostics | `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
+| Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
 | Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -33,13 +33,15 @@ The core tests cover:
 - matrix, graph, and tree consistency
 - MGC regression values
 - entropy regression values when LAPACK is available
-- promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, and entropy when LAPACK is available
+- intrinsic-dimension regression values
+- promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, and entropy when LAPACK is available
 
 The Python core wheel path covers:
 
 - importability of the revived Python facade modules
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, and structured record callables
+- intrinsic-dimension regression values
 - promoted Python examples for strings and structured records
 
 ## Extended and Historical Tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ The current core examples cover:
 - custom metric callables
 - explicit matrix, graph, and tree representations
 - entropy diagnostics
+- intrinsic-dimension diagnostics
 - MGC correlation between metric spaces
 - TWED for time-series records
 - EMD for histogram records

--- a/examples/core/CMakeLists.txt
+++ b/examples/core/CMakeLists.txt
@@ -15,6 +15,9 @@ endif ()
 add_executable(metric_space_correlation metric_space_correlation.cpp)
 target_link_libraries(metric_space_correlation PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(metric_space_intrinsic_dimension metric_space_intrinsic_dimension.cpp)
+target_link_libraries(metric_space_intrinsic_dimension PRIVATE ${METRIC_TARGET_NAME})
+
 add_executable(time_series_twed_space time_series_twed_space.cpp)
 target_link_libraries(time_series_twed_space PRIVATE ${METRIC_TARGET_NAME})
 
@@ -29,6 +32,7 @@ if (BUILD_TESTING)
         add_test(NAME example_metric_space_entropy COMMAND metric_space_entropy)
     endif ()
     add_test(NAME example_metric_space_correlation COMMAND metric_space_correlation)
+    add_test(NAME example_metric_space_intrinsic_dimension COMMAND metric_space_intrinsic_dimension)
     add_test(NAME example_time_series_twed_space COMMAND time_series_twed_space)
     add_test(NAME example_histogram_emd_space COMMAND histogram_emd_space)
 endif ()

--- a/examples/core/metric_space_intrinsic_dimension.cpp
+++ b/examples/core/metric_space_intrinsic_dimension.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#include <metric/operators.hpp>
+
+struct AbsoluteDistance {
+	auto operator()(int lhs, int rhs) const -> int
+	{
+		return lhs > rhs ? lhs - rhs : rhs - lhs;
+	}
+};
+
+int main()
+{
+	const std::vector<int> records = {0, 1, 2, 3, 4};
+	const double dimension = metric::operators::intrinsic_dimension(records, AbsoluteDistance{});
+	const double expected = std::log(5.0 / 3.0) / std::log(2.0);
+
+	std::cout << "expansion dimension estimate = " << dimension << "\n";
+	assert(std::abs(dimension - expected) < 1e-12);
+
+	return 0;
+}

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -7,6 +7,9 @@
 
 #include "space.hpp"
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -41,6 +44,35 @@ auto range_neighbors(const Container &records, Metric distance, const detail::re
 					 typename detail::finite_space_t<Container, Metric>::distance_type radius)
 {
 	return ::metric::Space::from_records(records, std::move(distance)).within_radius(query, radius);
+}
+
+template <typename Container, typename Metric>
+auto intrinsic_dimension(const Container &records, Metric distance) -> double
+{
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+
+	const auto distances = pairwise_distance_matrix(records, std::move(distance));
+
+	double maximum_dimension = 0.0;
+	for (const auto &row : distances) {
+		for (const auto &radius : row) {
+			if (radius <= distance_type{}) {
+				continue;
+			}
+
+			const auto outer_radius = radius + radius;
+			const auto inner_count = static_cast<double>(
+				std::count_if(row.begin(), row.end(), [&](const auto &value) { return value <= radius; }));
+			const auto outer_count = static_cast<double>(
+				std::count_if(row.begin(), row.end(), [&](const auto &value) { return value <= outer_radius; }));
+
+			if (inner_count > 0.0 && outer_count >= inner_count) {
+				maximum_dimension = std::max(maximum_dimension, std::log(outer_count / inner_count) / std::log(2.0));
+			}
+		}
+	}
+
+	return maximum_dimension;
 }
 
 } // namespace metric::operators

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
 
 from . import mappings, metrics, operators, spaces, transforms
 from .metrics import Edit
-from .operators import nearest_neighbors, pairwise_distance_matrix, range_neighbors
+from .operators import intrinsic_dimension, nearest_neighbors, pairwise_distance_matrix, range_neighbors
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
 
 __all__ = sorted(

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1,5 +1,7 @@
 """Small metric-space operators covered by the core Python smoke path."""
 
+import math
+
 from metric.spaces import FiniteMetricSpace
 
 
@@ -15,4 +17,29 @@ def range_neighbors(records, metric, query, radius):
     return FiniteMetricSpace(records, metric).rnn(query, radius)
 
 
-__all__ = ["pairwise_distance_matrix", "nearest_neighbors", "range_neighbors"]
+def intrinsic_dimension(records, metric):
+    """Estimate expansion dimension from finite metric-space distance growth."""
+    return intrinsic_dimension_from_distances(pairwise_distance_matrix(records, metric))
+
+
+def intrinsic_dimension_from_distances(distances):
+    maximum_dimension = 0.0
+    for row in distances:
+        for radius in row:
+            if radius <= 0:
+                continue
+
+            inner_count = sum(1 for distance in row if distance <= radius)
+            outer_count = sum(1 for distance in row if distance <= radius * 2)
+            if inner_count and outer_count >= inner_count:
+                maximum_dimension = max(maximum_dimension, math.log2(outer_count / inner_count))
+    return maximum_dimension
+
+
+__all__ = [
+    "intrinsic_dimension",
+    "intrinsic_dimension_from_distances",
+    "pairwise_distance_matrix",
+    "nearest_neighbors",
+    "range_neighbors",
+]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -4,7 +4,7 @@ import metric
 import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
-from metric.operators import nearest_neighbors, pairwise_distance_matrix, range_neighbors
+from metric.operators import intrinsic_dimension, nearest_neighbors, pairwise_distance_matrix, range_neighbors
 from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
 
 
@@ -37,9 +37,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.spaces.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
+        self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
+        self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.range_neighbors, range_neighbors)
         self.assertIs(metric.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.Space, Space)
@@ -73,6 +75,14 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(nearest_neighbors(self.records, self.metric, "cut", 2), [(0, 1), (1, 1)])
         self.assertEqual(range_neighbors(self.records, self.metric, "cut", 1), [(0, 1), (1, 1)])
         self.assertEqual(pairwise_distance_matrix(self.records, self.metric)[0][1], 1)
+
+    def test_intrinsic_dimension_estimates_distance_growth(self):
+        records = [0, 1, 2, 3, 4]
+
+        def absolute_distance(lhs, rhs):
+            return abs(lhs - rhs)
+
+        self.assertAlmostEqual(intrinsic_dimension(records, absolute_distance), np.log2(5.0 / 3.0))
 
     def test_edit_metric_satisfies_metric_contracts(self):
         self.assertMetricContracts(self.records, self.metric)

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,6 +11,7 @@ The tests tree separates the revived core gate from broader historical coverage.
 - matrix, graph, and tree consistency
 - MGC regression values
 - entropy regression values
+- intrinsic-dimension regression values
 - promoted core examples through CTest
 
 `tests/downstream_consumer/` verifies the installed CMake package with `find_package(panda_metric)`. It is part of the C++ core CI gate.

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -1,10 +1,18 @@
 #include <cassert>
+#include <cmath>
 #include <string>
 #include <vector>
 
 #include "metric/distance.hpp"
 #include "metric/operators.hpp"
 #include "metric/space.hpp"
+
+struct AbsoluteDistance {
+    auto operator()(int lhs, int rhs) const -> int
+    {
+        return lhs > rhs ? lhs - rhs : rhs - lhs;
+    }
+};
 
 int main()
 {
@@ -41,6 +49,10 @@ int main()
     const auto operator_range =
         metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
     assert(operator_range.size() == 2);
+
+    const std::vector<int> line = {0, 1, 2, 3, 4};
+    const double dimension = metric::operators::intrinsic_dimension(line, AbsoluteDistance{});
+    assert(std::abs(dimension - (std::log(5.0 / 3.0) / std::log(2.0))) < 1e-12);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `intrinsic_dimension` expansion-dimension diagnostics to C++ and Python core operators
- add C++ and Python regression coverage plus a promoted C++ example executed by CTest
- document the diagnostic in API docs, examples, stability, testing, Pages, and changelog content

## Verification
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core`
- `CMAKE_COMMON_VARIABLES='-DMETRIC_PYTHON_USE_BLAS=OFF' build/python-venv/bin/python -m pip wheel ./python --no-deps -w build/intrinsic-python-wheel`
- `build/python-venv/bin/python -m pip install --force-reinstall build/intrinsic-python-wheel/*.whl`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `build/python-venv/bin/python python/examples/metric_space/string_edit_space.py`
- `build/python-venv/bin/python python/examples/metric_space/structured_record_space.py`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`