### PR TITLE
Add medoid representatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
+- Add C++ and Python `medoid_index` and `medoid` helpers using deterministic minimum-total-distance selection.
 - Add C++ and Python `coverage_representative_indices` and `coverage_representatives` helpers using deterministic greedy radius coverage.
 - Add deterministic Python representative-selection fixtures for time-series alignment and structured mixed records.
 
@@ -17,6 +18,7 @@
 - Add a promoted Python histogram metric-space example using a one-dimensional transport callable on the core wheel path.
 - Add a promoted Python representative-selection example using histogram records and transport distance on the core wheel path.
 - Add a promoted C++ representative-selection example using string records and edit distance on the core CTest path.
+- Extend promoted representative-selection examples with medoid representatives.
 
 ## [0.3.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::range_neighbors`
 - `metric::operators::representative_indices`
 - `metric::operators::representatives`
+- `metric::operators::medoid_index`
+- `metric::operators::medoid`
 - `metric::operators::coverage_representative_indices`
 - `metric::operators::coverage_representatives`
 - `metric::operators::intrinsic_dimension`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -67,14 +67,18 @@ auto nearest = metric::operators::nearest_neighbors(records, metric::Edit<std::s
 auto close = metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
+auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
+auto center_record = metric::operators::medoid(records, metric::Edit<std::string>{});
 auto covered_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
 auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
+
+`medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, representative selection, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, representative selection, medoids, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -50,6 +50,8 @@ from metric.operators import (
     coverage_representative_indices,
     coverage_representatives,
     intrinsic_dimension,
+    medoid,
+    medoid_index,
     nearest_neighbors,
     pairwise_distance_matrix,
     range_neighbors,
@@ -62,12 +64,16 @@ neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
 close = range_neighbors(records, Edit(), "cut", radius=1)
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
+center_id = medoid_index(records, Edit())
+center_record = medoid(records, Edit())
 covered_ids = coverage_representative_indices(records, Edit(), radius=1)
 covered_records = coverage_representatives(records, Edit(), radius=1)
 dimension = intrinsic_dimension(records, Edit())
 ```
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
+
+`medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/examples/representative-selection.md
+++ b/docs/examples/representative-selection.md
@@ -2,9 +2,9 @@
 
 Representative selection chooses existing records from a finite metric space. This is useful when the record type does not have a meaningful vector centroid, such as strings, histograms, event sequences, or mixed structured records.
 
-The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects string representatives using edit distance, deterministic farthest-first traversal, and deterministic radius coverage.
+The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects string representatives using edit distance, deterministic farthest-first traversal, medoid selection, and deterministic radius coverage.
 
-The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects histogram representatives using a one-dimensional transport callable and the same two strategy rules.
+The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects histogram representatives using a one-dimensional transport callable and the same three strategy rules.
 
 C++ shape:
 
@@ -19,6 +19,8 @@ std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
 
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
+auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
+auto center_record = metric::operators::medoid(records, metric::Edit<std::string>{});
 auto covered_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
 auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 ```
@@ -29,6 +31,8 @@ Python shape:
 from metric import (
     coverage_representative_indices,
     coverage_representatives,
+    medoid,
+    medoid_index,
     representative_indices,
     representatives,
 )
@@ -41,10 +45,14 @@ records = [
 
 selected_ids = representative_indices(records, cumulative_transport_distance, k=2)
 selected_records = representatives(records, cumulative_transport_distance, k=2)
+center_id = medoid_index(records, cumulative_transport_distance)
+center_record = medoid(records, cumulative_transport_distance)
 covered_ids = coverage_representative_indices(records, cumulative_transport_distance, radius=1)
 covered_records = coverage_representatives(records, cumulative_transport_distance, radius=1)
 ```
 
 The farthest-first helpers start from `seed_index=0` by default, then repeatedly choose the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
 
-The coverage helpers scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered. This is a deterministic radius-cover heuristic, not a k-medoids optimizer. The promoted behavior is documented and covered by the core C++ and Python CI gates. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.
+The medoid helpers choose the existing record with the smallest total distance to every record in the finite metric space. Equal total-distance ties are resolved by record order. This is a single-medoid summary, not a k-medoids optimizer.
+
+The coverage helpers scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered. This is a deterministic radius-cover heuristic. The promoted behavior is documented and covered by the core C++ and Python CI gates. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -48,12 +48,13 @@ Current promoted base:
 
 - C++ `metric::operators::representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
 - Python `metric.operators.representative_indices` and `representatives` expose the same traversal rule.
+- C++ and Python `medoid_index` / `medoid` expose deterministic single-medoid selection by minimum total distance.
 - C++ and Python `coverage_representative_indices` / `coverage_representatives` expose deterministic greedy radius coverage.
 - Promoted fixtures use string records with edit distance, histogram records with a one-dimensional transport callable, process curves with alignment distance, and structured records with mixed categorical and numeric penalties.
 
 Candidate strategies:
 
-- medoid or k-medoids representatives
+- k-medoids representatives
 - redundancy reduction by distance threshold
 - compression summaries that preserve nearest-neighbor behavior
 
@@ -177,7 +178,7 @@ The revival should not:
 
 Near-term branches should stay small and evidence-driven:
 
-- add medoid or redundancy-threshold representative fixtures now that farthest-first and radius-coverage fixtures exist
+- add k-medoids or redundancy-threshold representative fixtures now that farthest-first, medoid, and radius-coverage fixtures exist
 - add graph construction documentation with exact versus approximate terminology
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,7 +13,7 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection, medoid, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -34,7 +34,7 @@ The core tests cover:
 - MGC regression values
 - entropy regression values when LAPACK is available
 - intrinsic-dimension regression values
-- representative-selection and radius-coverage regression values
+- representative-selection, medoid, and radius-coverage regression values
 - promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, representative selection, and entropy when LAPACK is available
 
 The Python core wheel path covers:
@@ -43,7 +43,7 @@ The Python core wheel path covers:
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
-- deterministic representative-selection and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
+- deterministic representative-selection, medoid, and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
 - promoted Python examples for strings, structured records, time-series alignment, histogram transport, and representative selection
 - subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
 

--- a/examples/core/representative_selection_space.cpp
+++ b/examples/core/representative_selection_space.cpp
@@ -13,11 +13,15 @@ int main()
 	const auto space = metric::Space::from_records(records, metric::Edit<std::string>{});
 	const auto selected = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 3);
 	const auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
+	const auto center = metric::operators::medoid_index(records, metric::Edit<std::string>{});
+	const auto center_record = metric::operators::medoid(records, metric::Edit<std::string>{});
 	const auto covered = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
 	const auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 
 	assert((selected == std::vector<std::size_t>{0, 3, 1}));
 	assert((selected_records == std::vector<std::string>{"cat", "dog", "cot"}));
+	assert(center == 1);
+	assert(center_record == "cot");
 	assert((covered == std::vector<std::size_t>{0, 3}));
 	assert((covered_records == std::vector<std::string>{"cat", "dog"}));
 	assert(space.distance(selected[0], selected[1]) == 3);
@@ -27,6 +31,7 @@ int main()
 		std::cout << " " << records[index];
 	}
 	std::cout << "\n";
