### PR TITLE
Add C++ representative selection helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
+- Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
 
 ### Documentation and Examples
 
@@ -13,6 +14,7 @@
 - Add a promoted Python time-series metric-space example using an alignment-aware callable on the core wheel path.
 - Add a promoted Python histogram metric-space example using a one-dimensional transport callable on the core wheel path.
 - Add a promoted Python representative-selection example using histogram records and transport distance on the core wheel path.
+- Add a promoted C++ representative-selection example using string records and edit distance on the core CTest path.
 
 ## [0.3.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::pairwise_distance_matrix`
 - `metric::operators::nearest_neighbors`
 - `metric::operators::range_neighbors`
+- `metric::operators::representative_indices`
+- `metric::operators::representatives`
 - `metric::operators::intrinsic_dimension`
 - `metric::MatrixSpace`
 - `metric::GraphSpace`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -65,10 +65,16 @@ std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
 auto distances = metric::operators::pairwise_distance_matrix(records, metric::Edit<std::string>{});
 auto nearest = metric::operators::nearest_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 2);
 auto close = metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
+auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
+auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, and `intrinsic_dimension`. `intrinsic_dimension` returns an expansion-dimension estimate based on neighborhood growth; it is a finite-space diagnostic, not an exact manifold dimension.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, and `intrinsic_dimension`.
+
+`representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
+
+`intrinsic_dimension` returns an expansion-dimension estimate based on neighborhood growth. It is a finite-space diagnostic, not an exact manifold dimension.
 
 ## Custom Metrics
 

--- a/docs/examples/representative-selection.md
+++ b/docs/examples/representative-selection.md
@@ -2,9 +2,26 @@
 
 Representative selection chooses existing records from a finite metric space. This is useful when the record type does not have a meaningful vector centroid, such as strings, histograms, event sequences, or mixed structured records.
 
-The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects three histogram records using a one-dimensional transport callable and deterministic farthest-first traversal.
+The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects three string records using edit distance and deterministic farthest-first traversal.
 
-Core shape:
+The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects three histogram records using a one-dimensional transport callable and the same traversal rule.
+
+C++ shape:
+
+```cpp
+#include <metric/distance.hpp>
+#include <metric/operators.hpp>
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
+
+auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
+auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
+```
+
+Python shape:
 
 ```python
 from metric import representative_indices, representatives
