### PR TITLE
Add separated representatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
 - Add C++ and Python `medoid_index` and `medoid` helpers using deterministic minimum-total-distance selection.
+- Add C++ and Python `separated_representative_indices` and `separated_representatives` helpers using deterministic redundancy-threshold selection.
 - Add C++ and Python `coverage_representative_indices` and `coverage_representatives` helpers using deterministic greedy radius coverage.
 - Add deterministic Python representative-selection fixtures for time-series alignment and structured mixed records.
 
@@ -19,6 +20,7 @@
 - Add a promoted Python representative-selection example using histogram records and transport distance on the core wheel path.
 - Add a promoted C++ representative-selection example using string records and edit distance on the core CTest path.
 - Extend promoted representative-selection examples with medoid representatives.
+- Extend promoted representative-selection examples with separated representatives.
 
 ## [0.3.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::representatives`
 - `metric::operators::medoid_index`
 - `metric::operators::medoid`
+- `metric::operators::separated_representative_indices`
+- `metric::operators::separated_representatives`
 - `metric::operators::coverage_representative_indices`
 - `metric::operators::coverage_representatives`
 - `metric::operators::intrinsic_dimension`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -69,16 +69,20 @@ auto selected_ids = metric::operators::representative_indices(records, metric::E
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
 auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
 auto center_record = metric::operators::medoid(records, metric::Edit<std::string>{});
+auto separated_ids = metric::operators::separated_representative_indices(records, metric::Edit<std::string>{}, 2);
+auto separated_records = metric::operators::separated_representatives(records, metric::Edit<std::string>{}, 2);
 auto covered_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
 auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
+
+`separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, representative selection, medoids, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -57,6 +57,8 @@ from metric.operators import (
     range_neighbors,
     representative_indices,
     representatives,
+    separated_representative_indices,
+    separated_representatives,
 )
 
 distances = pairwise_distance_matrix(records, Edit())
@@ -66,6 +68,8 @@ selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
 center_id = medoid_index(records, Edit())
 center_record = medoid(records, Edit())
+separated_ids = separated_representative_indices(records, Edit(), minimum_distance=2)
+separated_records = separated_representatives(records, Edit(), minimum_distance=2)
 covered_ids = coverage_representative_indices(records, Edit(), radius=1)
 covered_records = coverage_representatives(records, Edit(), radius=1)
 dimension = intrinsic_dimension(records, Edit())
@@ -74,6 +78,8 @@ dimension = intrinsic_dimension(records, Edit())
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
+
+`separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/examples/representative-selection.md
+++ b/docs/examples/representative-selection.md
@@ -2,9 +2,9 @@
 
 Representative selection chooses existing records from a finite metric space. This is useful when the record type does not have a meaningful vector centroid, such as strings, histograms, event sequences, or mixed structured records.
 
-The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects string representatives using edit distance, deterministic farthest-first traversal, medoid selection, and deterministic radius coverage.
+The promoted C++ example [representative_selection_space.cpp](../../examples/core/representative_selection_space.cpp) selects string representatives using edit distance, deterministic farthest-first traversal, medoid selection, separated representatives, and deterministic radius coverage.
 
-The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects histogram representatives using a one-dimensional transport callable and the same three strategy rules.
+The promoted Python example [representative_selection_space.py](../../python/examples/metric_space/representative_selection_space.py) selects histogram representatives using a one-dimensional transport callable and the same four strategy rules.
 
 C++ shape:
 
@@ -21,6 +21,8 @@ auto selected_ids = metric::operators::representative_indices(records, metric::E
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
 auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
 auto center_record = metric::operators::medoid(records, metric::Edit<std::string>{});
+auto separated_ids = metric::operators::separated_representative_indices(records, metric::Edit<std::string>{}, 2);
+auto separated_records = metric::operators::separated_representatives(records, metric::Edit<std::string>{}, 2);
 auto covered_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
 auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 ```
@@ -35,6 +37,8 @@ from metric import (
     medoid_index,
     representative_indices,
     representatives,
+    separated_representative_indices,
+    separated_representatives,
 )
 
 records = [
@@ -47,6 +51,8 @@ selected_ids = representative_indices(records, cumulative_transport_distance, k=
 selected_records = representatives(records, cumulative_transport_distance, k=2)
 center_id = medoid_index(records, cumulative_transport_distance)
 center_record = medoid(records, cumulative_transport_distance)
+separated_ids = separated_representative_indices(records, cumulative_transport_distance, minimum_distance=1.5)
+separated_records = separated_representatives(records, cumulative_transport_distance, minimum_distance=1.5)
 covered_ids = coverage_representative_indices(records, cumulative_transport_distance, radius=1)
 covered_records = coverage_representatives(records, cumulative_transport_distance, radius=1)
 ```
@@ -54,5 +60,7 @@ covered_records = coverage_representatives(records, cumulative_transport_distanc
 The farthest-first helpers start from `seed_index=0` by default, then repeatedly choose the unselected record whose nearest selected representative is farthest away. Equal-distance ties are resolved by record order, so small fixtures can use exact expected representative IDs.
 
 The medoid helpers choose the existing record with the smallest total distance to every record in the finite metric space. Equal total-distance ties are resolved by record order. This is a single-medoid summary, not a k-medoids optimizer.
+
+The separated-representative helpers scan records in order and keep a candidate when it is at least `minimum_distance` from every already selected representative. This is a deterministic redundancy-threshold heuristic; it returns a maximal separated subset for that input order, not an optimal packing proof.
 
 The coverage helpers scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered. This is a deterministic radius-cover heuristic. The promoted behavior is documented and covered by the core C++ and Python CI gates. Additional strategies should be promoted only after they have their own fixtures, result contracts, and release notes.

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -49,13 +49,13 @@ Current promoted base:
 - C++ `metric::operators::representative_indices` and `representatives` expose deterministic farthest-first traversal over finite metric spaces.
 - Python `metric.operators.representative_indices` and `representatives` expose the same traversal rule.
 - C++ and Python `medoid_index` / `medoid` expose deterministic single-medoid selection by minimum total distance.
+- C++ and Python `separated_representative_indices` / `separated_representatives` expose deterministic redundancy-threshold selection by minimum distance.
 - C++ and Python `coverage_representative_indices` / `coverage_representatives` expose deterministic greedy radius coverage.
 - Promoted fixtures use string records with edit distance, histogram records with a one-dimensional transport callable, process curves with alignment distance, and structured records with mixed categorical and numeric penalties.
 
 Candidate strategies:
 
 - k-medoids representatives
-- redundancy reduction by distance threshold
 - compression summaries that preserve nearest-neighbor behavior
 
 Required fixtures:
@@ -178,7 +178,7 @@ The revival should not:
 
 Near-term branches should stay small and evidence-driven:
 
-- add k-medoids or redundancy-threshold representative fixtures now that farthest-first, medoid, and radius-coverage fixtures exist
+- add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
 - add graph construction documentation with exact versus approximate terminology
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,7 +13,7 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection, medoid, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -34,7 +34,7 @@ The core tests cover:
 - MGC regression values
 - entropy regression values when LAPACK is available
 - intrinsic-dimension regression values
-- representative-selection, medoid, and radius-coverage regression values
+- representative-selection, medoid, separated-representative, and radius-coverage regression values
 - promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, representative selection, and entropy when LAPACK is available
 
 The Python core wheel path covers:
@@ -43,7 +43,7 @@ The Python core wheel path covers:
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
-- deterministic representative-selection, medoid, and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
+- deterministic representative-selection, medoid, separated-representative, and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
 - promoted Python examples for strings, structured records, time-series alignment, histogram transport, and representative selection
 - subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
 

--- a/examples/core/representative_selection_space.cpp
+++ b/examples/core/representative_selection_space.cpp
@@ -15,6 +15,8 @@ int main()
 	const auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 3);
 	const auto center = metric::operators::medoid_index(records, metric::Edit<std::string>{});
 	const auto center_record = metric::operators::medoid(records, metric::Edit<std::string>{});
+	const auto separated = metric::operators::separated_representative_indices(records, metric::Edit<std::string>{}, 2);
+	const auto separated_records = metric::operators::separated_representatives(records, metric::Edit<std::string>{}, 2);
 	const auto covered = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
 	const auto covered_records = metric::operators::coverage_representatives(records, metric::Edit<std::string>{}, 1);
 
@@ -22,6 +24,8 @@ int main()
 	assert((selected_records == std::vector<std::string>{"cat", "dog", "cot"}));
 	assert(center == 1);
 	assert(center_record == "cot");
+	assert((separated == std::vector<std::size_t>{0, 3}));
+	assert((separated_records == std::vector<std::string>{"cat", "dog"}));
 	assert((covered == std::vector<std::size_t>{0, 3}));
 	assert((covered_records == std::vector<std::string>{"cat", "dog"}));
 	assert(space.distance(selected[0], selected[1]) == 3);
@@ -32,6 +36,11 @@ int main()
 	}
 	std::cout << "\n";
 	std::cout << "medoid representative: " << records[center] << "\n";
+	std::cout << "separated representatives:";
+	for (const auto index : separated) {
+		std::cout << " " << records[index];
+	}
+	std::cout << "\n";
 	std::cout << "radius-cover representatives:";
 	for (const auto index : covered) {
 		std::cout << " " << records[index];

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -156,6 +156,53 @@ auto medoid(const Container &records, Metric distance) -> detail::record_type_t<
 	return records[medoid_index(records, std::move(distance))];
 }
 
+template <typename Container, typename Metric, typename MinimumDistance>
+auto separated_representative_indices(const Container &records, Metric distance, MinimumDistance minimum_distance)
+	-> std::vector<std::size_t>
+{
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+	using comparison_type = typename std::common_type<distance_type, MinimumDistance>::type;
+
+	if (minimum_distance < MinimumDistance{}) {
+		throw std::invalid_argument("minimum_distance must be non-negative");
+	}
+	if (records.empty()) {
+		return {};
+	}
+
+	const auto threshold = static_cast<comparison_type>(minimum_distance);
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	std::vector<std::size_t> selected;
+
+	for (std::size_t candidate_index = 0; candidate_index < records.size(); ++candidate_index) {
+		bool is_separated = true;
+		for (const auto selected_index : selected) {
+			if (static_cast<comparison_type>(space.distance(candidate_index, selected_index)) < threshold) {
+				is_separated = false;
+				break;
+			}
+		}
+		if (is_separated) {
+			selected.push_back(candidate_index);
+		}
+	}
+
+	return selected;
+}
+
+template <typename Container, typename Metric, typename MinimumDistance>
+auto separated_representatives(const Container &records, Metric distance, MinimumDistance minimum_distance)
+	-> std::vector<detail::record_type_t<Container>>
+{
+	const auto selected = separated_representative_indices(records, std::move(distance), minimum_distance);
+	std::vector<detail::record_type_t<Container>> result;
+	result.reserve(selected.size());
+	for (const auto index : selected) {
+		result.push_back(records[index]);
+	}
+	return result;
+}
+
 template <typename Container, typename Metric, typename Radius>
 auto coverage_representative_indices(const Container &records, Metric distance, Radius radius)
 	-> std::vector<std::size_t>

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, representative-selection, medoid, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/examples/metric_space/representative_selection_space.py
+++ b/python/examples/metric_space/representative_selection_space.py
@@ -6,6 +6,8 @@ from metric import (
     medoid_index,
     representative_indices,
     representatives,
+    separated_representative_indices,
+    separated_representatives,
 )
 
 
@@ -38,6 +40,8 @@ def main():
     selected_records = representatives(records, cumulative_transport_distance, k=3)
     center = medoid_index(records, cumulative_transport_distance)
     center_record = medoid(records, cumulative_transport_distance)
+    separated = separated_representative_indices(records, cumulative_transport_distance, minimum_distance=1.5)
+    separated_records = separated_representatives(records, cumulative_transport_distance, minimum_distance=1.5)
     covered = coverage_representative_indices(records, cumulative_transport_distance, radius=1.5)
     covered_records = coverage_representatives(records, cumulative_transport_distance, radius=1.5)
 
@@ -45,12 +49,15 @@ def main():
     assert selected_records == [records[0], records[2], records[4]]
     assert center == 1
     assert center_record == records[1]
+    assert separated == [0, 2, 4]
+    assert separated_records == [records[0], records[2], records[4]]
     assert covered == [0, 2]
     assert covered_records == [records[0], records[2]]
     assert space.distance(selected[0], selected[1]) == 3.0
 
     print("representative histograms =", ", ".join(names[index] for index in selected))
     print("medoid histogram =", names[center])
+    print("separated histograms =", ", ".join(names[index] for index in separated))
     print("radius-cover histograms =", ", ".join(names[index] for index in covered))
     print("farthest seed distance =", space.distance(selected[0], selected[1]))
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -30,6 +30,8 @@ from .operators import (
     range_neighbors,
     representative_indices,
     representatives,
+    separated_representative_indices,
+    separated_representatives,
 )
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
 

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -107,6 +107,36 @@ def medoid(records, metric):
     return records[medoid_index(records, metric)]
 
 
+def separated_representative_indices(records, metric, minimum_distance):
+    """Select representatives greedily separated by a minimum distance."""
+    records = list(records)
+    if minimum_distance < 0:
+        raise ValueError("minimum_distance must be non-negative")
+    if not records:
+        return []
+
+    space = FiniteMetricSpace(records, metric)
+    selected = []
+
+    for candidate_index in range(len(records)):
+        if all(
+            space.distance(candidate_index, selected_index) >= minimum_distance
+            for selected_index in selected
+        ):
+            selected.append(candidate_index)
+
+    return selected
+
+
+def separated_representatives(records, metric, minimum_distance):
+    """Select representative records greedily separated by a minimum distance."""
+    records = list(records)
+    return [
+        records[index]
+        for index in separated_representative_indices(records, metric, minimum_distance)
+    ]
+
+
 def coverage_representative_indices(records, metric, radius):
     """Select representatives that greedily cover records within a radius."""
     records = list(records)
@@ -170,4 +200,6 @@ __all__ = [
     "range_neighbors",
     "representative_indices",
     "representatives",
+    "separated_representative_indices",
+    "separated_representatives",
 ]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -19,6 +19,8 @@ from metric.operators import (
     range_neighbors,
     representative_indices,
     representatives,
+    separated_representative_indices,
+    separated_representatives,
 )
 from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
 
@@ -57,6 +59,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.medoid, medoid)
         self.assertIs(metric.operators.representative_indices, representative_indices)
         self.assertIs(metric.operators.representatives, representatives)
