### PR TITLE
Add Python representative selection helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 ### Algorithm Changes
 
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
+- Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 
 ### Documentation and Examples
 
 - Add a promotion-gated research roadmap for diagnostics, representative selection, sparse graphs, cross-space dependency discovery, denoising, vector-database adapters, and benchmarks.
 - Add a promoted Python time-series metric-space example using an alignment-aware callable on the core wheel path.
 - Add a promoted Python histogram metric-space example using a one-dimensional transport callable on the core wheel path.
+- Add a promoted Python representative-selection example using histogram records and transport distance on the core wheel path.
 
 ## [0.3.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Examples:
 - [Structured Data](docs/examples/structured-data.md)
 - [Time-Series Space With TWED](docs/examples/time-series-twed.md)
 - [Histogram Space With EMD](docs/examples/histogram-emd.md)
+- [Representative Selection](docs/examples/representative-selection.md)
 - [Entropy Diagnostics](docs/examples/entropy-diagnostics.md)
 - [Intrinsic Dimension Diagnostic](docs/examples/intrinsic-dimension.md)
 - [Correlation Between Metric Spaces](docs/examples/correlation-between-spaces.md)

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, representative selection, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -46,13 +46,24 @@ space.rnn(query, radius=1)
 ## Operators
 
 ```python
-from metric.operators import intrinsic_dimension, nearest_neighbors, pairwise_distance_matrix, range_neighbors
+from metric.operators import (
+    intrinsic_dimension,
+    nearest_neighbors,
+    pairwise_distance_matrix,
+    range_neighbors,
+    representative_indices,
+    representatives,
+)
 
 distances = pairwise_distance_matrix(records, Edit())
 neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
 close = range_neighbors(records, Edit(), "cut", radius=1)
+selected_ids = representative_indices(records, Edit(), k=2)
+selected_records = representatives(records, Edit(), k=2)
 dimension = intrinsic_dimension(records, Edit())
 ```
+
+`representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
 `intrinsic_dimension` returns an expansion-dimension estimate based on finite-space neighborhood growth. Treat it as a diagnostic that depends on the metric, sample density, duplicates, and available radii.
 

--- a/docs/examples/representative-selection.md
+++ b/docs/examples/representative-selection.md
@@ -1,0 +1,24 @@
+# Representative Selection
+
+Representative selection chooses existing records from a finite metric space. This is useful when the record type does not have a meaningful vector centroid, such as strings, histograms, event sequences, or mixed structured records.
+
+The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects three histogram records using a one-dimensional transport callable and deterministic farthest-first traversal.
+
+Core shape:
+
+```python
+from metric import representative_indices, representatives
+
+records = [
+    (1.0, 0.0, 0.0, 0.0),
+    (0.0, 1.0, 0.0, 0.0),
+    (0.0, 0.0, 0.0, 1.0),
+]
+
+selected_ids = representative_indices(records, cumulative_transport_distance, k=2)
+selected_records = representatives(records, cumulative_transport_distance, k=2)
+```
+
+The helper starts from `seed_index=0` by default, then repeatedly chooses the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
+
+This is a coverage-oriented heuristic, not a k-medoids optimizer. It is promoted for the Python core facade because the behavior is deterministic, documented, and covered by wheel CI. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Structured Data](examples/structured-data.md)
 - [Time-Series Space With TWED](examples/time-series-twed.md)
 - [Histogram Space With EMD](examples/histogram-emd.md)
+- [Representative Selection](examples/representative-selection.md)
 - [Entropy Diagnostics](examples/entropy-diagnostics.md)
 - [Intrinsic Dimension Diagnostic](examples/intrinsic-dimension.md)
 - [Correlation Between Metric Spaces](examples/correlation-between-spaces.md)

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -44,10 +44,15 @@ Promotion evidence:
 
 Goal: choose small, meaningful subsets of a finite metric space without assuming vector centroids.
 
+Current promoted base:
+
+- Python `metric.operators.representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
+- The promoted fixture uses histogram records with a one-dimensional transport callable and exact expected representative IDs.
+
 Candidate strategies:
 
 - medoid or k-medoids representatives
-- farthest-first traversal
+- C++ parity for farthest-first traversal
 - coverage-based representatives under a radius
 - redundancy reduction by distance threshold
 - compression summaries that preserve nearest-neighbor behavior
