### PR TITLE
Add exact graph edge fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Algorithm Changes
 
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
+- Add C++ and Python `exact_knn_graph_edges` and `exact_radius_graph_edges` helpers using exhaustive pairwise distances and deterministic edge ordering.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
 - Add C++ and Python `medoid_index` and `medoid` helpers using deterministic minimum-total-distance selection.
@@ -22,6 +23,7 @@
 - Extend promoted representative-selection examples with medoid representatives.
 - Extend promoted representative-selection examples with separated representatives.
 - Add graph representation terminology for exact, approximate, directed, symmetrized, weighted, and normalized graph construction.
+- Add exact graph edge fixture documentation for k-nearest-neighbor and radius edge lists.
 
 ## [0.3.2] - 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::pairwise_distance_matrix`
 - `metric::operators::nearest_neighbors`
 - `metric::operators::range_neighbors`
+- `metric::operators::exact_knn_graph_edges`
+- `metric::operators::exact_radius_graph_edges`
 - `metric::operators::representative_indices`
 - `metric::operators::representatives`
 - `metric::operators::medoid_index`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -65,6 +65,8 @@ std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
 auto distances = metric::operators::pairwise_distance_matrix(records, metric::Edit<std::string>{});
 auto nearest = metric::operators::nearest_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 2);
 auto close = metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
+auto knn_edges = metric::operators::exact_knn_graph_edges(records, metric::Edit<std::string>{}, 1);
+auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
 auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
