### PR TITLE
Add representative selection fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
+- Add deterministic Python representative-selection fixtures for time-series alignment and structured mixed records.
 
 ### Documentation and Examples
 

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -48,12 +48,11 @@ Current promoted base:
 
 - C++ `metric::operators::representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
 - Python `metric.operators.representative_indices` and `representatives` expose the same traversal rule.
-- Promoted fixtures use string records with edit distance and histogram records with a one-dimensional transport callable.
+- Promoted fixtures use string records with edit distance, histogram records with a one-dimensional transport callable, process curves with alignment distance, and structured records with mixed categorical and numeric penalties.
 
 Candidate strategies:
 
 - medoid or k-medoids representatives
-- additional farthest-first fixtures for process curves and mixed records
 - coverage-based representatives under a radius
 - redundancy reduction by distance threshold
 - compression summaries that preserve nearest-neighbor behavior
@@ -178,8 +177,7 @@ The revival should not:
 
 Near-term branches should stay small and evidence-driven:
 
-- add process-curve and mixed-record representative fixtures
-- add medoid or radius-coverage representative fixtures after farthest-first coverage spans more record types
+- add medoid or radius-coverage representative fixtures now that farthest-first coverage spans multiple record types
 - add graph construction documentation with exact versus approximate terminology
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -43,7 +43,7 @@ The Python core wheel path covers:
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
-- deterministic representative-selection regression values
+- deterministic representative-selection regression values for histogram transport, time-series alignment, and structured mixed-record callables
 - promoted Python examples for strings, structured records, time-series alignment, histogram transport, and representative selection
 - subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
 

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -222,6 +222,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertGreater(space.distance(0, 2), 10.0)
         self.assertEqual(space.neighbors(query, 2)[0][0], 0)
         self.assertAlmostEqual(pairwise_distance_matrix(records, structured_record_distance)[0][1], 0.25)
+        self.assertEqual(representative_indices(records, structured_record_distance, 3), [0, 2, 3])
+        self.assertEqual(
+            [record["id"] for record in representatives(records, structured_record_distance, 3)],
+            ["pump-a", "valve-c", "pump-d"],
+        )
         self.assertMetricContracts(records, structured_record_distance)
 
     def test_time_series_records_use_alignment_metric_callable(self):
@@ -256,6 +261,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(space.distance(0, 1), 2.0)
         self.assertEqual(space.distance(0, 2), 6.0)
         self.assertEqual(pairwise_distance_matrix(records, aligned_curve_distance)[3][2], 9.0)
+        self.assertEqual(representative_indices(records, aligned_curve_distance, 3), [0, 2, 3])
+        self.assertEqual(
+            representatives(records, aligned_curve_distance, 3),
+            [records[0], records[2], records[3]],
+        )
         self.assertGreater(intrinsic_dimension(records, aligned_curve_distance), 0.0)
         self.assertMetricContracts(records, aligned_curve_distance)
 


### PR DESCRIPTION
## Summary
- add deterministic representative-selection coverage for time-series alignment records
- add deterministic representative-selection coverage for structured mixed records
- update the research roadmap, testing scope, and changelog to reflect the expanded fixture coverage

## Local verification
- `build/python-venv/bin/python -m pip wheel ./python --no-deps -w build/representative-fixtures-wheel`
- `build/python-venv/bin/python -m pip install --force-reinstall build/representative-fixtures-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`