### PR TITLE
Prepare v0.3.2 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-19
+
 ### API Changes
 
 - Add `metric::operators::intrinsic_dimension` and `metric.intrinsic_dimension` as expansion-dimension diagnostics for finite metric spaces.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.19)
 #endif()
 #cmake_policy(SET CMP0076 NEW)
 
-project(panda_metric VERSION 0.3.1 LANGUAGES CXX)
+project(panda_metric VERSION 0.3.2 LANGUAGES CXX)
 
 # CCache
 # set(METRIC_USE_CCACHE ON)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -85,11 +85,11 @@ PyPI publishing workflow:
 ```shell
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
-  -f ref=v0.3.1 \
+  -f ref=v0.3.2 \
   -f publish=false
 ```
 
-Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.1` and `publish=true`.
+Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.2` and `publish=true`.
 
 For Trusted Publishing, configure PyPI with:
 
@@ -103,7 +103,7 @@ Then run:
 ```shell
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
-  -f ref=v0.3.1 \
+  -f ref=v0.3.2 \
   -f publish=true \
   -f auth_method=trusted-publishing
 ```

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -128,7 +128,7 @@ PyPI publishing moved to the `v0.3.1` packaging patch release so Linux wheels us
 - publish run `27801491154` rebuilt and checked the same distribution set successfully, but the final Twine upload failed with `HTTPError: 403 Forbidden` from `https://upload.pypi.org/legacy/`
 - PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` after the failed upload, so no visible `metric-space` release was published
 
-The remaining external release action is to update or replace the repository PyPI credentials, or configure PyPI Trusted Publishing for owner `metric-space-ai`, repository `metric`, workflow `publish-python.yml`, and environment `pypi`. The workflow supports both repository-secret password uploads and Trusted Publishing uploads; after PyPI access is fixed, rerun `.github/workflows/publish-python.yml` with `ref=v0.3.1`, `publish=true`, and the appropriate `auth_method`. No local Twine credentials were present during the 2026-06-19 release check.
+The remaining external release action is to update or replace the repository PyPI credentials, or configure PyPI Trusted Publishing for owner `metric-space-ai`, repository `metric`, workflow `publish-python.yml`, and environment `pypi`. The workflow supports both repository-secret password uploads and Trusted Publishing uploads; after PyPI access is fixed, rerun `.github/workflows/publish-python.yml` with the current release tag, `publish=true`, and the appropriate `auth_method`. No local Twine credentials were present during the 2026-06-19 release check.
 
 ## Post-v0.3.1 Master Progress
 
@@ -138,6 +138,10 @@ The following revival improvements landed on `master` after the `v0.3.1` tag:
 - promoted Python structured-record example, merged as `0417dd113f2452ec4772e7835cbf86a33e572e81`
 - release and PyPI build gates running both promoted Python examples, merged as `3d7b1a6e4cfeb37708615e2eb795a1d66bd8450d`
 - Python core metric-contract checks for edit distance, NumPy record callables, and structured-record callables, merged as `3073280344ef66831fbcfcf9197df7d01050b82c`
+- revival source-format checks for promoted source and docs files, merged as `cf35266ba5e18b6113f8eb3aa8715ac500050710`
+- intrinsic-dimension diagnostics in C++ and Python, merged as `d510e0ceb78a307a4e91545837ee4e6ff81eccc3`
+
+The current source tree targets `0.3.2` for the next GitHub release and Python distribution metadata so those post-`v0.3.1` changes can be tagged and published together.
 
 ## Historical Code Policy
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -10,7 +10,7 @@ The revived core API is organized around explicit finite metric spaces:
 Legacy compiled extension names remain available when their modules are present.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 try:
     from metric._impl.metric import *

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metric-space"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python bindings and helpers for finite metric-space numerics"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump C++ and Python package metadata to `0.3.2`
- move the current changelog entries into a dated `0.3.2` release section
- update the release checklist and revival status for the post-`v0.3.1` release path

## Verification
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`
- `cmake --preset core`
- `build/python-venv/bin/python -m build ./python --sdist --outdir build/v0.3.2-release-metadata`
- `CMAKE_COMMON_VARIABLES='-DMETRIC_PYTHON_USE_BLAS=OFF' build/python-venv/bin/python -m pip wheel build/v0.3.2-release-metadata/metric_space-0.3.2.tar.gz --no-deps -w build/v0.3.2-release-metadata`
- `build/python-venv/bin/python -m pip install --force-reinstall build/v0.3.2-release-metadata/metric_space-0.3.2-*.whl`
- `build/python-venv/bin/python - <<'PY' ... print(metric.__version__) ... PY` -> `0.3.2`
- `build/python-venv/bin/python -m twine check build/v0.3.2-release-metadata/*`
- `cmake --build --preset core --parallel 2 && ctest --preset core`