+	std::cout << "medoid representative: " << records[center] << "\n";
 	std::cout << "radius-cover representatives:";
 	for (const auto index : covered) {
 		std::cout << " " << records[index];

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -120,6 +120,42 @@ auto representatives(const Container &records, Metric distance, std::size_t k, s
 	return result;
 }
 
+template <typename Container, typename Metric>
+auto medoid_index(const Container &records, Metric distance) -> std::size_t
+{
+	if (records.empty()) {
+		throw std::invalid_argument("cannot select a medoid from an empty record set");
+	}
+
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	std::size_t best_index = 0;
+	distance_type best_total_distance{};
+	bool has_best = false;
+
+	for (std::size_t candidate_index = 0; candidate_index < records.size(); ++candidate_index) {
+		distance_type total_distance{};
+		for (std::size_t other_index = 0; other_index < records.size(); ++other_index) {
+			total_distance += space.distance(candidate_index, other_index);
+		}
+
+		if (!has_best || total_distance < best_total_distance) {
+			best_index = candidate_index;
+			best_total_distance = total_distance;
+			has_best = true;
+		}
+	}
+
+	return best_index;
+}
+
+template <typename Container, typename Metric>
+auto medoid(const Container &records, Metric distance) -> detail::record_type_t<Container>
+{
+	return records[medoid_index(records, std::move(distance))];
+}
+
 template <typename Container, typename Metric, typename Radius>
 auto coverage_representative_indices(const Container &records, Metric distance, Radius radius)
 	-> std::vector<std::size_t>

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, and range-neighbor helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, representative-selection, medoid, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/examples/metric_space/representative_selection_space.py
+++ b/python/examples/metric_space/representative_selection_space.py
@@ -2,6 +2,8 @@ from metric import (
     Space,
     coverage_representative_indices,
     coverage_representatives,
+    medoid,
+    medoid_index,
     representative_indices,
     representatives,
 )
@@ -34,16 +36,21 @@ def main():
     space = Space(records, cumulative_transport_distance)
     selected = representative_indices(records, cumulative_transport_distance, k=3)
     selected_records = representatives(records, cumulative_transport_distance, k=3)
+    center = medoid_index(records, cumulative_transport_distance)
+    center_record = medoid(records, cumulative_transport_distance)
     covered = coverage_representative_indices(records, cumulative_transport_distance, radius=1.5)
     covered_records = coverage_representatives(records, cumulative_transport_distance, radius=1.5)
 
     assert selected == [0, 2, 4]
     assert selected_records == [records[0], records[2], records[4]]
+    assert center == 1
+    assert center_record == records[1]
     assert covered == [0, 2]
     assert covered_records == [records[0], records[2]]
     assert space.distance(selected[0], selected[1]) == 3.0
 
     print("representative histograms =", ", ".join(names[index] for index in selected))
+    print("medoid histogram =", names[center])
     print("radius-cover histograms =", ", ".join(names[index] for index in covered))
     print("farthest seed distance =", space.distance(selected[0], selected[1]))
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -23,6 +23,8 @@ from .operators import (
     coverage_representative_indices,
     coverage_representatives,
     intrinsic_dimension,
+    medoid,
+    medoid_index,
     nearest_neighbors,
     pairwise_distance_matrix,
     range_neighbors,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -79,6 +79,34 @@ def representatives(records, metric, k, seed_index=0):
     ]
 
 
+def medoid_index(records, metric):
+    """Select the record ID with the smallest total distance to all records."""
+    records = list(records)
+    if not records:
+        raise ValueError("cannot select a medoid from an empty record set")
+
+    space = FiniteMetricSpace(records, metric)
+    best_index = 0
+    best_total_distance = None
+
+    for candidate_index in range(len(records)):
+        total_distance = sum(
+            space.distance(candidate_index, other_index)
+            for other_index in range(len(records))
+        )
+        if best_total_distance is None or total_distance < best_total_distance:
+            best_index = candidate_index
+            best_total_distance = total_distance
+
+    return best_index
+
+
+def medoid(records, metric):
+    """Select the record with the smallest total distance to all records."""
+    records = list(records)
+    return records[medoid_index(records, metric)]
+
+
 def coverage_representative_indices(records, metric, radius):
     """Select representatives that greedily cover records within a radius."""
     records = list(records)
@@ -135,6 +163,8 @@ __all__ = [
     "intrinsic_dimension_from_distances",
     "coverage_representative_indices",
     "coverage_representatives",
+    "medoid",
+    "medoid_index",
     "pairwise_distance_matrix",
     "nearest_neighbors",
     "range_neighbors",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -12,6 +12,8 @@ from metric.operators import (
     coverage_representative_indices,
     coverage_representatives,
     intrinsic_dimension,
+    medoid,
+    medoid_index,
     nearest_neighbors,
     pairwise_distance_matrix,
     range_neighbors,
@@ -51,6 +53,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
+        self.assertIs(metric.operators.medoid_index, medoid_index)
+        self.assertIs(metric.operators.medoid, medoid)
         self.assertIs(metric.operators.representative_indices, representative_indices)
         self.assertIs(metric.operators.representatives, representatives)
         self.assertIs(metric.operators.coverage_representative_indices, coverage_representative_indices)
@@ -59,6 +63,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
+        self.assertIs(metric.medoid_index, medoid_index)
+        self.assertIs(metric.medoid, medoid)
         self.assertIs(metric.range_neighbors, range_neighbors)
         self.assertIs(metric.representative_indices, representative_indices)
         self.assertIs(metric.representatives, representatives)
@@ -70,6 +76,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("Space", metric.__all__)
         self.assertIn("mappings", metric.__all__)
         self.assertIn("transforms", metric.__all__)
+        self.assertIn("medoid_index", metric.__all__)
+        self.assertIn("medoid", metric.__all__)
         self.assertIn("representative_indices", metric.__all__)
         self.assertIn("representatives", metric.__all__)
         self.assertIn("coverage_representative_indices", metric.__all__)
@@ -149,6 +157,8 @@ class RevivalApiTest(unittest.TestCase):
             representatives(records, cumulative_transport_distance, 3),
             [records[0], records[2], records[4]],
         )
+        self.assertEqual(medoid_index(records, cumulative_transport_distance), 1)
+        self.assertEqual(medoid(records, cumulative_transport_distance), records[1])
         self.assertEqual(coverage_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2])
         self.assertEqual(
             coverage_representatives(records, cumulative_transport_distance, 1.5),
@@ -164,6 +174,8 @@ class RevivalApiTest(unittest.TestCase):
 
         self.assertEqual(representative_indices(records, absolute_distance, 3), [0, 3, 2])
         self.assertEqual(representative_indices(records, absolute_distance, 2, seed_index=1), [1, 3])
+        self.assertEqual(medoid_index(records, absolute_distance), 1)
+        self.assertEqual(medoid(records, absolute_distance), 1)
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 2), [0, 3])
         self.assertEqual(coverage_representatives(records, absolute_distance, 2), [0, 10])
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 20), [0])
@@ -179,6 +191,10 @@ class RevivalApiTest(unittest.TestCase):
             representative_indices([], absolute_distance, 1)
         with self.assertRaises(ValueError):
             representative_indices(records, absolute_distance, 5)
