### PR TITLE
Document representative fixture status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -170,6 +170,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - promoted Python representative-selection example and wheel-gate coverage, merged as `78d9d4cdb065555541e10131698452c6d713a257`
 - C++ representative-selection helpers using deterministic farthest-first traversal, merged as `2aa8cfbc7cddcb642896de64cdf2d00a6031504f`
 - promoted C++ representative-selection example and CTest coverage, merged as `2aa8cfbc7cddcb642896de64cdf2d00a6031504f`
+- representative-selection fixtures for process curves and structured mixed records, merged as `dd891b7d32d5f862d1517173a9a5cd8c7d032e36`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the representative-selection process-curve and mixed-record fixture work in the revival status page
- link it to the #352 merge commit

## Local verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`