### PR TITLE
Add Python time-series metric-space example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Documentation and Examples
+
+- Add a promoted Python time-series metric-space example using an alignment-aware callable on the core wheel path.
+
 ## [0.3.2] - 2026-06-19
 
 ### API Changes

--- a/docs/examples/structured-data.md
+++ b/docs/examples/structured-data.md
@@ -6,6 +6,7 @@ Promoted examples that currently run in the core CI path:
 
 - [string_edit_space.py](../../python/examples/metric_space/string_edit_space.py): Python strings compared with edit distance
 - [structured_record_space.py](../../python/examples/metric_space/structured_record_space.py): Python structured records compared with a domain metric callable
+- [time_series_alignment_space.py](../../python/examples/metric_space/time_series_alignment_space.py): Python process curves compared with an alignment-aware callable
 - [metric_space_strings.cpp](../../examples/core/metric_space_strings.cpp): strings compared with edit distance
 - [custom_metric_space.cpp](../../examples/core/custom_metric_space.cpp): strings compared with a custom padded Hamming metric
 - [time_series_twed_space.cpp](../../examples/core/time_series_twed_space.cpp): process curves compared with TWED

--- a/docs/examples/time-series-twed.md
+++ b/docs/examples/time-series-twed.md
@@ -4,6 +4,9 @@ Time-series records often need an alignment-aware metric. A shifted or stretched
 
 The promoted C++ example [time_series_twed_space.cpp](../../examples/core/time_series_twed_space.cpp) uses `metric::TWED` to compare small curves, then builds a `metric::MatrixSpace` over those time-series records.
 
+The promoted Python example [time_series_alignment_space.py](../../python/examples/metric_space/time_series_alignment_space.py)
+uses the same finite-space pattern with a small alignment-aware callable. It stays on the core wheel path while the compiled TWED binding remains part of the broader legacy/full Python surface.
+
 Core shape:
 
 ```cpp

--- a/python/examples/metric_space/time_series_alignment_space.py
+++ b/python/examples/metric_space/time_series_alignment_space.py
@@ -1,0 +1,56 @@
+from metric import Space, intrinsic_dimension
+from metric.operators import pairwise_distance_matrix
+
+
+GAP_COST = 2.0
+
+
+def aligned_curve_distance(lhs, rhs):
+    """Edit-distance style alignment metric for short process curves."""
+    lhs = tuple(lhs)
+    rhs = tuple(rhs)
+
+    previous = [index * GAP_COST for index in range(len(rhs) + 1)]
+    for lhs_index, lhs_value in enumerate(lhs, start=1):
+        current = [lhs_index * GAP_COST] + [0.0] * len(rhs)
+        for rhs_index, rhs_value in enumerate(rhs, start=1):
+            substitute = previous[rhs_index - 1] + min(
+                abs(lhs_value - rhs_value),
+                2 * GAP_COST,
+            )
+            delete = previous[rhs_index] + GAP_COST
+            insert = current[rhs_index - 1] + GAP_COST
+            current[rhs_index] = min(substitute, delete, insert)
+        previous = current
+
+    return previous[-1]
+
+
+def main():
+    names = ["baseline", "shifted", "flat", "spike"]
+    records = [
+        (0, 1, 1, 1, 2, 3),
+        (0, 0, 1, 1, 1, 2, 3),
+        (2, 2, 2, 2, 2, 2),
+        (0, 1, 6, 1, 2, 3),
+    ]
+    query = (0, 1, 1, 1, 2, 4)
+
+    space = Space(records, aligned_curve_distance)
+    nearest_id, nearest_distance = space.nearest(query)
+    distances = pairwise_distance_matrix(records, aligned_curve_distance)
+    dimension = intrinsic_dimension(records, aligned_curve_distance)
+
+    assert names[nearest_id] == "baseline"
+    assert nearest_distance == 1.0
+    assert distances[0][1] == 2.0
+    assert distances[0][2] == 6.0
+    assert dimension > 0.0
+
+    print("nearest process curve =", names[nearest_id], nearest_distance)
+    print("distance(baseline, shifted) =", distances[0][1])
+    print("intrinsic dimension estimate =", round(dimension, 3))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -141,6 +141,41 @@ class RevivalApiTest(unittest.TestCase):
         self.assertAlmostEqual(pairwise_distance_matrix(records, structured_record_distance)[0][1], 0.25)
         self.assertMetricContracts(records, structured_record_distance)
 
+    def test_time_series_records_use_alignment_metric_callable(self):
+        gap_cost = 2.0
+        records = [
+            (0, 1, 1, 1, 2, 3),
+            (0, 0, 1, 1, 1, 2, 3),
+            (2, 2, 2, 2, 2, 2),
+            (0, 1, 6, 1, 2, 3),
+        ]
+        query = (0, 1, 1, 1, 2, 4)
+
+        def aligned_curve_distance(lhs, rhs):
+            previous = [index * gap_cost for index in range(len(rhs) + 1)]
+            for lhs_index, lhs_value in enumerate(lhs, start=1):
+                current = [lhs_index * gap_cost] + [0.0] * len(rhs)
+                for rhs_index, rhs_value in enumerate(rhs, start=1):
+                    substitute = previous[rhs_index - 1] + min(
+                        abs(lhs_value - rhs_value),
+                        2 * gap_cost,
+                    )
+                    delete = previous[rhs_index] + gap_cost
+                    insert = current[rhs_index - 1] + gap_cost
+                    current[rhs_index] = min(substitute, delete, insert)
+                previous = current
+
+            return previous[-1]
+
+        space = Space(records, aligned_curve_distance)
+
+        self.assertEqual(space.nearest(query), (0, 1.0))
+        self.assertEqual(space.distance(0, 1), 2.0)
+        self.assertEqual(space.distance(0, 2), 6.0)
+        self.assertEqual(pairwise_distance_matrix(records, aligned_curve_distance)[3][2], 9.0)
+        self.assertGreater(intrinsic_dimension(records, aligned_curve_distance), 0.0)
+        self.assertMetricContracts(records, aligned_curve_distance)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a promoted Python metric-space example for short process curves using an alignment-aware callable
- add core API coverage for the same time-series metric callable and intrinsic-dimension helper
- link the new example from the structured-data and time-series docs, and note it in the changelog

## Verification
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python python/examples/metric_space/time_series_alignment_space.py
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python.tests.core.test_revival_api -v
- for example in python/examples/metric_space/*.py; do PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python "$example"; done
- ruby scripts/check_revival_format.rb
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_markdown_links.rb
- git diff --check