+        self.assertIs(metric.operators.separated_representative_indices, separated_representative_indices)
+        self.assertIs(metric.operators.separated_representatives, separated_representatives)
         self.assertIs(metric.operators.coverage_representative_indices, coverage_representative_indices)
         self.assertIs(metric.operators.coverage_representatives, coverage_representatives)
         self.assertIs(metric.mappings, mappings)
@@ -68,6 +72,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.range_neighbors, range_neighbors)
         self.assertIs(metric.representative_indices, representative_indices)
         self.assertIs(metric.representatives, representatives)
+        self.assertIs(metric.separated_representative_indices, separated_representative_indices)
+        self.assertIs(metric.separated_representatives, separated_representatives)
         self.assertIs(metric.coverage_representative_indices, coverage_representative_indices)
         self.assertIs(metric.coverage_representatives, coverage_representatives)
         self.assertIs(metric.FiniteMetricSpace, FiniteMetricSpace)
@@ -80,6 +86,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("medoid", metric.__all__)
         self.assertIn("representative_indices", metric.__all__)
         self.assertIn("representatives", metric.__all__)
+        self.assertIn("separated_representative_indices", metric.__all__)
+        self.assertIn("separated_representatives", metric.__all__)
         self.assertIn("coverage_representative_indices", metric.__all__)
         self.assertIn("coverage_representatives", metric.__all__)
         self.assertEqual(mappings.STABILITY, "beta")
