### PR TITLE
Document medoid representative status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -24,6 +24,7 @@ The current local tree implements the first revival slice:
 - intrinsic-dimension diagnostics in C++ and Python core operator helpers
 - deterministic C++ representative-selection helpers in `metric::operators`
 - deterministic Python representative-selection helpers in `metric.operators`
+- deterministic C++ and Python medoid representative helpers
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -172,6 +173,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - promoted C++ representative-selection example and CTest coverage, merged as `2aa8cfbc7cddcb642896de64cdf2d00a6031504f`
 - representative-selection fixtures for process curves and structured mixed records, merged as `dd891b7d32d5f862d1517173a9a5cd8c7d032e36`
 - C++ and Python radius-coverage representative helpers with promoted examples and CI coverage, merged as `5eb721b1ae7004dd6643e9d74d9995c6ad0463c7`
+- C++ and Python medoid representative helpers with promoted examples and CI coverage, merged as `3022a8485b1df5f8322437bc5d6d9998305082ca`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the newly merged medoid representative helpers in the revival status page
- include the #356 merge commit as post-v0.3.2 progress

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`