+        with self.assertRaises(ValueError):
+            medoid_index([], absolute_distance)
+        with self.assertRaises(ValueError):
+            medoid([], absolute_distance)
         with self.assertRaises(IndexError):
             representative_indices(records, absolute_distance, 1, seed_index=-1)
         with self.assertRaises(IndexError):

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -57,6 +57,9 @@ int main()
     const auto representative_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
     assert((representative_records == std::vector<std::string>{"cat", "dog", "cot"}));
 
+    assert(metric::operators::medoid_index(records, metric::Edit<std::string>{}) == 1);
+    assert(metric::operators::medoid(records, metric::Edit<std::string>{}) == "cot");
+
     const auto coverage_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
     assert((coverage_ids == std::vector<std::size_t>{0, 3}));
 
@@ -79,6 +82,14 @@ int main()
     }
     assert(rejected_empty_records);
 
+    bool rejected_empty_medoid = false;
+    try {
+        metric::operators::medoid_index(std::vector<std::string>{}, metric::Edit<std::string>{});
+    } catch (const std::invalid_argument &) {
+        rejected_empty_medoid = true;
+    }
+    assert(rejected_empty_medoid);
+
     bool rejected_large_k = false;
     try {
         metric::operators::representative_indices(records, metric::Edit<std::string>{}, records.size() + 1);
@@ -99,6 +110,8 @@ int main()
     assert((metric::operators::coverage_representative_indices(line, AbsoluteDistance{}, 2) ==
             std::vector<std::size_t>{0, 3}));
     assert((metric::operators::coverage_representatives(line, AbsoluteDistance{}, 2) == std::vector<int>{0, 3}));
+    assert(metric::operators::medoid_index(line, AbsoluteDistance{}) == 2);
+    assert(metric::operators::medoid(line, AbsoluteDistance{}) == 2);
 
     bool rejected_negative_radius = false;
     try {


### PR DESCRIPTION
## Summary
- add C++ and Python `medoid_index` / `medoid` helpers using minimum total distance with deterministic record-order ties
- cover the helpers in promoted C++ and Python smoke paths
- update representative-selection examples, API docs, roadmap, testing docs, and changelog

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/medoid-wheel` from `python/`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/medoid-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`