### PR TITLE
Document master PyPI dry-run

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -161,6 +161,8 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - promoted Python histogram metric-space example using a one-dimensional transport callable, merged as `dbed0eba25455e420baba79f49d134c126dd6c14`
 - Python core API tests now subprocess-run every `python/examples/metric_space/*.py` example, merged as `dbed0eba25455e420baba79f49d134c126dd6c14`
 - testing and release-checklist docs now describe the expanded promoted Python example gate, merged as `dbed0eba25455e420baba79f49d134c126dd6c14`
+- PyPI publish dry-run `27804901826` completed successfully on `master` commit `1ab3ada019f0460f4ba418291bd2146342ef8064` with one source distribution artifact and checked wheel artifact sets for CPython 3.10 through 3.14 on Linux, macOS, and Windows
+- PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` after the master dry-run, so no visible `metric-space` release has been published
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the successful manual PyPI dry-run on current master after the promoted Python example expansion
- note the generated sdist and platform wheel artifact sets
- keep the PyPI 404/package-publication blocker visible

## Verification
- ruby scripts/check_markdown_links.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_revival_whitespace.rb
- git diff --check