@@ -159,6 +167,11 @@ class RevivalApiTest(unittest.TestCase):
         )
         self.assertEqual(medoid_index(records, cumulative_transport_distance), 1)
         self.assertEqual(medoid(records, cumulative_transport_distance), records[1])
+        self.assertEqual(separated_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2, 4])
+        self.assertEqual(
+            separated_representatives(records, cumulative_transport_distance, 1.5),
+            [records[0], records[2], records[4]],
+        )
         self.assertEqual(coverage_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2])
         self.assertEqual(
             coverage_representatives(records, cumulative_transport_distance, 1.5),
@@ -176,6 +189,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(representative_indices(records, absolute_distance, 2, seed_index=1), [1, 3])
         self.assertEqual(medoid_index(records, absolute_distance), 1)
         self.assertEqual(medoid(records, absolute_distance), 1)
+        self.assertEqual(separated_representative_indices(records, absolute_distance, 2), [0, 2, 3])
+        self.assertEqual(separated_representatives(records, absolute_distance, 2), [0, 2, 10])
+        self.assertEqual(separated_representative_indices([], absolute_distance, 2), [])
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 2), [0, 3])
         self.assertEqual(coverage_representatives(records, absolute_distance, 2), [0, 10])
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 20), [0])
@@ -195,6 +211,8 @@ class RevivalApiTest(unittest.TestCase):
             medoid_index([], absolute_distance)
         with self.assertRaises(ValueError):
             medoid([], absolute_distance)