@@ -19,6 +36,6 @@ selected_ids = representative_indices(records, cumulative_transport_distance, k=
 selected_records = representatives(records, cumulative_transport_distance, k=2)
 ```
 
-The helper starts from `seed_index=0` by default, then repeatedly chooses the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
+The helpers start from `seed_index=0` by default, then repeatedly choose the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
 
-This is a coverage-oriented heuristic, not a k-medoids optimizer. It is promoted for the Python core facade because the behavior is deterministic, documented, and covered by wheel CI. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.
+This is a coverage-oriented heuristic, not a k-medoids optimizer. It is promoted because the behavior is deterministic, documented, and covered by the core C++ and Python CI gates. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -46,13 +46,14 @@ Goal: choose small, meaningful subsets of a finite metric space without assuming
 
 Current promoted base:
 
-- Python `metric.operators.representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
-- The promoted fixture uses histogram records with a one-dimensional transport callable and exact expected representative IDs.
+- C++ `metric::operators::representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
+- Python `metric.operators.representative_indices` and `representatives` expose the same traversal rule.
+- Promoted fixtures use string records with edit distance and histogram records with a one-dimensional transport callable.
 
 Candidate strategies:
 
 - medoid or k-medoids representatives
-- C++ parity for farthest-first traversal
+- additional farthest-first fixtures for process curves and mixed records
 - coverage-based representatives under a radius
 - redundancy reduction by distance threshold
 - compression summaries that preserve nearest-neighbor behavior
@@ -177,8 +178,8 @@ The revival should not:
 
 Near-term branches should stay small and evidence-driven:
 
-- add one C++ representative-selection smoke test for string records
-- add medoid or radius-coverage representative fixtures after the farthest-first helper has C++ parity
+- add process-curve and mixed-record representative fixtures
+- add medoid or radius-coverage representative fixtures after farthest-first coverage spans more record types
 - add graph construction documentation with exact versus approximate terminology
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and Python representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and Python representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -34,7 +34,8 @@ The core tests cover:
 - MGC regression values
 - entropy regression values when LAPACK is available
 - intrinsic-dimension regression values
-- promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, and entropy when LAPACK is available
+- representative-selection regression values
+- promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, representative selection, and entropy when LAPACK is available
 
 The Python core wheel path covers:
 

--- a/examples/core/CMakeLists.txt
+++ b/examples/core/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(metric_space_correlation PRIVATE ${METRIC_TARGET_NAME})
 add_executable(metric_space_intrinsic_dimension metric_space_intrinsic_dimension.cpp)
 target_link_libraries(metric_space_intrinsic_dimension PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(representative_selection_space representative_selection_space.cpp)
+target_link_libraries(representative_selection_space PRIVATE ${METRIC_TARGET_NAME})
+
 add_executable(time_series_twed_space time_series_twed_space.cpp)
 target_link_libraries(time_series_twed_space PRIVATE ${METRIC_TARGET_NAME})
 
@@ -33,6 +36,7 @@ if (BUILD_TESTING)
     endif ()
     add_test(NAME example_metric_space_correlation COMMAND metric_space_correlation)
     add_test(NAME example_metric_space_intrinsic_dimension COMMAND metric_space_intrinsic_dimension)
+    add_test(NAME example_representative_selection_space COMMAND representative_selection_space)
     add_test(NAME example_time_series_twed_space COMMAND time_series_twed_space)
     add_test(NAME example_histogram_emd_space COMMAND histogram_emd_space)
 endif ()

--- a/examples/core/representative_selection_space.cpp
+++ b/examples/core/representative_selection_space.cpp
@@ -1,0 +1,29 @@
+#include <metric/distance.hpp>
+#include <metric/operators.hpp>
+#include <metric/space.hpp>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main()
+{
+	std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
+	const auto space = metric::Space::from_records(records, metric::Edit<std::string>{});
+	const auto selected = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 3);
+	const auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
+
+	assert((selected == std::vector<std::size_t>{0, 3, 1}));
+	assert((selected_records == std::vector<std::string>{"cat", "dog", "cot"}));
+	assert(space.distance(selected[0], selected[1]) == 3);
+
+	std::cout << "representatives:";
+	for (const auto index : selected) {
+		std::cout << " " << records[index];
+	}
+	std::cout << "\n";
+	std::cout << "distance(cat, dog) = " << space.distance(selected[0], selected[1]) << "\n";
+
+	return 0;
+}

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -44,6 +45,79 @@ auto range_neighbors(const Container &records, Metric distance, const detail::re
 					 typename detail::finite_space_t<Container, Metric>::distance_type radius)
 {
 	return ::metric::Space::from_records(records, std::move(distance)).within_radius(query, radius);
+}
+
+template <typename Container, typename Metric>
+auto representative_indices(const Container &records, Metric distance, std::size_t k, std::size_t seed_index = 0)
+	-> std::vector<std::size_t>
+{
+	if (k == 0) {
+		return {};
+	}
+	if (records.empty()) {
+		throw std::invalid_argument("cannot select representatives from an empty record set");
+	}
+	if (k > records.size()) {
+		throw std::invalid_argument("k cannot exceed the number of records");
+	}
+	if (seed_index >= records.size()) {
+		throw std::out_of_range("seed_index is outside the record set");
+	}
+
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	std::vector<std::size_t> selected = {seed_index};
+	std::vector<bool> is_selected(records.size(), false);
+	is_selected[seed_index] = true;
+
+	std::vector<distance_type> nearest_selected_distances(records.size());
+	for (std::size_t index = 0; index < records.size(); ++index) {
+		nearest_selected_distances[index] = space.distance(index, seed_index);
+	}
+
+	while (selected.size() < k) {
+		std::size_t next_index = records.size();
+		distance_type next_distance{};
+		bool has_next = false;
+
+		for (std::size_t index = 0; index < nearest_selected_distances.size(); ++index) {
+			if (is_selected[index]) {
+				continue;
+			}
+			if (!has_next || nearest_selected_distances[index] > next_distance) {
+				next_index = index;
+				next_distance = nearest_selected_distances[index];
+				has_next = true;
+			}
+		}
+
+		if (!has_next) {
+			throw std::logic_error("failed to select the next representative");
+		}
+
+		selected.push_back(next_index);
+		is_selected[next_index] = true;
+		for (std::size_t index = 0; index < nearest_selected_distances.size(); ++index) {
+			nearest_selected_distances[index] =
+				std::min(nearest_selected_distances[index], space.distance(index, next_index));
+		}
+	}
+
+	return selected;
+}
+
+template <typename Container, typename Metric>
+auto representatives(const Container &records, Metric distance, std::size_t k, std::size_t seed_index = 0)
+	-> std::vector<detail::record_type_t<Container>>
+{
+	const auto selected = representative_indices(records, std::move(distance), k, seed_index);
+	std::vector<detail::record_type_t<Container>> result;
+	result.reserve(selected.size());
+	for (const auto index : selected) {
+		result.push_back(records[index]);
+	}
+	return result;
 }
 
 template <typename Container, typename Metric>

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cmath>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -49,6 +50,36 @@ int main()
     const auto operator_range =
         metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
     assert(operator_range.size() == 2);
+
+    const auto representative_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 3);
+    assert((representative_ids == std::vector<std::size_t>{0, 3, 1}));
+
+    const auto representative_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
+    assert((representative_records == std::vector<std::string>{"cat", "dog", "cot"}));
+
+    bool rejected_empty_records = false;
+    try {
+        metric::operators::representative_indices(std::vector<std::string>{}, metric::Edit<std::string>{}, 1);
+    } catch (const std::invalid_argument &) {
+        rejected_empty_records = true;
+    }
+    assert(rejected_empty_records);
+
+    bool rejected_large_k = false;
+    try {
+        metric::operators::representative_indices(records, metric::Edit<std::string>{}, records.size() + 1);
+    } catch (const std::invalid_argument &) {
+        rejected_large_k = true;
+    }
+    assert(rejected_large_k);
+
+    bool rejected_seed = false;
+    try {
+        metric::operators::representative_indices(records, metric::Edit<std::string>{}, 1, records.size());
+    } catch (const std::out_of_range &) {
+        rejected_seed = true;
+    }
+    assert(rejected_seed);
 
     const std::vector<int> line = {0, 1, 2, 3, 4};
     const double dimension = metric::operators::intrinsic_dimension(line, AbsoluteDistance{});


### PR DESCRIPTION
## Summary
- add C++ `metric::operators::representative_indices` / `representatives` with deterministic farthest-first traversal
- cover traversal order, record return, and validation in the core C++ smoke test
- add a promoted C++ representative-selection example and update API/docs/roadmap wording for C++/Python parity

## Local verification
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --preset core`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`