@@ -76,13 +78,15 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph_edges`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
 
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
+
+`exact_knn_graph_edges` and `exact_radius_graph_edges` return directed edge tuples shaped as `(source_index, target_index, distance)`. They exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph edges, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -49,6 +49,8 @@ space.rnn(query, radius=1)
 from metric.operators import (
     coverage_representative_indices,
     coverage_representatives,
+    exact_knn_graph_edges,
+    exact_radius_graph_edges,
     intrinsic_dimension,
     medoid,
     medoid_index,
@@ -64,6 +66,8 @@ from metric.operators import (
 distances = pairwise_distance_matrix(records, Edit())
 neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
 close = range_neighbors(records, Edit(), "cut", radius=1)
+knn_edges = exact_knn_graph_edges(records, Edit(), k=1)
+radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
 center_id = medoid_index(records, Edit())
@@ -80,6 +84,8 @@ dimension = intrinsic_dimension(records, Edit())
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
 
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
+
+`exact_knn_graph_edges` and `exact_radius_graph_edges` return directed edge tuples shaped as `(source_index, target_index, distance)`. They exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,6 +4,8 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
+The promoted core edge-list helpers are `exact_knn_graph_edges` and `exact_radius_graph_edges`. They return directed `(source_index, target_index, distance)` edges, exclude self-loops, and are tested against deterministic fixtures. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Higher-level graph result objects, symmetrization policies, and normalized weights remain roadmap items.
+
 ## Required Metadata
 
 Every promoted graph-construction result should state:
@@ -23,6 +25,8 @@ Without this metadata, a graph is an expert representation, not a promoted resul
 
 An exact k-nearest-neighbor graph has one outgoing neighbor set per source record. For each record, the selected neighbors are the `k` nearest other records under the metric, after applying a documented tie-breaking rule.
 
+`exact_knn_graph_edges` uses exhaustive pairwise distances, excludes self-loops, preserves source-record order, and resolves equal distances by target record order.
+
 Exactness must be supported by exhaustive pairwise distances, a proved exact algorithm, or deterministic tests that compare against dense pairwise distances on small fixtures.
 
 kNN graphs are naturally directed. If record `a` includes record `b` among its nearest neighbors, `b` does not necessarily include `a`.
@@ -38,6 +42,8 @@ Approximate graphs must not be documented as exact unless their edge sets are ve
 ## Radius Graph
 
 A radius graph connects records whose metric distance is within a threshold.
+
+`exact_radius_graph_edges` uses exhaustive pairwise distances, excludes self-loops, preserves source-record order, and emits every directed edge whose distance is within `radius`.
 
 An exact directed radius graph has edge `i -> j` when `distance(i, j) <= radius`, subject to a documented self-loop policy. An exact undirected radius graph uses the same threshold but stores one undirected relationship for each qualifying pair.
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -1,0 +1,55 @@
+# Exact Graph Edge Fixtures
+
+Exact graph helpers emit directed edge lists over a finite metric space. They are small fixtures for validating graph construction semantics before higher-level graph result objects are promoted.
+
+The edge tuple shape is `(source_index, target_index, distance)`. Self-loops are excluded. kNN ties are resolved by target record order.
+
+C++ shape:
+
+```cpp
+#include <metric/operators.hpp>
+
+#include <cstdlib>
+#include <vector>
+
+struct AbsoluteDistance {
+    auto operator()(int lhs, int rhs) const -> int
+    {
+        return std::abs(lhs - rhs);
+    }
+};
+
+std::vector<int> records = {0, 1, 2, 3, 4};
+
+auto knn_edges = metric::operators::exact_knn_graph_edges(records, AbsoluteDistance{}, 2);
+auto radius_edges = metric::operators::exact_radius_graph_edges(records, AbsoluteDistance{}, 1);
+```
+
+Python shape:
+
+```python
+from metric import exact_knn_graph_edges, exact_radius_graph_edges
+
+records = [0, 1, 2, 3, 4]
+
+def absolute_distance(lhs, rhs):
+    return abs(lhs - rhs)
+
+knn_edges = exact_knn_graph_edges(records, absolute_distance, k=2)
+radius_edges = exact_radius_graph_edges(records, absolute_distance, radius=1)
+```
+
+For `records = [0, 1, 2, 3, 4]`, the exact radius graph with radius `1` has directed edges:
+
+```text
+(0, 1, 1)
+(1, 0, 1)
+(1, 2, 1)
+(2, 1, 1)
+(2, 3, 1)
+(3, 2, 1)
+(3, 4, 1)
+(4, 3, 1)
+```
+
+These helpers are exact because they evaluate the pairwise distances needed for every source record. `metric::KNNGraph` remains an approximate compatibility representation and should not be used as evidence for exact graph construction unless its edge set is compared against dense pairwise distances for the fixture.

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Structured Data](examples/structured-data.md)
 - [Time-Series Space With TWED](examples/time-series-twed.md)
 - [Histogram Space With EMD](examples/histogram-emd.md)
+- [Exact Graph Edge Fixtures](examples/graph-construction.md)
 - [Representative Selection](examples/representative-selection.md)
 - [Entropy Diagnostics](examples/entropy-diagnostics.md)
 - [Intrinsic Dimension Diagnostic](examples/intrinsic-dimension.md)

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -78,11 +78,11 @@ Goal: make graph representations a first-class runtime choice for finite metric 
 Current promoted base:
 
 - Graph construction terminology documents exact versus approximate graph construction, directed versus symmetrized edges, edge payload meanings, normalization policies, and promotion requirements.
+- C++ and Python `exact_knn_graph_edges` / `exact_radius_graph_edges` expose deterministic directed edge-list fixtures backed by exhaustive pairwise distances.
 
 Candidate strategies:
 
-- exact k-nearest-neighbor graph construction
-- radius graph construction
+- graph result objects that carry construction metadata
 - symmetrization and weighting policies
 - sparsification primitives with documented assumptions
 - graph diagnostics such as connectivity, degree distribution, and edge stretch
@@ -183,6 +183,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add deterministic graph fixtures with expected edge sets
+- add graph result objects with construction metadata
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph_edges`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -34,6 +34,7 @@ The core tests cover:
 - MGC regression values
 - entropy regression values when LAPACK is available
 - intrinsic-dimension regression values
+- exact graph edge fixtures for k-nearest-neighbor and radius construction
 - representative-selection, medoid, separated-representative, and radius-coverage regression values
 - promoted examples for strings, custom metrics, explicit representations, TWED, EMD, MGC, intrinsic dimension, representative selection, and entropy when LAPACK is available
 
@@ -43,6 +44,7 @@ The Python core wheel path covers:
 - `Space`, `FiniteMetricSpace`, and operator helper behavior
 - metric contract checks for built-in edit distance, NumPy record callables, structured record callables, time-series alignment callables, and histogram transport callables
 - intrinsic-dimension regression values
