### PR TITLE
Document graph terminology status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -26,6 +26,7 @@ The current local tree implements the first revival slice:
 - deterministic Python representative-selection helpers in `metric.operators`
 - deterministic C++ and Python medoid representative helpers
 - deterministic C++ and Python separated-representative helpers
+- graph representation terminology for exact, approximate, directed, symmetrized, weighted, and normalized graph construction
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -176,6 +177,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ and Python radius-coverage representative helpers with promoted examples and CI coverage, merged as `5eb721b1ae7004dd6643e9d74d9995c6ad0463c7`
 - C++ and Python medoid representative helpers with promoted examples and CI coverage, merged as `3022a8485b1df5f8322437bc5d6d9998305082ca`
 - C++ and Python separated-representative helpers with promoted examples and CI coverage, merged as `5cfae5fdbb7159aa04c51dfe85734fd295d0f7b9`
+- graph representation terminology for exact and approximate graph construction, merged as `5b002c216a437c44c47b252b429268d13b679951`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the newly merged graph representation terminology page in the revival status page
- include the #360 merge commit as post-v0.3.2 progress

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`