### PR TITLE
Document graph construction terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add a promoted C++ representative-selection example using string records and edit distance on the core CTest path.
 - Extend promoted representative-selection examples with medoid representatives.
 - Extend promoted representative-selection examples with separated representatives.
+- Add graph representation terminology for exact, approximate, directed, symmetrized, weighted, and normalized graph construction.
 
 ## [0.3.2] - 2026-06-19
 

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -112,6 +112,8 @@ The core can materialize explicit representations when a workflow needs control 
 
 `metric::MatrixSpace` stores the full pairwise matrix. `metric::GraphSpace` stores a sparse nearest-neighbor graph. `metric::TreeSpace` provides tree-based neighbor access.
 
+Graph construction terminology for exact, approximate, directed, symmetrized, weighted, and normalized graphs is documented in [Graph Representation Terminology](../concepts/graph-representations.md).
+
 ## Engine Roadmap
 
 The implemented C++ facade currently covers finite-space construction, neighbor access through `metric::Space::from_records` and `neighbors`, and free operator helpers for pairwise distances and neighbor queries. Additional intent names such as `groups`, `embed`, `map`, `reduce`, `denoise`, `outliers`, and `compare` describe the public direction and should be promoted only when they are backed by stable strategies, result objects, examples, and CI.

--- a/docs/concepts/explicit-representations.md
+++ b/docs/concepts/explicit-representations.md
@@ -20,7 +20,7 @@ Use it when the dataset is small to medium sized, the metric is expensive enough
 
 `metric::GraphSpace` stores local neighbor structure. It is useful when sparse local geometry drives the workflow.
 
-Graph representations document whether edges are exact, approximate, directed, symmetrized, weighted, or normalized.
+Graph representations document whether edges are exact, approximate, directed, symmetrized, weighted, or normalized. The promoted terminology is defined in [Graph Representation Terminology](graph-representations.md).
 
 ## Tree
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -1,0 +1,79 @@
+# Graph Representation Terminology
+
+Graph representations are derived structures over a finite metric space. They keep local metric-space relationships sparse, but they do not replace the metric that defined the space.
+
+This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
+
+## Required Metadata
+
+Every promoted graph-construction result should state:
+
+- source record IDs
+- metric used to compute edge evidence
+- construction rule, such as k-nearest neighbors or radius threshold
+- whether the edge set is exact or approximate
+- whether edges are directed, undirected, or symmetrized
+- whether edge payloads are metric distances, affinities, booleans, or normalized weights
+- tie-breaking rule for equal distances
+- deterministic seed or stochastic build policy when approximation is used
+
+Without this metadata, a graph is an expert representation, not a promoted result contract.
+
+## Exact kNN Graph
+
+An exact k-nearest-neighbor graph has one outgoing neighbor set per source record. For each record, the selected neighbors are the `k` nearest other records under the metric, after applying a documented tie-breaking rule.
+
+Exactness must be supported by exhaustive pairwise distances, a proved exact algorithm, or deterministic tests that compare against dense pairwise distances on small fixtures.
+
+kNN graphs are naturally directed. If record `a` includes record `b` among its nearest neighbors, `b` does not necessarily include `a`.
+
+## Approximate kNN Graph
+
+An approximate k-nearest-neighbor graph is built from a heuristic, randomized search, pruned candidate set, external ANN backend, or iterative refinement process.
+
+Approximate graphs must not be documented as exact unless their edge sets are verified against the dense pairwise result for the relevant fixture. They should report construction parameters, deterministic seeds when present, and recall or consistency diagnostics when those diagnostics are available.
+
+`metric::KNNGraph` is a compatibility and expert API for approximate kNN graph construction. New promoted examples should state when they are using it as an approximate graph representation.
+
+## Radius Graph
+
+A radius graph connects records whose metric distance is within a threshold.
+
+An exact directed radius graph has edge `i -> j` when `distance(i, j) <= radius`, subject to a documented self-loop policy. An exact undirected radius graph uses the same threshold but stores one undirected relationship for each qualifying pair.
+
+A radius graph is approximate when it is built from candidate pruning, approximate neighbors, or any method that may miss qualifying pairs.
+
+## Direction And Symmetrization
+
+Directed graphs preserve the construction rule exactly as emitted.
+
+Undirected or symmetrized graphs must document their policy:
+
+- `union`: keep an undirected edge when either directed edge exists
+- `mutual`: keep an undirected edge only when both directed edges exist
+- `weighted merge`: combine both directed weights with a named reducer such as minimum, maximum, or average
+
+The policy changes graph connectivity and degree distributions, so it is part of the result contract.
+
+## Weights And Normalization
+
+Graph edge payloads must state what they mean:
+
+- metric distance: raw distance from the source metric
+- affinity: a transformed similarity, often from a kernel
+- boolean adjacency: edge existence only
+- normalized weight: row-normalized, degree-normalized, Laplacian-normalized, or another named normalization
+
+Normalized weights are not raw metric distances. They should carry the normalization policy and any scale parameters.
+
+## Promotion Requirements
+
+Graph construction moves from expert representation to promoted operator only when it has:
+
+- deterministic fixtures with expected edge sets
+- comparison against dense pairwise distances for exact modes
+- documented approximate behavior and diagnostics for approximate modes
+- examples that name direction, weighting, symmetrization, and normalization policies
+- release-gate tests in the C++ or Python core path
+
+Until those requirements are met, graph APIs remain available as explicit representations and compatibility surfaces rather than first-page graph-construction promises.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,11 +24,12 @@ This docs tree is the canonical home for concepts, API references, engine archit
 3. Read [Engine Overview](engine/index.md) to understand the engine model.
 4. Read [Metric Spaces](concepts/metric-space.md) and [Finite Metric Spaces](concepts/finite-metric-space.md).
 5. Read [Explicit Representations](concepts/explicit-representations.md) to understand matrix, graph, and tree execution forms.
-6. Use the [Python API](api/python.md) or [C++ API](api/cpp.md) for implementation.
-7. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
-8. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
-9. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
-10. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
+6. Read [Graph Representation Terminology](concepts/graph-representations.md) before promoting sparse graph construction.
+7. Use the [Python API](api/python.md) or [C++ API](api/cpp.md) for implementation.
+8. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
+9. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
+10. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
+11. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
 
 ## Concepts
 
@@ -38,6 +39,7 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Metrics as Recoding Costs](concepts/metrics-as-recoding-costs.md)
 - [Vector Space as a Special Case](concepts/vector-space-as-special-case.md)
 - [Explicit Representations](concepts/explicit-representations.md)
+- [Graph Representation Terminology](concepts/graph-representations.md)
 
 ## Examples
 

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -75,6 +75,10 @@ Promotion evidence:
 
 Goal: make graph representations a first-class runtime choice for finite metric spaces.
 
+Current promoted base:
+
+- Graph construction terminology documents exact versus approximate graph construction, directed versus symmetrized edges, edge payload meanings, normalization policies, and promotion requirements.
+
 Candidate strategies:
 
 - exact k-nearest-neighbor graph construction
@@ -179,6 +183,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph construction documentation with exact versus approximate terminology
+- add deterministic graph fixtures with expected edge sets
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties


### PR DESCRIPTION
## Summary
- add a graph representation terminology concept page covering exact versus approximate construction, direction, symmetrization, weights, normalization, and promotion requirements
- link the page from the docs index, explicit representations guide, and C++ API docs
- update the research roadmap and changelog to reflect this documentation baseline

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`