### PR TITLE
Document representative selection status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -22,6 +22,7 @@ The current local tree implements the first revival slice:
 - C++ smoke and contract tests under `tests/core_smoke/`
 - Python core API and metric-contract tests under `python/tests/core/`
 - intrinsic-dimension diagnostics in C++ and Python core operator helpers
+- deterministic Python representative-selection helpers in `metric.operators`
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -164,6 +165,8 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - PyPI publish dry-run `27804901826` completed successfully on `master` commit `1ab3ada019f0460f4ba418291bd2146342ef8064` with one source distribution artifact and checked wheel artifact sets for CPython 3.10 through 3.14 on Linux, macOS, and Windows
 - PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` after the master dry-run, so no visible `metric-space` release has been published
 - promotion-gated research roadmap for diagnostics, representative selection, sparse graphs, cross-space dependency discovery, denoising, vector-database adapters, and benchmarks, merged as `b80eaba438a6a45f327951c87f74d88c4af37ed3`
+- Python representative-selection helpers using deterministic farthest-first traversal, merged as `78d9d4cdb065555541e10131698452c6d713a257`
+- promoted Python representative-selection example and wheel-gate coverage, merged as `78d9d4cdb065555541e10131698452c6d713a257`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the Python representative-selection helper in the revival status page
- add the #348 merge commit to the post-v0.3.2 progress list

## Local verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`