### PR TITLE
Add radius coverage representatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
+- Add C++ and Python `coverage_representative_indices` and `coverage_representatives` helpers using deterministic greedy radius coverage.
 - Add deterministic Python representative-selection fixtures for time-series alignment and structured mixed records.
 
 ### Documentation and Examples

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::range_neighbors`
 - `metric::operators::representative_indices`
 - `metric::operators::representatives`
+- `metric::operators::coverage_representative_indices`
+- `metric::operators::coverage_representatives`
 - `metric::operators::intrinsic_dimension`
 - `metric::MatrixSpace`
 - `metric::GraphSpace`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -67,12 +67,16 @@ auto nearest = metric::operators::nearest_neighbors(records, metric::Edit<std::s
 auto close = metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
+auto covered_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
+auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
+
+`coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 
 `intrinsic_dimension` returns an expansion-dimension estimate based on neighborhood growth. It is a finite-space diagnostic, not an exact manifold dimension.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -47,6 +47,8 @@ space.rnn(query, radius=1)
 
 ```python
 from metric.operators import (
+    coverage_representative_indices,
+    coverage_representatives,
     intrinsic_dimension,
     nearest_neighbors,
     pairwise_distance_matrix,
@@ -60,10 +62,14 @@ neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
 close = range_neighbors(records, Edit(), "cut", radius=1)
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
+covered_ids = coverage_representative_indices(records, Edit(), radius=1)
+covered_records = coverage_representatives(records, Edit(), radius=1)
 dimension = intrinsic_dimension(records, Edit())
 ```
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
+
+`coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 
 `intrinsic_dimension` returns an expansion-dimension estimate based on finite-space neighborhood growth. Treat it as a diagnostic that depends on the metric, sample density, duplicates, and available radii.
 

--- a/docs/examples/representative-selection.md
+++ b/docs/examples/representative-selection.md
@@ -2,9 +2,9 @@
 
 Representative selection chooses existing records from a finite metric space. This is useful when the record type does not have a meaningful vector centroid, such as strings, histograms, event sequences, or mixed structured records.
 
-The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects three string records using edit distance and deterministic farthest-first traversal.
+The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects string representatives using edit distance, deterministic farthest-first traversal, and deterministic radius coverage.
 
-The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects three histogram records using a one-dimensional transport callable and the same traversal rule.
+The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects histogram representatives using a one-dimensional transport callable and the same two strategy rules.
 
 C++ shape:
 
@@ -19,12 +19,19 @@ std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
 
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
+auto covered_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
+auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 ```
 
 Python shape:
 
 ```python
-from metric import representative_indices, representatives
+from metric import (
+    coverage_representative_indices,
+    coverage_representatives,
+    representative_indices,
+    representatives,
+)
 
 records = [
     (1.0, 0.0, 0.0, 0.0),
@@ -34,8 +41,10 @@ records = [
 
 selected_ids = representative_indices(records, cumulative_transport_distance, k=2)
 selected_records = representatives(records, cumulative_transport_distance, k=2)
+covered_ids = coverage_representative_indices(records, cumulative_transport_distance, radius=1)
+covered_records = coverage_representatives(records, cumulative_transport_distance, radius=1)
 ```
 
-The helpers start from `seed_index=0` by default, then repeatedly choose the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
+The farthest-first helpers start from `seed_index=0` by default, then repeatedly choose the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
 
