### PR TITLE
Add research roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Documentation and Examples
 
+- Add a promotion-gated research roadmap for diagnostics, representative selection, sparse graphs, cross-space dependency discovery, denoising, vector-database adapters, and benchmarks.
 - Add a promoted Python time-series metric-space example using an alignment-aware callable on the core wheel path.
 - Add a promoted Python histogram metric-space example using a one-dimensional transport callable on the core wheel path.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ METRIC is not another vector database and not a loose algorithm catalog. It prov
 - Docs source: [docs/index.md](docs/index.md)
 - Engine overview: [docs/engine/index.md](docs/engine/index.md)
 - API surface: [docs/stability.md](docs/stability.md)
+- Research roadmap: [docs/research-roadmap.md](docs/research-roadmap.md)
 - Revival status: [docs/revival-status.md](docs/revival-status.md)
 - Changelog: [CHANGELOG.md](CHANGELOG.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Metric-Space Numerics Manifesto](manifesto.md)
 - [API Surface](stability.md)
 - [Testing and CI Scope](testing-and-ci.md)
+- [Research Roadmap](research-roadmap.md)
 - [Revival Status](revival-status.md)
 - [C++ API](api/cpp.md)
 - [Python API](api/python.md)
@@ -26,7 +27,8 @@ This docs tree is the canonical home for concepts, API references, engine archit
 6. Use the [Python API](api/python.md) or [C++ API](api/cpp.md) for implementation.
 7. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
 8. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
-9. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
+9. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
+10. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
 
 ## Concepts
 
@@ -52,6 +54,7 @@ This docs tree is the canonical home for concepts, API references, engine archit
 
 The project keeps the design records that shaped the engine in the repository root. They are useful when extending the engine or reviewing why the API is organized around intent names, strategies, representations, and runtime policies.
 