+        with self.assertRaises(ValueError):
+            separated_representative_indices(records, absolute_distance, -1)
         with self.assertRaises(IndexError):
             representative_indices(records, absolute_distance, 1, seed_index=-1)
         with self.assertRaises(IndexError):
@@ -262,6 +280,11 @@ class RevivalApiTest(unittest.TestCase):
             [record["id"] for record in representatives(records, structured_record_distance, 3)],
             ["pump-a", "valve-c", "pump-d"],
         )
+        self.assertEqual(separated_representative_indices(records, structured_record_distance, 2.0), [0, 2])
+        self.assertEqual(
+            [record["id"] for record in separated_representatives(records, structured_record_distance, 2.0)],
+            ["pump-a", "valve-c"],
+        )
         self.assertEqual(coverage_representative_indices(records, structured_record_distance, 1.5), [0, 2])
         self.assertEqual(
             [record["id"] for record in coverage_representatives(records, structured_record_distance, 1.5)],
@@ -304,6 +327,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(representative_indices(records, aligned_curve_distance, 3), [0, 2, 3])
         self.assertEqual(
             representatives(records, aligned_curve_distance, 3),
+            [records[0], records[2], records[3]],
+        )
+        self.assertEqual(separated_representative_indices(records, aligned_curve_distance, 4.0), [0, 2, 3])
+        self.assertEqual(
+            separated_representatives(records, aligned_curve_distance, 4.0),
             [records[0], records[2], records[3]],
         )
         self.assertEqual(coverage_representative_indices(records, aligned_curve_distance, 4.0), [0, 2])

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -60,6 +60,14 @@ int main()
     assert(metric::operators::medoid_index(records, metric::Edit<std::string>{}) == 1);
     assert(metric::operators::medoid(records, metric::Edit<std::string>{}) == "cot");
 
+    const auto separated_ids =
+        metric::operators::separated_representative_indices(records, metric::Edit<std::string>{}, 2);
+    assert((separated_ids == std::vector<std::size_t>{0, 3}));
+
+    const auto separated_records =
+        metric::operators::separated_representatives(records, metric::Edit<std::string>{}, 2);
+    assert((separated_records == std::vector<std::string>{"cat", "dog"}));
+
     const auto coverage_ids = metric::operators::coverage_representative_indices(records, metric::Edit<std::string>{}, 1);
     assert((coverage_ids == std::vector<std::size_t>{0, 3}));
 
@@ -112,6 +120,9 @@ int main()
     assert((metric::operators::coverage_representatives(line, AbsoluteDistance{}, 2) == std::vector<int>{0, 3}));
     assert(metric::operators::medoid_index(line, AbsoluteDistance{}) == 2);
     assert(metric::operators::medoid(line, AbsoluteDistance{}) == 2);
+    assert((metric::operators::separated_representative_indices(line, AbsoluteDistance{}, 2) ==
+            std::vector<std::size_t>{0, 2, 4}));
+    assert((metric::operators::separated_representatives(line, AbsoluteDistance{}, 2) == std::vector<int>{0, 2, 4}));
 
     bool rejected_negative_radius = false;
     try {
@@ -120,6 +131,14 @@ int main()
         rejected_negative_radius = true;
     }
     assert(rejected_negative_radius);
+
+    bool rejected_negative_minimum_distance = false;
+    try {
+        metric::operators::separated_representative_indices(line, AbsoluteDistance{}, -1);
+    } catch (const std::invalid_argument &) {
+        rejected_negative_minimum_distance = true;
+    }
+    assert(rejected_negative_minimum_distance);
 
     const double dimension = metric::operators::intrinsic_dimension(line, AbsoluteDistance{});
     assert(std::abs(dimension - (std::log(5.0 / 3.0) / std::log(2.0))) < 1e-12);


### PR DESCRIPTION
## Summary
- add C++ and Python `separated_representative_indices` / `separated_representatives` helpers for deterministic minimum-distance representative selection
- cover the new helpers in C++ smoke tests and Python core fixtures for histograms, structured records, and time-series records
- update promoted examples, API docs, stability/testing docs, research roadmap, README, and changelog

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/separated-wheel` from `python/`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/separated-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`