### PR TITLE
Document radius coverage status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -171,6 +171,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ representative-selection helpers using deterministic farthest-first traversal, merged as `2aa8cfbc7cddcb642896de64cdf2d00a6031504f`
 - promoted C++ representative-selection example and CTest coverage, merged as `2aa8cfbc7cddcb642896de64cdf2d00a6031504f`
 - representative-selection fixtures for process curves and structured mixed records, merged as `dd891b7d32d5f862d1517173a9a5cd8c7d032e36`
+- C++ and Python radius-coverage representative helpers with promoted examples and CI coverage, merged as `5eb721b1ae7004dd6643e9d74d9995c6ad0463c7`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the radius-coverage representative helpers in the revival status page
- link the status entry to the #354 merge commit

## Local verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`