+- [Research Roadmap](research-roadmap.md)
 - [Engine Implementation Plan](../ENGINE_IMPLEMENTATION_PLAN.md)
 - [Capability Roadmap](../CAPABILITY_ROADMAP.md)
 - [Algorithmic Gap Analysis](../ALGORITHMIC_GAP_ANALYSIS.md)

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -1,0 +1,179 @@
+# Research Roadmap
+
+This roadmap translates the revival plan's research directions into a promotion-gated backlog. It keeps research breadth visible without moving unverified code into the stable release contract.
+
+## Promotion Rule
+
+A research direction moves toward the Core Revival API only after it has:
+
+- a documented user problem and record type
+- a metric or metric-family assumption
+- deterministic fixtures with expected values or contract assertions
+- one promoted C++ or Python example
+- CI coverage in the relevant release gate
+- release notes that describe assumptions, limitations, and compatibility impact
+
+Until those conditions hold, the work remains Beta, Experimental, or Historical as defined in [API Surface](stability.md).
+
+## Priority 1: Diagnostics For Finite Metric Spaces
+
+Goal: make METRIC useful before users commit to a representation or mapping strategy.
+
+Current stable base:
+
+- nearest-neighbor and range-neighbor helpers
+- pairwise distance matrices
+- entropy examples
+- MGC examples
+- intrinsic-dimension diagnostics
+
+Next increments:
+
+- document diagnostic result interpretation for sparse, duplicate-heavy, and noisy record sets
+- add representative fixtures for strings, histograms, process curves, and mixed records
+- expose diagnostic result objects with metadata such as metric name, sample size, radius policy, and warnings
+- compare dense-matrix, graph, and tree behavior on the same fixture
+
+Promotion evidence:
+
+- deterministic regression tests in `tests/core_smoke/` or `python/tests/core/`
+- promoted examples under `examples/core/` or `python/examples/metric_space/`
+- documentation that states when a diagnostic is a heuristic rather than a proof
+
+## Priority 2: Representative Selection And Compression
+
+Goal: choose small, meaningful subsets of a finite metric space without assuming vector centroids.
+
+Candidate strategies:
+
+- medoid or k-medoids representatives
+- farthest-first traversal
+- coverage-based representatives under a radius
+- redundancy reduction by distance threshold
+- compression summaries that preserve nearest-neighbor behavior
+
+Required fixtures:
+
+- string records with edit distance
+- histogram records with transport distance
+- process curves with time-series alignment
+- structured records with mixed categorical and numeric penalties
+
+Promotion evidence:
+
+- exact expected representatives for small fixtures
+- complexity and tie-breaking rules
+- examples that show why a vector centroid is not the right object
+
+## Priority 3: Sparse Graph Representations
+
+Goal: make graph representations a first-class runtime choice for finite metric spaces.
+
+Candidate strategies:
+
+- exact k-nearest-neighbor graph construction
+- radius graph construction
+- symmetrization and weighting policies
+- sparsification primitives with documented assumptions
+- graph diagnostics such as connectivity, degree distribution, and edge stretch
+
+Promotion evidence:
+
+- consistency tests against dense pairwise distances
+- deterministic graph fixtures with expected edge sets
+- documentation that distinguishes exact, approximate, directed, undirected, weighted, and normalized graphs
+
+## Priority 4: Cross-Space Dependency Discovery
+
+Goal: compare paired metric spaces when records have different native types.
+
+Candidate strategies:
+
+- MGC over paired finite metric spaces
+- distance correlation over paired spaces
+- permutation-test wrappers with reproducible seeds
+- diagnostics for sample count, duplicate distances, and degenerate spaces
+
+Required fixtures:
+
+- process curves paired with event strings
+- histograms paired with structured process records
+- vector baseline fixtures for compatibility checks
+
+Promotion evidence:
+
+- deterministic small-fixture regression values
+- documented interpretation of correlation and p-value outputs
+- examples that avoid implying causality from correlation
+
+## Priority 5: Denoising And Manifold Cleanup
+
+Goal: transform a finite metric space into a cleaner or simpler finite metric space while preserving metric assumptions.
+
+Candidate strategies:
+
+- outlier removal by local neighborhood density
+- redundant-record pruning
+- graph-based smoothing over metric neighborhoods
+- metric-space reconstruction or reverse mapping where an explicit strategy exists
+
+Promotion evidence:
+
+- before/after fixtures with objective expected outcomes
+- clear preservation guarantees, or explicit statements that a transform does not preserve metric structure
+- examples that report discarded records and diagnostic warnings
+
+## Priority 6: Adapter Layer For Vector Databases
+
+Goal: treat vector databases as storage or search backends, not as the conceptual model.
+
+Candidate strategies:
+
+- adapter for storing explicit metric-space records and metadata
+- adapter for using embeddings as one optional representation
+- fallback path that preserves the original metric and records
+- comparison workflows that show domain metric versus embedding behavior
+
+Promotion evidence:
+
+- adapter interface that never requires the user to discard record identity or metric assumptions
+- tests that prove round-tripping of records, IDs, distances, and metadata
+- documentation that distinguishes backend search from metric-space modeling
+
+## Priority 7: Benchmark Suite
+
+Goal: compare metric-space workflows against vector or embedding baselines on representative data.
+
+Candidate datasets:
+
+- string edit-distance fixtures
+- histogram or empirical-distribution fixtures
+- process-curve fixtures
+- mixed industrial-record fixtures
+- vector-only control fixtures
+
+Benchmark rules:
+
+- correctness and interpretability checks come before speed charts
+- every benchmark records metric, representation, runtime policy, seed, hardware, and dataset version
+- benchmark publishing stays separate from correctness CI until results are deterministic enough to archive
+
+## Non-Goals During Revival
+
+The revival should not:
+
+- promote neural-network or autoencoder modules as stable APIs before deterministic fixtures exist
+- add new algorithm families without documentation and release-gate tests
+- imply METRIC is a general vector database
+- convert all records to embeddings by default
+- make benchmark speedups substitute for metric-space correctness
+
+## Next Candidate Branches
+
+Near-term branches should stay small and evidence-driven:
+
+- add one C++ representative-selection smoke test for string records
+- add one Python representative-selection prototype behind `metric.operators` only if it has deterministic fixtures
+- add graph construction documentation with exact versus approximate terminology
+- add MGC interpretation docs for paired metric spaces
+- add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties


### PR DESCRIPTION
## Summary
- add a promotion-gated research roadmap for Workstream I directions
- prioritize diagnostics, representative selection, sparse graphs, cross-space dependency discovery, denoising, vector-database adapters, and benchmarks
- link the roadmap from the README and docs index

## Verification
- ruby scripts/check_markdown_links.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_revival_whitespace.rb
- git diff --cached --check