@@ -173,7 +178,7 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add one C++ representative-selection smoke test for string records
-- add one Python representative-selection prototype behind `metric.operators` only if it has deterministic fixtures
+- add medoid or radius-coverage representative fixtures after the farthest-first helper has C++ parity
 - add graph construction documentation with exact versus approximate terminology
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -17,7 +17,7 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, and intrinsic-dimension helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and Python representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, and intrinsic-dimension helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and Python representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -42,7 +42,8 @@ The Python core wheel path covers:
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
-- promoted Python examples for strings, structured records, time-series alignment, and histogram transport
+- deterministic representative-selection regression values
+- promoted Python examples for strings, structured records, time-series alignment, histogram transport, and representative selection
 - subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
 
 ## Extended and Historical Tests

--- a/python/examples/metric_space/representative_selection_space.py
+++ b/python/examples/metric_space/representative_selection_space.py
@@ -1,0 +1,41 @@
+from metric import Space, representative_indices, representatives
+
+
+def cumulative_transport_distance(lhs, rhs):
+    """One-dimensional earth mover distance for equal-mass histograms."""
+    if len(lhs) != len(rhs):
+        raise ValueError("histograms must have the same number of bins")
+
+    cumulative_delta = 0.0
+    distance = 0.0
+    for lhs_mass, rhs_mass in zip(lhs, rhs):
+        cumulative_delta += lhs_mass - rhs_mass
+        distance += abs(cumulative_delta)
+
+    return distance
+
+
+def main():
+    names = ["left-edge", "one-step", "right-edge", "split-left", "center"]
+    records = [
+        (1.0, 0.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0, 1.0),
+        (0.5, 0.5, 0.0, 0.0),
+        (0.0, 0.5, 0.5, 0.0),
+    ]
+
+    space = Space(records, cumulative_transport_distance)
+    selected = representative_indices(records, cumulative_transport_distance, k=3)
+    selected_records = representatives(records, cumulative_transport_distance, k=3)
+
+    assert selected == [0, 2, 4]
+    assert selected_records == [records[0], records[2], records[4]]
+    assert space.distance(selected[0], selected[1]) == 3.0
+
+    print("representative histograms =", ", ".join(names[index] for index in selected))
+    print("coverage seed distance =", space.distance(selected[0], selected[1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -19,7 +19,14 @@ except ModuleNotFoundError:
 
 from . import mappings, metrics, operators, spaces, transforms
 from .metrics import Edit
-from .operators import intrinsic_dimension, nearest_neighbors, pairwise_distance_matrix, range_neighbors
+from .operators import (
+    intrinsic_dimension,
+    nearest_neighbors,
+    pairwise_distance_matrix,
+    range_neighbors,
+    representative_indices,
+    representatives,
+)
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
 
 __all__ = sorted(

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1,6 +1,7 @@
 """Small metric-space operators covered by the core Python smoke path."""
 
 import math
+import operator
 
 from metric.spaces import FiniteMetricSpace
 
@@ -15,6 +16,67 @@ def nearest_neighbors(records, metric, query, k=1):
 
 def range_neighbors(records, metric, query, radius):
     return FiniteMetricSpace(records, metric).rnn(query, radius)
+
+
+def representative_indices(records, metric, k, seed_index=0):
+    """Select representative record IDs with deterministic farthest-first traversal."""
+    records = list(records)
+    try:
+        k = operator.index(k)
+        seed_index = operator.index(seed_index)
+    except TypeError:
+        raise TypeError("k and seed_index must be integers") from None
+
+    if k < 0:
+        raise ValueError("k must be non-negative")
+    if k == 0:
+        return []
+    if not records:
+        raise ValueError("cannot select representatives from an empty record set")
+    if k > len(records):
+        raise ValueError("k cannot exceed the number of records")
+    if seed_index < 0 or seed_index >= len(records):
+        raise IndexError("seed_index is outside the record set")
+
+    space = FiniteMetricSpace(records, metric)
+    selected = [seed_index]
+    selected_set = {seed_index}
+    nearest_selected_distances = [
+        space.distance(index, seed_index)
+        for index in range(len(records))
+    ]
+
+    while len(selected) < k:
+        next_index = None
+        next_distance = None
+        for index, distance in enumerate(nearest_selected_distances):
+            if index in selected_set:
+                continue
+            if next_distance is None or distance > next_distance:
+                next_index = index
+                next_distance = distance
+
+        if next_index is None:
+            raise RuntimeError("failed to select the next representative")
+
+        selected.append(next_index)
+        selected_set.add(next_index)
+        for index in range(len(records)):
+            nearest_selected_distances[index] = min(
+                nearest_selected_distances[index],
+                space.distance(index, next_index),
+            )
+
+    return selected
+
+
+def representatives(records, metric, k, seed_index=0):
+    """Select representative records with deterministic farthest-first traversal."""
+    records = list(records)
+    return [
+        records[index]
+        for index in representative_indices(records, metric, k, seed_index)
+    ]
 
 
 def intrinsic_dimension(records, metric):
@@ -42,4 +104,6 @@ __all__ = [
     "pairwise_distance_matrix",
     "nearest_neighbors",
     "range_neighbors",
+    "representative_indices",
+    "representatives",
 ]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -8,7 +8,14 @@ import metric
 import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
-from metric.operators import intrinsic_dimension, nearest_neighbors, pairwise_distance_matrix, range_neighbors
+from metric.operators import (
+    intrinsic_dimension,
+    nearest_neighbors,
+    pairwise_distance_matrix,
+    range_neighbors,
+    representative_indices,
+    representatives,
+)
 from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
 
 
@@ -42,17 +49,23 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
+        self.assertIs(metric.operators.representative_indices, representative_indices)
+        self.assertIs(metric.operators.representatives, representatives)
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.range_neighbors, range_neighbors)
+        self.assertIs(metric.representative_indices, representative_indices)
+        self.assertIs(metric.representatives, representatives)
         self.assertIs(metric.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.Space, Space)
         self.assertIn("FiniteMetricSpace", metric.__all__)
         self.assertIn("Space", metric.__all__)
         self.assertIn("mappings", metric.__all__)
         self.assertIn("transforms", metric.__all__)
+        self.assertIn("representative_indices", metric.__all__)
+        self.assertIn("representatives", metric.__all__)
         self.assertEqual(mappings.STABILITY, "beta")
         self.assertEqual(transforms.STABILITY, "beta")
         self.assertIsInstance(mappings.available(), tuple)
@@ -104,6 +117,55 @@ class RevivalApiTest(unittest.TestCase):
             return abs(lhs - rhs)
 
         self.assertAlmostEqual(intrinsic_dimension(records, absolute_distance), np.log2(5.0 / 3.0))
+
+    def test_representative_selection_uses_farthest_first_traversal(self):
+        records = [
+            (1.0, 0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0, 0.0),
+            (0.0, 0.0, 0.0, 1.0),
+            (0.5, 0.5, 0.0, 0.0),
+            (0.0, 0.5, 0.5, 0.0),
+        ]
+
+        def cumulative_transport_distance(lhs, rhs):
+            cumulative_delta = 0.0
+            distance = 0.0
+            for lhs_mass, rhs_mass in zip(lhs, rhs):
+                cumulative_delta += lhs_mass - rhs_mass
+                distance += abs(cumulative_delta)
+
+            return distance
+
+        self.assertEqual(representative_indices(records, cumulative_transport_distance, 3), [0, 2, 4])
+        self.assertEqual(
+            representatives(records, cumulative_transport_distance, 3),
+            [records[0], records[2], records[4]],
+        )
+        self.assertEqual(representative_indices(records, cumulative_transport_distance, 0), [])
+
+    def test_representative_selection_validates_inputs_and_ties(self):
+        records = [0, 1, 2, 10]
+
+        def absolute_distance(lhs, rhs):
+            return abs(lhs - rhs)
+
+        self.assertEqual(representative_indices(records, absolute_distance, 3), [0, 3, 2])
+        self.assertEqual(representative_indices(records, absolute_distance, 2, seed_index=1), [1, 3])
+
+        with self.assertRaises(TypeError):
+            representative_indices(records, absolute_distance, 1.5)
+        with self.assertRaises(TypeError):
+            representative_indices(records, absolute_distance, 1, seed_index=0.5)
+        with self.assertRaises(ValueError):
+            representative_indices(records, absolute_distance, -1)
+        with self.assertRaises(ValueError):
+            representative_indices([], absolute_distance, 1)
+        with self.assertRaises(ValueError):
+            representative_indices(records, absolute_distance, 5)
+        with self.assertRaises(IndexError):
+            representative_indices(records, absolute_distance, 1, seed_index=-1)
+        with self.assertRaises(IndexError):
+            representative_indices(records, absolute_distance, 1, seed_index=len(records))
 
     def test_edit_metric_satisfies_metric_contracts(self):
         self.assertMetricContracts(self.records, self.metric)


### PR DESCRIPTION
## Summary
- add Python `representative_indices` / `representatives` helpers using deterministic farthest-first traversal
- add core tests for imports, traversal order, tie-breaking, and invalid inputs
- add a promoted representative-selection example and docs/status updates for the Python core surface

## Local verification
- `build/python-venv/bin/python -m pip wheel ./python --no-deps -w build/representative-selection-wheel`
- `build/python-venv/bin/python -m pip install --force-reinstall build/representative-selection-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`