+- exact graph edge fixtures for k-nearest-neighbor and radius construction
 - deterministic representative-selection, medoid, separated-representative, and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
 - promoted Python examples for strings, structured records, time-series alignment, histogram transport, and representative selection
 - subprocess execution of every `python/examples/metric_space/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <type_traits>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -45,6 +46,89 @@ auto range_neighbors(const Container &records, Metric distance, const detail::re
 					 typename detail::finite_space_t<Container, Metric>::distance_type radius)
 {
 	return ::metric::Space::from_records(records, std::move(distance)).within_radius(query, radius);
+}
+
+template <typename Container, typename Metric>
+auto exact_knn_graph_edges(const Container &records, Metric distance, std::size_t k)
+	-> std::vector<
+		std::tuple<std::size_t, std::size_t, typename detail::finite_space_t<Container, Metric>::distance_type>>
+{
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+	using edge_type = std::tuple<std::size_t, std::size_t, distance_type>;
+
+	if (k == 0) {
+		return {};
+	}
+
+	const auto max_neighbors = records.empty() ? std::size_t{0} : records.size() - 1;
+	if (k > max_neighbors) {
+		throw std::invalid_argument("k cannot exceed the number of non-self neighbors");
+	}
+
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	std::vector<edge_type> edges;
+	edges.reserve(records.size() * k);
+
+	for (std::size_t source_index = 0; source_index < records.size(); ++source_index) {
+		std::vector<std::pair<distance_type, std::size_t>> candidates;
+		candidates.reserve(records.size() - 1);
+
+		for (std::size_t target_index = 0; target_index < records.size(); ++target_index) {
+			if (source_index == target_index) {
+				continue;
+			}
+			candidates.emplace_back(space.distance(source_index, target_index), target_index);
+		}
+
+		std::sort(candidates.begin(), candidates.end(),
+				  [](const auto &lhs, const auto &rhs) {
+					  if (lhs.first < rhs.first) {
+						  return true;
+					  }
+					  if (rhs.first < lhs.first) {
+						  return false;
+					  }
+					  return lhs.second < rhs.second;
+				  });
+
+		for (std::size_t neighbor_index = 0; neighbor_index < k; ++neighbor_index) {
+			edges.emplace_back(source_index, candidates[neighbor_index].second, candidates[neighbor_index].first);
+		}
+	}
+
+	return edges;
+}
+
+template <typename Container, typename Metric, typename Radius>
+auto exact_radius_graph_edges(const Container &records, Metric distance, Radius radius)
+	-> std::vector<
+		std::tuple<std::size_t, std::size_t, typename detail::finite_space_t<Container, Metric>::distance_type>>
+{
+	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
+	using comparison_type = typename std::common_type<distance_type, Radius>::type;
+	using edge_type = std::tuple<std::size_t, std::size_t, distance_type>;
+
+	if (radius < Radius{}) {
+		throw std::invalid_argument("radius must be non-negative");
+	}
+
+	const auto threshold = static_cast<comparison_type>(radius);
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	std::vector<edge_type> edges;
+
+	for (std::size_t source_index = 0; source_index < records.size(); ++source_index) {
+		for (std::size_t target_index = 0; target_index < records.size(); ++target_index) {
+			if (source_index == target_index) {
+				continue;
+			}
+			const auto edge_distance = space.distance(source_index, target_index);
+			if (static_cast<comparison_type>(edge_distance) <= threshold) {
+				edges.emplace_back(source_index, target_index, edge_distance);
+			}
+		}
+	}
+
+	return edges;
 }
 
 template <typename Container, typename Metric>

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -22,6 +22,8 @@ from .metrics import Edit
 from .operators import (
     coverage_representative_indices,
     coverage_representatives,
+    exact_knn_graph_edges,
+    exact_radius_graph_edges,
     intrinsic_dimension,
     medoid,
     medoid_index,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -18,6 +18,63 @@ def range_neighbors(records, metric, query, radius):
     return FiniteMetricSpace(records, metric).rnn(query, radius)
 
 
+def exact_knn_graph_edges(records, metric, k):
+    """Build exact directed kNN graph edges as source, target, distance tuples."""
+    records = list(records)
+    try:
+        k = operator.index(k)
+    except TypeError:
+        raise TypeError("k must be an integer") from None
+
+    if k < 0:
+        raise ValueError("k must be non-negative")
+    if k == 0:
+        return []
+
+    max_neighbors = max(0, len(records) - 1)
+    if k > max_neighbors:
+        raise ValueError("k cannot exceed the number of non-self neighbors")
+
+    space = FiniteMetricSpace(records, metric)
+    edges = []
+
+    for source_index in range(len(records)):
+        candidates = []
+        for target_index in range(len(records)):
+            if source_index == target_index:
+                continue
+            candidates.append((
+                space.distance(source_index, target_index),
+                target_index,
+            ))
+
+        candidates.sort()
+        for distance, target_index in candidates[:k]:
+            edges.append((source_index, target_index, distance))
+
+    return edges
+
+
+def exact_radius_graph_edges(records, metric, radius):
+    """Build exact directed radius graph edges as source, target, distance tuples."""
+    records = list(records)
+    if radius < 0:
+        raise ValueError("radius must be non-negative")
+
+    space = FiniteMetricSpace(records, metric)
+    edges = []
+
+    for source_index in range(len(records)):
+        for target_index in range(len(records)):
+            if source_index == target_index:
+                continue
+            distance = space.distance(source_index, target_index)
+            if distance <= radius:
+                edges.append((source_index, target_index, distance))
+
+    return edges
+
+
 def representative_indices(records, metric, k, seed_index=0):
     """Select representative record IDs with deterministic farthest-first traversal."""
     records = list(records)
@@ -193,6 +250,8 @@ __all__ = [
     "intrinsic_dimension_from_distances",
     "coverage_representative_indices",
     "coverage_representatives",
+    "exact_knn_graph_edges",
+    "exact_radius_graph_edges",
     "medoid",
     "medoid_index",
     "pairwise_distance_matrix",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -11,6 +11,8 @@ from metric import mappings, transforms
 from metric.operators import (
     coverage_representative_indices,
     coverage_representatives,
+    exact_knn_graph_edges,
+    exact_radius_graph_edges,
     intrinsic_dimension,
     medoid,
     medoid_index,
@@ -54,6 +56,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.spaces.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
+        self.assertIs(metric.operators.exact_knn_graph_edges, exact_knn_graph_edges)
+        self.assertIs(metric.operators.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.operators.medoid_index, medoid_index)
         self.assertIs(metric.operators.medoid, medoid)
@@ -66,6 +70,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
+        self.assertIs(metric.exact_knn_graph_edges, exact_knn_graph_edges)
+        self.assertIs(metric.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.medoid_index, medoid_index)
         self.assertIs(metric.medoid, medoid)
@@ -82,6 +88,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("Space", metric.__all__)
         self.assertIn("mappings", metric.__all__)
         self.assertIn("transforms", metric.__all__)
+        self.assertIn("exact_knn_graph_edges", metric.__all__)
+        self.assertIn("exact_radius_graph_edges", metric.__all__)
         self.assertIn("medoid_index", metric.__all__)
         self.assertIn("medoid", metric.__all__)
         self.assertIn("representative_indices", metric.__all__)
@@ -172,6 +180,14 @@ class RevivalApiTest(unittest.TestCase):
             separated_representatives(records, cumulative_transport_distance, 1.5),
             [records[0], records[2], records[4]],
         )
+        self.assertEqual(
+            exact_knn_graph_edges(records, cumulative_transport_distance, 1),
+            [(0, 3, 0.5), (1, 3, 0.5), (2, 4, 1.5), (3, 0, 0.5), (4, 1, 0.5)],
+        )
+        self.assertEqual(
+            exact_radius_graph_edges(records, cumulative_transport_distance, 0.5),
+            [(0, 3, 0.5), (1, 3, 0.5), (1, 4, 0.5), (3, 0, 0.5), (3, 1, 0.5), (4, 1, 0.5)],
+        )
         self.assertEqual(coverage_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2])
         self.assertEqual(
             coverage_representatives(records, cumulative_transport_distance, 1.5),
@@ -192,6 +208,24 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(separated_representative_indices(records, absolute_distance, 2), [0, 2, 3])
         self.assertEqual(separated_representatives(records, absolute_distance, 2), [0, 2, 10])
         self.assertEqual(separated_representative_indices([], absolute_distance, 2), [])
+        self.assertEqual(
+            exact_knn_graph_edges(records, absolute_distance, 2),
+            [
+                (0, 1, 1),
+                (0, 2, 2),
+                (1, 0, 1),
+                (1, 2, 1),
+                (2, 1, 1),
+                (2, 0, 2),
+                (3, 2, 8),
+                (3, 1, 9),
+            ],
+        )
+        self.assertEqual(
+            exact_radius_graph_edges(records, absolute_distance, 2),
+            [(0, 1, 1), (0, 2, 2), (1, 0, 1), (1, 2, 1), (2, 0, 2), (2, 1, 1)],
+        )
+        self.assertEqual(exact_knn_graph_edges(records, absolute_distance, 0), [])
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 2), [0, 3])
         self.assertEqual(coverage_representatives(records, absolute_distance, 2), [0, 10])
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 20), [0])
@@ -213,6 +247,12 @@ class RevivalApiTest(unittest.TestCase):
             medoid([], absolute_distance)
         with self.assertRaises(ValueError):
             separated_representative_indices(records, absolute_distance, -1)
+        with self.assertRaises(ValueError):
+            exact_knn_graph_edges(records, absolute_distance, 4)
+        with self.assertRaises(TypeError):
+            exact_knn_graph_edges(records, absolute_distance, 1.5)
+        with self.assertRaises(ValueError):
+            exact_radius_graph_edges(records, absolute_distance, -1)
         with self.assertRaises(IndexError):
             representative_indices(records, absolute_distance, 1, seed_index=-1)
         with self.assertRaises(IndexError):

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "metric/distance.hpp"
@@ -124,6 +125,42 @@ int main()
             std::vector<std::size_t>{0, 2, 4}));
     assert((metric::operators::separated_representatives(line, AbsoluteDistance{}, 2) == std::vector<int>{0, 2, 4}));
 
+    const auto exact_knn_edges = metric::operators::exact_knn_graph_edges(line, AbsoluteDistance{}, 2);
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_knn_edges = {
+        {0, 1, 1},
+        {0, 2, 2},
+        {1, 0, 1},
+        {1, 2, 1},
+        {2, 1, 1},
+        {2, 3, 1},
+        {3, 2, 1},
+        {3, 4, 1},
+        {4, 3, 1},
+        {4, 2, 2},
+    };
+    assert(exact_knn_edges == expected_knn_edges);
+
+    const auto exact_radius_edges = metric::operators::exact_radius_graph_edges(line, AbsoluteDistance{}, 1);
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_radius_edges = {
+        {0, 1, 1},
+        {1, 0, 1},
+        {1, 2, 1},
+        {2, 1, 1},
+        {2, 3, 1},
+        {3, 2, 1},
+        {3, 4, 1},
+        {4, 3, 1},
+    };
+    assert(exact_radius_edges == expected_radius_edges);
+
+    bool rejected_large_graph_k = false;
+    try {
+        metric::operators::exact_knn_graph_edges(line, AbsoluteDistance{}, line.size());
+    } catch (const std::invalid_argument &) {
+        rejected_large_graph_k = true;
+    }
+    assert(rejected_large_graph_k);
+
     bool rejected_negative_radius = false;
     try {
         metric::operators::coverage_representative_indices(line, AbsoluteDistance{}, -1);
@@ -131,6 +168,14 @@ int main()
         rejected_negative_radius = true;
     }
     assert(rejected_negative_radius);
+
+    bool rejected_negative_graph_radius = false;
+    try {
+        metric::operators::exact_radius_graph_edges(line, AbsoluteDistance{}, -1);
+    } catch (const std::invalid_argument &) {
+        rejected_negative_graph_radius = true;
+    }
+    assert(rejected_negative_graph_radius);
 
     bool rejected_negative_minimum_distance = false;
     try {


### PR DESCRIPTION
## Summary
- add C++ and Python `exact_knn_graph_edges` / `exact_radius_graph_edges` helpers that emit deterministic directed edge lists from exhaustive pairwise distances
- cover exact kNN and radius edge fixtures in C++ core smoke tests and Python core tests, including histogram transport fixtures
- update graph terminology docs, API docs, testing/stability docs, roadmap, README, and changelog

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/exact-graph-wheel` from `python/`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/exact-graph-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`