### PR TITLE
Add Python histogram metric-space example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased]
 
+### Algorithm Changes
+
+- Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
+
 ### Documentation and Examples
 
 - Add a promoted Python time-series metric-space example using an alignment-aware callable on the core wheel path.
+- Add a promoted Python histogram metric-space example using a one-dimensional transport callable on the core wheel path.
 
 ## [0.3.2] - 2026-06-19
 

--- a/docs/examples/histogram-emd.md
+++ b/docs/examples/histogram-emd.md
@@ -4,6 +4,9 @@ Histograms and empirical distributions are often better compared by transport co
 
 The promoted C++ example [histogram_emd_space.cpp](../../examples/core/histogram_emd_space.cpp) uses a small one-dimensional ground-cost matrix, then builds a `metric::MatrixSpace` over histogram records.
 
+The promoted Python example [histogram_transport_space.py](../../python/examples/metric_space/histogram_transport_space.py)
+uses the same metric-space pattern with a deterministic one-dimensional transport callable. It covers the core wheel path without requiring the broader compiled EMD binding.
+
 Core shape:
 
 ```cpp

--- a/docs/examples/structured-data.md
+++ b/docs/examples/structured-data.md
@@ -7,6 +7,7 @@ Promoted examples that currently run in the core CI path:
 - [string_edit_space.py](../../python/examples/metric_space/string_edit_space.py): Python strings compared with edit distance
 - [structured_record_space.py](../../python/examples/metric_space/structured_record_space.py): Python structured records compared with a domain metric callable
 - [time_series_alignment_space.py](../../python/examples/metric_space/time_series_alignment_space.py): Python process curves compared with an alignment-aware callable
+- [histogram_transport_space.py](../../python/examples/metric_space/histogram_transport_space.py): Python histograms compared with a transport callable
 - [metric_space_strings.cpp](../../examples/core/metric_space_strings.cpp): strings compared with edit distance
 - [custom_metric_space.cpp](../../examples/core/custom_metric_space.cpp): strings compared with a custom padded Hamming metric
 - [time_series_twed_space.cpp](../../examples/core/time_series_twed_space.cpp): process curves compared with TWED

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -57,8 +57,10 @@ Python wheel verification:
 ```shell
 python -m pip wheel ./python --no-deps -w wheelhouse
 python -m pip install --force-reinstall wheelhouse/*.whl
-python python/examples/metric_space/string_edit_space.py
-python python/examples/metric_space/structured_record_space.py
+for example in python/examples/metric_space/*.py; do
+  python "$example"
+done
+PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s python/tests/core -v
 ```
 
 Docs and formatting verification:

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -40,9 +40,10 @@ The Python core wheel path covers:
 
 - importability of the revived Python facade modules
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
-- metric contract checks for built-in edit distance, NumPy record callables, and structured record callables
+- metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
-- promoted Python examples for strings and structured records
+- promoted Python examples for strings, structured records, time-series alignment, and histogram transport
+- subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
 
 ## Extended and Historical Tests
 

--- a/python/examples/metric_space/histogram_transport_space.py
+++ b/python/examples/metric_space/histogram_transport_space.py
@@ -1,0 +1,48 @@
+from metric import Space, intrinsic_dimension
+from metric.operators import pairwise_distance_matrix
+
+
+def cumulative_transport_distance(lhs, rhs):
+    """One-dimensional earth mover distance for equal-mass histograms."""
+    if len(lhs) != len(rhs):
+        raise ValueError("histograms must have the same number of bins")
+
+    cumulative_delta = 0.0
+    distance = 0.0
+    for lhs_mass, rhs_mass in zip(lhs, rhs):
+        cumulative_delta += lhs_mass - rhs_mass
+        distance += abs(cumulative_delta)
+
+    return distance
+
+
+def main():
+    names = ["left-edge", "one-step", "right-edge", "split-left", "center"]
+    records = [
+        (1.0, 0.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0, 1.0),
+        (0.5, 0.5, 0.0, 0.0),
+        (0.0, 0.5, 0.5, 0.0),
+    ]
+    query = (0.25, 0.75, 0.0, 0.0)
+
+    space = Space(records, cumulative_transport_distance)
+    nearest_id, nearest_distance = space.nearest(query)
+    distances = pairwise_distance_matrix(records, cumulative_transport_distance)
+    dimension = intrinsic_dimension(records, cumulative_transport_distance)
+
+    assert names[nearest_id] == "one-step"
+    assert nearest_distance == 0.25
+    assert distances[0][1] == 1.0
+    assert distances[0][2] == 3.0
+    assert distances[3][4] == 1.0
+    assert dimension > 0.0
+
+    print("nearest histogram =", names[nearest_id], nearest_distance)
+    print("distance(left-edge, right-edge) =", distances[0][2])
+    print("intrinsic dimension estimate =", round(dimension, 3))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -1,4 +1,8 @@
+import os
+import subprocess
+import sys
 import unittest
+from pathlib import Path
 
 import metric
 import numpy as np
@@ -53,6 +57,23 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(transforms.STABILITY, "beta")
         self.assertIsInstance(mappings.available(), tuple)
         self.assertIsInstance(transforms.available(), tuple)
+
+    def test_promoted_metric_space_examples_run(self):
+        examples_dir = Path(__file__).resolve().parents[2] / "examples" / "metric_space"
+        examples = sorted(examples_dir.glob("*.py"))
+
+        self.assertGreaterEqual(len(examples), 1)
+        for example in examples:
+            with self.subTest(example=example.name):
+                result = subprocess.run(
+                    [sys.executable, str(example)],
+                    check=False,
+                    env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout)
 
     def test_finite_metric_space_caches_pairwise_distances(self):
         space = FiniteMetricSpace(self.records, self.metric)
@@ -175,6 +196,38 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(pairwise_distance_matrix(records, aligned_curve_distance)[3][2], 9.0)
         self.assertGreater(intrinsic_dimension(records, aligned_curve_distance), 0.0)
         self.assertMetricContracts(records, aligned_curve_distance)
+
+    def test_histogram_records_use_transport_metric_callable(self):
+        records = [
+            (1.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0, 1.0),
+            (0.5, 0.5, 0.0, 0.0),
+            (0.0, 0.5, 0.5, 0.0),
+        ]
+        query = (0.25, 0.75, 0.0, 0.0)
+
+        def cumulative_transport_distance(lhs, rhs):
+            if len(lhs) != len(rhs):
+                raise ValueError("histograms must have the same number of bins")
+
+            cumulative_delta = 0.0
+            distance = 0.0
+            for lhs_mass, rhs_mass in zip(lhs, rhs):
+                cumulative_delta += lhs_mass - rhs_mass
+                distance += abs(cumulative_delta)
+
+            return distance
+
+        space = Space(records, cumulative_transport_distance)
+
+        self.assertEqual(space.nearest(query), (1, 0.25))
+        self.assertEqual(space.distance(0, 1), 1.0)
+        self.assertEqual(space.distance(0, 2), 3.0)
+        self.assertEqual(space.distance(3, 4), 1.0)
+        self.assertEqual(pairwise_distance_matrix(records, cumulative_transport_distance)[1][4], 0.5)
+        self.assertGreater(intrinsic_dimension(records, cumulative_transport_distance), 0.0)
+        self.assertMetricContracts(records, cumulative_transport_distance)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a promoted Python histogram metric-space example using a deterministic one-dimensional transport callable
- add core API coverage for histogram transport distances and subprocess execution of all promoted Python examples
- update the histogram docs, structured-data example list, testing scope, release checklist, and changelog

## Verification
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python python/examples/metric_space/histogram_transport_space.py
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v
- for example in python/examples/metric_space/*.py; do PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python "$example"; done
- ruby scripts/check_revival_format.rb
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_markdown_links.rb
- git diff --check