-This is a coverage-oriented heuristic, not a k-medoids optimizer. It is promoted because the behavior is deterministic, documented, and covered by the core C++ and Python CI gates. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.
+The coverage helpers scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered. This is a deterministic radius-cover heuristic, not a k-medoids optimizer. The promoted behavior is documented and covered by the core C++ and Python CI gates. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -48,12 +48,12 @@ Current promoted base:
 
 - C++ `metric::operators::representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
 - Python `metric.operators.representative_indices` and `representatives` expose the same traversal rule.
+- C++ and Python `coverage_representative_indices` / `coverage_representatives` expose deterministic greedy radius coverage.
 - Promoted fixtures use string records with edit distance, histogram records with a one-dimensional transport callable, process curves with alignment distance, and structured records with mixed categorical and numeric penalties.
 
 Candidate strategies:
 
 - medoid or k-medoids representatives
-- coverage-based representatives under a radius
 - redundancy reduction by distance threshold
 - compression summaries that preserve nearest-neighbor behavior
 
@@ -177,7 +177,7 @@ The revival should not:
 
 Near-term branches should stay small and evidence-driven:
 
-- add medoid or radius-coverage representative fixtures now that farthest-first coverage spans multiple record types
+- add medoid or redundancy-threshold representative fixtures now that farthest-first and radius-coverage fixtures exist
 - add graph construction documentation with exact versus approximate terminology
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,7 +13,7 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -34,7 +34,7 @@ The core tests cover:
 - MGC regression values
 - entropy regression values when LAPACK is available
 - intrinsic-dimension regression values
-- representative-selection regression values
+- representative-selection and radius-coverage regression values
 - promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, representative selection, and entropy when LAPACK is available
 
 The Python core wheel path covers:
@@ -43,7 +43,7 @@ The Python core wheel path covers:
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
-- deterministic representative-selection regression values for histogram transport, time-series alignment, and structured mixed-record callables
+- deterministic representative-selection and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
 - promoted Python examples for strings, structured records, time-series alignment, histogram transport, and representative selection
 - subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
 

--- a/examples/core/representative_selection_space.cpp
+++ b/examples/core/representative_selection_space.cpp
@@ -13,13 +13,22 @@ int main()
 	const auto space = metric::Space::from_records(records, metric::Edit<std::string>{});
 	const auto selected = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 3);
 	const auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
+	const auto covered = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
+	const auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 
 	assert((selected == std::vector<std::size_t>{0, 3, 1}));
 	assert((selected_records == std::vector<std::string>{"cat", "dog", "cot"}));
+	assert((covered == std::vector<std::size_t>{0, 3}));
+	assert((covered_records == std::vector<std::string>{"cat", "dog"}));
 	assert(space.distance(selected[0], selected[1]) == 3);
 
 	std::cout << "representatives:";
 	for (const auto index : selected) {
+		std::cout << " " << records[index];
+	}
+	std::cout << "\n";
+	std::cout << "radius-cover representatives:";
+	for (const auto index : covered) {
 		std::cout << " " << records[index];
 	}
 	std::cout << "\n";

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -120,6 +120,62 @@ auto representatives(const Container &records, Metric distance, std::size_t k, s
 	return result;
 }
 
+template <typename Container, typename Metric, typename Radius>
+auto coverage_representative_indices(const Container &records, Metric distance, Radius radius)
+	-> std::vector<std::size_t>
+{
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+
+	if (radius < Radius{}) {
+		throw std::invalid_argument("radius must be non-negative");
+	}
+	if (records.empty()) {
+		return {};
+	}
+
+	const auto cover_radius = static_cast<distance_type>(radius);
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	std::vector<std::size_t> selected;
+	std::vector<bool> covered(records.size(), false);
+	std::size_t covered_count = 0;
+
+	while (covered_count < records.size()) {
+		auto seed_index = records.size();
+		for (std::size_t index = 0; index < covered.size(); ++index) {
+			if (!covered[index]) {
+				seed_index = index;
+				break;
+			}
+		}
+		if (seed_index == records.size()) {
+			throw std::logic_error("failed to select the next coverage representative");
+		}
+
+		selected.push_back(seed_index);
+		for (std::size_t index = 0; index < covered.size(); ++index) {
+			if (!covered[index] && space.distance(seed_index, index) <= cover_radius) {
+				covered[index] = true;
+				++covered_count;
+			}
+		}
+	}
+
+	return selected;
+}
+
+template <typename Container, typename Metric, typename Radius>
+auto coverage_representatives(const Container &records, Metric distance, Radius radius)
+	-> std::vector<detail::record_type_t<Container>>
+{
+	const auto selected = coverage_representative_indices(records, std::move(distance), radius);
+	std::vector<detail::record_type_t<Container>> result;
+	result.reserve(selected.size());
+	for (const auto index : selected) {
+		result.push_back(records[index]);
+	}
+	return result;
+}
+
 template <typename Container, typename Metric>
 auto intrinsic_dimension(const Container &records, Metric distance) -> double
 {

--- a/python/examples/metric_space/representative_selection_space.py
+++ b/python/examples/metric_space/representative_selection_space.py
@@ -1,4 +1,10 @@
-from metric import Space, representative_indices, representatives
+from metric import (
+    Space,
+    coverage_representative_indices,
+    coverage_representatives,
+    representative_indices,
+    representatives,
+)
 
 
 def cumulative_transport_distance(lhs, rhs):
@@ -28,13 +34,18 @@ def main():
     space = Space(records, cumulative_transport_distance)
     selected = representative_indices(records, cumulative_transport_distance, k=3)
     selected_records = representatives(records, cumulative_transport_distance, k=3)
+    covered = coverage_representative_indices(records, cumulative_transport_distance, radius=1.5)
+    covered_records = coverage_representatives(records, cumulative_transport_distance, radius=1.5)
 
     assert selected == [0, 2, 4]
     assert selected_records == [records[0], records[2], records[4]]
+    assert covered == [0, 2]
+    assert covered_records == [records[0], records[2]]
     assert space.distance(selected[0], selected[1]) == 3.0
 
     print("representative histograms =", ", ".join(names[index] for index in selected))
-    print("coverage seed distance =", space.distance(selected[0], selected[1]))
+    print("radius-cover histograms =", ", ".join(names[index] for index in covered))
+    print("farthest seed distance =", space.distance(selected[0], selected[1]))
 
 
 if __name__ == "__main__":

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -20,6 +20,8 @@ except ModuleNotFoundError:
 from . import mappings, metrics, operators, spaces, transforms
 from .metrics import Edit
 from .operators import (
+    coverage_representative_indices,
+    coverage_representatives,
     intrinsic_dimension,
     nearest_neighbors,
     pairwise_distance_matrix,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -79,6 +79,38 @@ def representatives(records, metric, k, seed_index=0):
     ]
 
 
+def coverage_representative_indices(records, metric, radius):
+    """Select representatives that greedily cover records within a radius."""
+    records = list(records)
+    if radius < 0:
+        raise ValueError("radius must be non-negative")
+    if not records:
+        return []
+
+    space = FiniteMetricSpace(records, metric)
+    selected = []
+    covered = [False] * len(records)
+
+    while not all(covered):
+        seed_index = next(index for index, is_covered in enumerate(covered) if not is_covered)
+        selected.append(seed_index)
+
+        for index in range(len(records)):
+            if space.distance(seed_index, index) <= radius:
+                covered[index] = True
+
+    return selected
+
+
+def coverage_representatives(records, metric, radius):
+    """Select representative records that greedily cover records within a radius."""
+    records = list(records)
+    return [
+        records[index]
+        for index in coverage_representative_indices(records, metric, radius)
+    ]
+
+
 def intrinsic_dimension(records, metric):
     """Estimate expansion dimension from finite metric-space distance growth."""
     return intrinsic_dimension_from_distances(pairwise_distance_matrix(records, metric))
@@ -101,6 +133,8 @@ def intrinsic_dimension_from_distances(distances):
 __all__ = [
     "intrinsic_dimension",
     "intrinsic_dimension_from_distances",
+    "coverage_representative_indices",
+    "coverage_representatives",
     "pairwise_distance_matrix",
     "nearest_neighbors",
     "range_neighbors",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -9,6 +9,8 @@ import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
 from metric.operators import (
+    coverage_representative_indices,
+    coverage_representatives,
     intrinsic_dimension,
     nearest_neighbors,
     pairwise_distance_matrix,
@@ -51,6 +53,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.operators.representative_indices, representative_indices)
         self.assertIs(metric.operators.representatives, representatives)
+        self.assertIs(metric.operators.coverage_representative_indices, coverage_representative_indices)
+        self.assertIs(metric.operators.coverage_representatives, coverage_representatives)
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
@@ -58,6 +62,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.range_neighbors, range_neighbors)
         self.assertIs(metric.representative_indices, representative_indices)
         self.assertIs(metric.representatives, representatives)
+        self.assertIs(metric.coverage_representative_indices, coverage_representative_indices)
+        self.assertIs(metric.coverage_representatives, coverage_representatives)
         self.assertIs(metric.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.Space, Space)
         self.assertIn("FiniteMetricSpace", metric.__all__)
@@ -66,6 +72,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("transforms", metric.__all__)
         self.assertIn("representative_indices", metric.__all__)
         self.assertIn("representatives", metric.__all__)
+        self.assertIn("coverage_representative_indices", metric.__all__)
+        self.assertIn("coverage_representatives", metric.__all__)
         self.assertEqual(mappings.STABILITY, "beta")
         self.assertEqual(transforms.STABILITY, "beta")
         self.assertIsInstance(mappings.available(), tuple)
@@ -141,9 +149,14 @@ class RevivalApiTest(unittest.TestCase):
             representatives(records, cumulative_transport_distance, 3),
             [records[0], records[2], records[4]],
         )
+        self.assertEqual(coverage_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2])
+        self.assertEqual(
+            coverage_representatives(records, cumulative_transport_distance, 1.5),
+            [records[0], records[2]],
+        )
         self.assertEqual(representative_indices(records, cumulative_transport_distance, 0), [])
 
-    def test_representative_selection_validates_inputs_and_ties(self):
+    def test_representative_selection_validates_inputs_and_deterministic_ties(self):
         records = [0, 1, 2, 10]
 
         def absolute_distance(lhs, rhs):
@@ -151,6 +164,10 @@ class RevivalApiTest(unittest.TestCase):
 
         self.assertEqual(representative_indices(records, absolute_distance, 3), [0, 3, 2])
         self.assertEqual(representative_indices(records, absolute_distance, 2, seed_index=1), [1, 3])
+        self.assertEqual(coverage_representative_indices(records, absolute_distance, 2), [0, 3])
+        self.assertEqual(coverage_representatives(records, absolute_distance, 2), [0, 10])
+        self.assertEqual(coverage_representative_indices(records, absolute_distance, 20), [0])
+        self.assertEqual(coverage_representative_indices([], absolute_distance, 1), [])
 
         with self.assertRaises(TypeError):
             representative_indices(records, absolute_distance, 1.5)
@@ -166,6 +183,8 @@ class RevivalApiTest(unittest.TestCase):
             representative_indices(records, absolute_distance, 1, seed_index=-1)
         with self.assertRaises(IndexError):
             representative_indices(records, absolute_distance, 1, seed_index=len(records))
+        with self.assertRaises(ValueError):
+            coverage_representative_indices(records, absolute_distance, -1)
 
     def test_edit_metric_satisfies_metric_contracts(self):
         self.assertMetricContracts(self.records, self.metric)
@@ -227,6 +246,11 @@ class RevivalApiTest(unittest.TestCase):
             [record["id"] for record in representatives(records, structured_record_distance, 3)],
             ["pump-a", "valve-c", "pump-d"],
         )
+        self.assertEqual(coverage_representative_indices(records, structured_record_distance, 1.5), [0, 2])
+        self.assertEqual(
+            [record["id"] for record in coverage_representatives(records, structured_record_distance, 1.5)],
+            ["pump-a", "valve-c"],
+        )
         self.assertMetricContracts(records, structured_record_distance)
 
     def test_time_series_records_use_alignment_metric_callable(self):
@@ -265,6 +289,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(
             representatives(records, aligned_curve_distance, 3),
             [records[0], records[2], records[3]],
+        )
+        self.assertEqual(coverage_representative_indices(records, aligned_curve_distance, 4.0), [0, 2])
+        self.assertEqual(
+            coverage_representatives(records, aligned_curve_distance, 4.0),
+            [records[0], records[2]],
         )
         self.assertGreater(intrinsic_dimension(records, aligned_curve_distance), 0.0)
         self.assertMetricContracts(records, aligned_curve_distance)

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -57,6 +57,20 @@ int main()
     const auto representative_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
     assert((representative_records == std::vector<std::string>{"cat", "dog", "cot"}));
 
+    const auto coverage_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
+    assert((coverage_ids == std::vector<std::size_t>{0, 3}));
+
+    const auto coverage_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
+    assert((coverage_records == std::vector<std::string>{"cat", "dog"}));
+
+    bool rejected_edit_negative_radius = false;
+    try {
+        metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, -1);
+    } catch (const std::invalid_argument &) {
+        rejected_edit_negative_radius = true;
+    }
+    assert(rejected_edit_negative_radius);
+
     bool rejected_empty_records = false;
     try {
         metric::operators::representative_indices(std::vector<std::string>{}, metric::Edit<std::string>{}, 1);
@@ -82,6 +96,18 @@ int main()
     assert(rejected_seed);
 
     const std::vector<int> line = {0, 1, 2, 3, 4};
+    assert((metric::operators::coverage_representative_indices(line, AbsoluteDistance{}, 2) ==
+            std::vector<std::size_t>{0, 3}));
+    assert((metric::operators::coverage_representatives(line, AbsoluteDistance{}, 2) == std::vector<int>{0, 3}));
+
+    bool rejected_negative_radius = false;
+    try {
+        metric::operators::coverage_representative_indices(line, AbsoluteDistance{}, -1);
+    } catch (const std::invalid_argument &) {
+        rejected_negative_radius = true;
+    }
+    assert(rejected_negative_radius);
+
     const double dimension = metric::operators::intrinsic_dimension(line, AbsoluteDistance{});
     assert(std::abs(dimension - (std::log(5.0 / 3.0) / std::log(2.0))) < 1e-12);
 


### PR DESCRIPTION
## Summary
- add C++ and Python `coverage_representative_indices` / `coverage_representatives` helpers for deterministic greedy radius coverage
- cover radius behavior in C++ smoke tests, Python core tests, and promoted representative-selection examples
- update API docs, representative-selection guide, testing scope, stability docs, roadmap, README, and changelog

## Local verification
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `build/python-venv/bin/python -m pip wheel ./python --no-deps -w build/radius-coverage-wheel`
- `build/python-venv/bin/python -m pip install --force-reinstall build/radius-coverage-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`