### PR TITLE
Add graph construction result metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add C++ and Python `exact_knn_graph_edges` and `exact_radius_graph_edges` helpers using exhaustive pairwise distances and deterministic edge ordering.
+- Add C++ and Python `exact_knn_graph` and `exact_radius_graph` result objects with construction metadata for exact graph helpers.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
 - Add C++ and Python `medoid_index` and `medoid` helpers using deterministic minimum-total-distance selection.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::pairwise_distance_matrix`
 - `metric::operators::nearest_neighbors`
 - `metric::operators::range_neighbors`
+- `metric::operators::GraphConstructionResult`
+- `metric::operators::GraphConstructionMetadata`
+- `metric::operators::exact_knn_graph`
 - `metric::operators::exact_knn_graph_edges`
+- `metric::operators::exact_radius_graph`
 - `metric::operators::exact_radius_graph_edges`
 - `metric::operators::representative_indices`
 - `metric::operators::representatives`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -65,7 +65,9 @@ std::vector<std::string> records = {"cat", "cot", "coat", "dog"};
 auto distances = metric::operators::pairwise_distance_matrix(records, metric::Edit<std::string>{});
 auto nearest = metric::operators::nearest_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 2);
 auto close = metric::operators::range_neighbors(records, metric::Edit<std::string>{}, std::string("cut"), 1);
+auto knn_graph = metric::operators::exact_knn_graph(records, metric::Edit<std::string>{}, 1);
 auto knn_edges = metric::operators::exact_knn_graph_edges(records, metric::Edit<std::string>{}, 1);
+auto radius_graph = metric::operators::exact_radius_graph(records, metric::Edit<std::string>{}, 1);
 auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
@@ -78,7 +80,7 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph_edges`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -86,7 +88,7 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
-`exact_knn_graph_edges` and `exact_radius_graph_edges` return directed edge tuples shaped as `(source_index, target_index, distance)`. They exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+`exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` values with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph edges, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -47,9 +47,13 @@ space.rnn(query, radius=1)
 
 ```python
 from metric.operators import (
+    GraphConstructionMetadata,
+    GraphConstructionResult,
     coverage_representative_indices,
     coverage_representatives,
+    exact_knn_graph,
     exact_knn_graph_edges,
+    exact_radius_graph,
     exact_radius_graph_edges,
     intrinsic_dimension,
     medoid,
@@ -66,7 +70,9 @@ from metric.operators import (
 distances = pairwise_distance_matrix(records, Edit())
 neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
 close = range_neighbors(records, Edit(), "cut", radius=1)
+knn_graph = exact_knn_graph(records, Edit(), k=1)
 knn_edges = exact_knn_graph_edges(records, Edit(), k=1)
+radius_graph = exact_radius_graph(records, Edit(), radius=1)
 radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
@@ -85,7 +91,7 @@ dimension = intrinsic_dimension(records, Edit())
 
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
-`exact_knn_graph_edges` and `exact_radius_graph_edges` return directed edge tuples shaped as `(source_index, target_index, distance)`. They exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+`exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` objects with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,7 +4,7 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
-The promoted core edge-list helpers are `exact_knn_graph_edges` and `exact_radius_graph_edges`. They return directed `(source_index, target_index, distance)` edges, exclude self-loops, and are tested against deterministic fixtures. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Higher-level graph result objects, symmetrization policies, and normalized weights remain roadmap items.
+The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. All four helpers exclude self-loops and are tested against deterministic fixtures. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Symmetrization policies and normalized weights remain roadmap items.
 
 ## Required Metadata
 
@@ -25,7 +25,7 @@ Without this metadata, a graph is an expert representation, not a promoted resul
 
 An exact k-nearest-neighbor graph has one outgoing neighbor set per source record. For each record, the selected neighbors are the `k` nearest other records under the metric, after applying a documented tie-breaking rule.
 
-`exact_knn_graph_edges` uses exhaustive pairwise distances, excludes self-loops, preserves source-record order, and resolves equal distances by target record order.
+`exact_knn_graph` and `exact_knn_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and resolve equal distances by target record order. The result metadata records strategy `exact_knn`, the record count, edge count, exact/directed policy, `k`, metric-distance payloads, no symmetrization, no normalization, and the tie-breaking rule.
 
 Exactness must be supported by exhaustive pairwise distances, a proved exact algorithm, or deterministic tests that compare against dense pairwise distances on small fixtures.
 
@@ -43,7 +43,7 @@ Approximate graphs must not be documented as exact unless their edge sets are ve
 
 A radius graph connects records whose metric distance is within a threshold.
 
-`exact_radius_graph_edges` uses exhaustive pairwise distances, excludes self-loops, preserves source-record order, and emits every directed edge whose distance is within `radius`.
+`exact_radius_graph` and `exact_radius_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and emit every directed edge whose distance is within `radius`. The result metadata records strategy `exact_radius`, the record count, edge count, exact/directed policy, `radius`, metric-distance payloads, no symmetrization, no normalization, and the source/target scan rule.
 
 An exact directed radius graph has edge `i -> j` when `distance(i, j) <= radius`, subject to a documented self-loop policy. An exact undirected radius graph uses the same threshold but stores one undirected relationship for each qualifying pair.
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -1,6 +1,6 @@
 # Exact Graph Edge Fixtures
 
-Exact graph helpers emit directed edge lists over a finite metric space. They are small fixtures for validating graph construction semantics before higher-level graph result objects are promoted.
+Exact graph helpers emit directed graph-construction results over a finite metric space. The result form carries directed edge tuples plus metadata for validating graph construction semantics before symmetrization or weighting policies are promoted.
 
 The edge tuple shape is `(source_index, target_index, distance)`. Self-loops are excluded. kNN ties are resolved by target record order.
 
@@ -21,23 +21,31 @@ struct AbsoluteDistance {
 
 std::vector<int> records = {0, 1, 2, 3, 4};
 
-auto knn_edges = metric::operators::exact_knn_graph_edges(records, AbsoluteDistance{}, 2);
-auto radius_edges = metric::operators::exact_radius_graph_edges(records, AbsoluteDistance{}, 1);
+auto knn_graph = metric::operators::exact_knn_graph(records, AbsoluteDistance{}, 2);
+auto radius_graph = metric::operators::exact_radius_graph(records, AbsoluteDistance{}, 1);
+
+auto knn_edges = knn_graph.edges;
+auto radius_edges = radius_graph.edges;
 ```
 
 Python shape:
 
 ```python
-from metric import exact_knn_graph_edges, exact_radius_graph_edges
+from metric import exact_knn_graph, exact_radius_graph
 
 records = [0, 1, 2, 3, 4]
 
 def absolute_distance(lhs, rhs):
     return abs(lhs - rhs)
 
-knn_edges = exact_knn_graph_edges(records, absolute_distance, k=2)
-radius_edges = exact_radius_graph_edges(records, absolute_distance, radius=1)
+knn_graph = exact_knn_graph(records, absolute_distance, k=2)
+radius_graph = exact_radius_graph(records, absolute_distance, radius=1)
+
+knn_edges = knn_graph.edges
+radius_edges = radius_graph.edges
 ```
+
+`knn_graph.metadata` records strategy `exact_knn`, `record_count`, `edge_count`, `directed=True`, `self_loops=False`, `exact=True`, `k`, `edge_payload="metric_distance"`, `symmetrization="none"`, `normalization="none"`, and the tie-breaking rule. `radius_graph.metadata` records the same policy fields with `radius` instead of `k`.
 
 For `records = [0, 1, 2, 3, 4]`, the exact radius graph with radius `1` has directed edges:
 
@@ -52,4 +60,4 @@ For `records = [0, 1, 2, 3, 4]`, the exact radius graph with radius `1` has dire
 (4, 3, 1)
 ```
 
-These helpers are exact because they evaluate the pairwise distances needed for every source record. `metric::KNNGraph` remains an approximate compatibility representation and should not be used as evidence for exact graph construction unless its edge set is compared against dense pairwise distances for the fixture.
+These helpers are exact because they evaluate the pairwise distances needed for every source record. The `*_edges` helpers remain available for callers that only need edge tuples. `metric::KNNGraph` remains an approximate compatibility representation and should not be used as evidence for exact graph construction unless its edge set is compared against dense pairwise distances for the fixture.

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -79,10 +79,10 @@ Current promoted base:
 
 - Graph construction terminology documents exact versus approximate graph construction, directed versus symmetrized edges, edge payload meanings, normalization policies, and promotion requirements.
 - C++ and Python `exact_knn_graph_edges` / `exact_radius_graph_edges` expose deterministic directed edge-list fixtures backed by exhaustive pairwise distances.
+- C++ and Python `exact_knn_graph` / `exact_radius_graph` return graph construction result objects with directed edge lists and construction metadata.
 
 Candidate strategies:
 
-- graph result objects that carry construction metadata
 - symmetrization and weighting policies
 - sparsification primitives with documented assumptions
 - graph diagnostics such as connectivity, degree distribution, and edge stretch
@@ -183,6 +183,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph result objects with construction metadata
+- add graph symmetrization and weighting policies
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph_edges`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -10,7 +10,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <optional>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <tuple>
 #include <utility>
@@ -26,6 +28,30 @@ template <typename Container, typename Metric>
 using finite_space_t = ::metric::FiniteSpace<record_type_t<Container>, Metric>;
 
 } // namespace detail
+
+template <typename Distance, typename RadiusValue = Distance> struct GraphConstructionMetadata {
+	std::string strategy;
+	std::size_t record_count{};
+	std::size_t edge_count{};
+	bool directed{true};
+	bool self_loops{false};
+	bool exact{true};
+	std::optional<std::size_t> k;
+	std::optional<RadiusValue> radius;
+	std::string edge_payload;
+	std::string symmetrization;
+	std::string normalization;
+	std::string tie_break;
+};
+
+template <typename Distance, typename RadiusValue = Distance> struct GraphConstructionResult {
+	using distance_type = Distance;
+	using radius_type = RadiusValue;
+	using edge_type = std::tuple<std::size_t, std::size_t, Distance>;
+
+	std::vector<edge_type> edges;
+	GraphConstructionMetadata<Distance, RadiusValue> metadata;
+};
 
 template <typename Container, typename Metric>
 auto pairwise_distance_matrix(const Container &records, Metric distance)
@@ -49,15 +75,25 @@ auto range_neighbors(const Container &records, Metric distance, const detail::re
 }
 
 template <typename Container, typename Metric>
-auto exact_knn_graph_edges(const Container &records, Metric distance, std::size_t k)
-	-> std::vector<
-		std::tuple<std::size_t, std::size_t, typename detail::finite_space_t<Container, Metric>::distance_type>>
+auto exact_knn_graph(const Container &records, Metric distance, std::size_t k)
+	-> GraphConstructionResult<typename detail::finite_space_t<Container, Metric>::distance_type>
 {
 	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
-	using edge_type = std::tuple<std::size_t, std::size_t, distance_type>;
+
+	GraphConstructionResult<distance_type> result;
+	result.metadata.strategy = "exact_knn";
+	result.metadata.record_count = records.size();
+	result.metadata.directed = true;
+	result.metadata.self_loops = false;
+	result.metadata.exact = true;
+	result.metadata.k = k;
+	result.metadata.edge_payload = "metric_distance";
+	result.metadata.symmetrization = "none";
+	result.metadata.normalization = "none";
+	result.metadata.tie_break = "distance_then_target_index";
 
 	if (k == 0) {
-		return {};
+		return result;
 	}
 
 	const auto max_neighbors = records.empty() ? std::size_t{0} : records.size() - 1;
@@ -66,8 +102,7 @@ auto exact_knn_graph_edges(const Container &records, Metric distance, std::size_
 	}
 
 	const auto space = ::metric::Space::from_records(records, std::move(distance));
-	std::vector<edge_type> edges;
-	edges.reserve(records.size() * k);
+	result.edges.reserve(records.size() * k);
 
 	for (std::size_t source_index = 0; source_index < records.size(); ++source_index) {
 		std::vector<std::pair<distance_type, std::size_t>> candidates;
@@ -92,29 +127,49 @@ auto exact_knn_graph_edges(const Container &records, Metric distance, std::size_
 				  });
 
 		for (std::size_t neighbor_index = 0; neighbor_index < k; ++neighbor_index) {
-			edges.emplace_back(source_index, candidates[neighbor_index].second, candidates[neighbor_index].first);
+			result.edges.emplace_back(source_index, candidates[neighbor_index].second, candidates[neighbor_index].first);
 		}
 	}
 
-	return edges;
+	result.metadata.edge_count = result.edges.size();
+	return result;
 }
 
-template <typename Container, typename Metric, typename Radius>
-auto exact_radius_graph_edges(const Container &records, Metric distance, Radius radius)
+template <typename Container, typename Metric>
+auto exact_knn_graph_edges(const Container &records, Metric distance, std::size_t k)
 	-> std::vector<
 		std::tuple<std::size_t, std::size_t, typename detail::finite_space_t<Container, Metric>::distance_type>>
 {
+	return exact_knn_graph(records, std::move(distance), k).edges;
+}
+
+template <typename Container, typename Metric, typename Radius>
+auto exact_radius_graph(const Container &records, Metric distance, Radius radius)
+	-> GraphConstructionResult<typename detail::finite_space_t<Container, Metric>::distance_type,
+							   typename std::common_type<
+								   typename detail::finite_space_t<Container, Metric>::distance_type, Radius>::type>
+{
 	using distance_type = typename detail::finite_space_t<Container, Metric>::distance_type;
 	using comparison_type = typename std::common_type<distance_type, Radius>::type;
-	using edge_type = std::tuple<std::size_t, std::size_t, distance_type>;
 
 	if (radius < Radius{}) {
 		throw std::invalid_argument("radius must be non-negative");
 	}
 
+	GraphConstructionResult<distance_type, comparison_type> result;
+	result.metadata.strategy = "exact_radius";
+	result.metadata.record_count = records.size();
+	result.metadata.directed = true;
+	result.metadata.self_loops = false;
+	result.metadata.exact = true;
+	result.metadata.radius = static_cast<comparison_type>(radius);
+	result.metadata.edge_payload = "metric_distance";
+	result.metadata.symmetrization = "none";
+	result.metadata.normalization = "none";
+	result.metadata.tie_break = "source_then_target_index";
+
 	const auto threshold = static_cast<comparison_type>(radius);
 	const auto space = ::metric::Space::from_records(records, std::move(distance));
-	std::vector<edge_type> edges;
 
 	for (std::size_t source_index = 0; source_index < records.size(); ++source_index) {
 		for (std::size_t target_index = 0; target_index < records.size(); ++target_index) {
@@ -123,12 +178,21 @@ auto exact_radius_graph_edges(const Container &records, Metric distance, Radius 
 			}
 			const auto edge_distance = space.distance(source_index, target_index);
 			if (static_cast<comparison_type>(edge_distance) <= threshold) {
-				edges.emplace_back(source_index, target_index, edge_distance);
+				result.edges.emplace_back(source_index, target_index, edge_distance);
 			}
 		}
 	}
 
-	return edges;
+	result.metadata.edge_count = result.edges.size();
+	return result;
+}
+
+template <typename Container, typename Metric, typename Radius>
+auto exact_radius_graph_edges(const Container &records, Metric distance, Radius radius)
+	-> std::vector<
+		std::tuple<std::size_t, std::size_t, typename detail::finite_space_t<Container, Metric>::distance_type>>
+{
+	return exact_radius_graph(records, std::move(distance), radius).edges;
 }
 
 template <typename Container, typename Metric>

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -20,9 +20,13 @@ except ModuleNotFoundError:
 from . import mappings, metrics, operators, spaces, transforms
 from .metrics import Edit
 from .operators import (
+    GraphConstructionMetadata,
+    GraphConstructionResult,
     coverage_representative_indices,
     coverage_representatives,
+    exact_knn_graph,
     exact_knn_graph_edges,
+    exact_radius_graph,
     exact_radius_graph_edges,
     intrinsic_dimension,
     medoid,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1,9 +1,36 @@
 """Small metric-space operators covered by the core Python smoke path."""
 
+from dataclasses import dataclass
 import math
 import operator
 
 from metric.spaces import FiniteMetricSpace
+
+
+@dataclass(frozen=True)
+class GraphConstructionMetadata:
+    """Metadata for a promoted graph-construction result."""
+
+    strategy: str
+    record_count: int
+    edge_count: int
+    directed: bool
+    self_loops: bool
+    exact: bool
+    k: object = None
+    radius: object = None
+    edge_payload: str = ""
+    symmetrization: str = ""
+    normalization: str = ""
+    tie_break: str = ""
+
+
+@dataclass(frozen=True)
+class GraphConstructionResult:
+    """Graph construction result with directed edge tuples and metadata."""
+
+    edges: tuple
+    metadata: GraphConstructionMetadata
 
 
 def pairwise_distance_matrix(records, metric):
@@ -18,22 +45,27 @@ def range_neighbors(records, metric, query, radius):
     return FiniteMetricSpace(records, metric).rnn(query, radius)
 
 
-def exact_knn_graph_edges(records, metric, k):
-    """Build exact directed kNN graph edges as source, target, distance tuples."""
-    records = list(records)
+def _coerce_graph_k(k):
     try:
-        k = operator.index(k)
+        return operator.index(k)
     except TypeError:
         raise TypeError("k must be an integer") from None
 
+
+def _validate_graph_k(records, k):
     if k < 0:
         raise ValueError("k must be non-negative")
     if k == 0:
-        return []
+        return
 
     max_neighbors = max(0, len(records) - 1)
     if k > max_neighbors:
         raise ValueError("k cannot exceed the number of non-self neighbors")
+
+
+def _build_exact_knn_graph_edges(records, metric, k):
+    if k == 0:
+        return []
 
     space = FiniteMetricSpace(records, metric)
     edges = []
@@ -55,9 +87,37 @@ def exact_knn_graph_edges(records, metric, k):
     return edges
 
 
-def exact_radius_graph_edges(records, metric, radius):
-    """Build exact directed radius graph edges as source, target, distance tuples."""
+def exact_knn_graph(records, metric, k):
+    """Build an exact directed kNN graph result with construction metadata."""
     records = list(records)
+    k = _coerce_graph_k(k)
+    _validate_graph_k(records, k)
+    edges = _build_exact_knn_graph_edges(records, metric, k)
+
+    return GraphConstructionResult(
+        edges=tuple(edges),
+        metadata=GraphConstructionMetadata(
+            strategy="exact_knn",
+            record_count=len(records),
+            edge_count=len(edges),
+            directed=True,
+            self_loops=False,
+            exact=True,
+            k=k,
+            edge_payload="metric_distance",
+            symmetrization="none",
+            normalization="none",
+            tie_break="distance_then_target_index",
+        ),
+    )
+
+
+def exact_knn_graph_edges(records, metric, k):
+    """Build exact directed kNN graph edges as source, target, distance tuples."""
+    return list(exact_knn_graph(records, metric, k).edges)
+
+
+def _build_exact_radius_graph_edges(records, metric, radius):
     if radius < 0:
         raise ValueError("radius must be non-negative")
 
@@ -73,6 +133,34 @@ def exact_radius_graph_edges(records, metric, radius):
                 edges.append((source_index, target_index, distance))
 
     return edges
+
+
+def exact_radius_graph(records, metric, radius):
+    """Build an exact directed radius graph result with construction metadata."""
+    records = list(records)
+    edges = _build_exact_radius_graph_edges(records, metric, radius)
+
+    return GraphConstructionResult(
+        edges=tuple(edges),
+        metadata=GraphConstructionMetadata(
+            strategy="exact_radius",
+            record_count=len(records),
+            edge_count=len(edges),
+            directed=True,
+            self_loops=False,
+            exact=True,
+            radius=radius,
+            edge_payload="metric_distance",
+            symmetrization="none",
+            normalization="none",
+            tie_break="source_then_target_index",
+        ),
+    )
+
+
+def exact_radius_graph_edges(records, metric, radius):
+    """Build exact directed radius graph edges as source, target, distance tuples."""
+    return list(exact_radius_graph(records, metric, radius).edges)
 
 
 def representative_indices(records, metric, k, seed_index=0):
@@ -246,11 +334,15 @@ def intrinsic_dimension_from_distances(distances):
 
 
 __all__ = [
+    "GraphConstructionMetadata",
+    "GraphConstructionResult",
     "intrinsic_dimension",
     "intrinsic_dimension_from_distances",
     "coverage_representative_indices",
     "coverage_representatives",
+    "exact_knn_graph",
     "exact_knn_graph_edges",
+    "exact_radius_graph",
     "exact_radius_graph_edges",
     "medoid",
     "medoid_index",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -9,9 +9,13 @@ import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
 from metric.operators import (
+    GraphConstructionMetadata,
+    GraphConstructionResult,
     coverage_representative_indices,
     coverage_representatives,
+    exact_knn_graph,
     exact_knn_graph_edges,
+    exact_radius_graph,
     exact_radius_graph_edges,
     intrinsic_dimension,
     medoid,
@@ -56,7 +60,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.spaces.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
+        self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
+        self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.operators.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.operators.exact_knn_graph_edges, exact_knn_graph_edges)
+        self.assertIs(metric.operators.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.operators.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.operators.medoid_index, medoid_index)
@@ -70,7 +78,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
+        self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
+        self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.exact_knn_graph_edges, exact_knn_graph_edges)
+        self.assertIs(metric.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.medoid_index, medoid_index)
@@ -88,7 +100,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("Space", metric.__all__)
         self.assertIn("mappings", metric.__all__)
         self.assertIn("transforms", metric.__all__)
+        self.assertIn("GraphConstructionMetadata", metric.__all__)
+        self.assertIn("GraphConstructionResult", metric.__all__)
+        self.assertIn("exact_knn_graph", metric.__all__)
         self.assertIn("exact_knn_graph_edges", metric.__all__)
+        self.assertIn("exact_radius_graph", metric.__all__)
         self.assertIn("exact_radius_graph_edges", metric.__all__)
         self.assertIn("medoid_index", metric.__all__)
         self.assertIn("medoid", metric.__all__)
@@ -184,10 +200,41 @@ class RevivalApiTest(unittest.TestCase):
             exact_knn_graph_edges(records, cumulative_transport_distance, 1),
             [(0, 3, 0.5), (1, 3, 0.5), (2, 4, 1.5), (3, 0, 0.5), (4, 1, 0.5)],
         )
+        knn_graph = exact_knn_graph(records, cumulative_transport_distance, 1)
+        self.assertIsInstance(knn_graph, GraphConstructionResult)
+        self.assertEqual(list(knn_graph.edges), exact_knn_graph_edges(records, cumulative_transport_distance, 1))
+        self.assertIsInstance(knn_graph.metadata, GraphConstructionMetadata)
+        self.assertEqual(knn_graph.metadata.strategy, "exact_knn")
+        self.assertEqual(knn_graph.metadata.record_count, len(records))
+        self.assertEqual(knn_graph.metadata.edge_count, len(knn_graph.edges))
+        self.assertTrue(knn_graph.metadata.directed)
+        self.assertFalse(knn_graph.metadata.self_loops)
+        self.assertTrue(knn_graph.metadata.exact)
+        self.assertEqual(knn_graph.metadata.k, 1)
+        self.assertIsNone(knn_graph.metadata.radius)
+        self.assertEqual(knn_graph.metadata.edge_payload, "metric_distance")
+        self.assertEqual(knn_graph.metadata.symmetrization, "none")
+        self.assertEqual(knn_graph.metadata.normalization, "none")
+        self.assertEqual(knn_graph.metadata.tie_break, "distance_then_target_index")
         self.assertEqual(
             exact_radius_graph_edges(records, cumulative_transport_distance, 0.5),
             [(0, 3, 0.5), (1, 3, 0.5), (1, 4, 0.5), (3, 0, 0.5), (3, 1, 0.5), (4, 1, 0.5)],
         )
+        radius_graph = exact_radius_graph(records, cumulative_transport_distance, 0.5)
+        self.assertIsInstance(radius_graph, GraphConstructionResult)
+        self.assertEqual(list(radius_graph.edges), exact_radius_graph_edges(records, cumulative_transport_distance, 0.5))
+        self.assertEqual(radius_graph.metadata.strategy, "exact_radius")
+        self.assertEqual(radius_graph.metadata.record_count, len(records))
+        self.assertEqual(radius_graph.metadata.edge_count, len(radius_graph.edges))
+        self.assertTrue(radius_graph.metadata.directed)
+        self.assertFalse(radius_graph.metadata.self_loops)
+        self.assertTrue(radius_graph.metadata.exact)
+        self.assertIsNone(radius_graph.metadata.k)
+        self.assertEqual(radius_graph.metadata.radius, 0.5)
+        self.assertEqual(radius_graph.metadata.edge_payload, "metric_distance")
+        self.assertEqual(radius_graph.metadata.symmetrization, "none")
+        self.assertEqual(radius_graph.metadata.normalization, "none")
+        self.assertEqual(radius_graph.metadata.tie_break, "source_then_target_index")
         self.assertEqual(coverage_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2])
         self.assertEqual(
             coverage_representatives(records, cumulative_transport_distance, 1.5),
@@ -226,6 +273,8 @@ class RevivalApiTest(unittest.TestCase):
             [(0, 1, 1), (0, 2, 2), (1, 0, 1), (1, 2, 1), (2, 0, 2), (2, 1, 1)],
         )
         self.assertEqual(exact_knn_graph_edges(records, absolute_distance, 0), [])
+        self.assertEqual(exact_knn_graph(records, absolute_distance, 0).edges, ())
+        self.assertEqual(exact_knn_graph(records, absolute_distance, 0).metadata.k, 0)
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 2), [0, 3])
         self.assertEqual(coverage_representatives(records, absolute_distance, 2), [0, 10])
         self.assertEqual(coverage_representative_indices(records, absolute_distance, 20), [0])

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -140,6 +140,22 @@ int main()
     };
     assert(exact_knn_edges == expected_knn_edges);
 
+    const auto knn_graph = metric::operators::exact_knn_graph(line, AbsoluteDistance{}, 2);
+    assert(knn_graph.edges == expected_knn_edges);
+    assert(knn_graph.metadata.strategy == "exact_knn");
+    assert(knn_graph.metadata.record_count == line.size());
+    assert(knn_graph.metadata.edge_count == expected_knn_edges.size());
+    assert(knn_graph.metadata.directed);
+    assert(!knn_graph.metadata.self_loops);
+    assert(knn_graph.metadata.exact);
+    assert(knn_graph.metadata.k.has_value());
+    assert(knn_graph.metadata.k.value() == 2);
+    assert(!knn_graph.metadata.radius.has_value());
+    assert(knn_graph.metadata.edge_payload == "metric_distance");
+    assert(knn_graph.metadata.symmetrization == "none");
+    assert(knn_graph.metadata.normalization == "none");
+    assert(knn_graph.metadata.tie_break == "distance_then_target_index");
+
     const auto exact_radius_edges = metric::operators::exact_radius_graph_edges(line, AbsoluteDistance{}, 1);
     const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_radius_edges = {
         {0, 1, 1},
@@ -152,6 +168,22 @@ int main()
         {4, 3, 1},
     };
     assert(exact_radius_edges == expected_radius_edges);
+
+    const auto radius_graph = metric::operators::exact_radius_graph(line, AbsoluteDistance{}, 1);
+    assert(radius_graph.edges == expected_radius_edges);
+    assert(radius_graph.metadata.strategy == "exact_radius");
+    assert(radius_graph.metadata.record_count == line.size());
+    assert(radius_graph.metadata.edge_count == expected_radius_edges.size());
+    assert(radius_graph.metadata.directed);
+    assert(!radius_graph.metadata.self_loops);
+    assert(radius_graph.metadata.exact);
+    assert(!radius_graph.metadata.k.has_value());
+    assert(radius_graph.metadata.radius.has_value());
+    assert(radius_graph.metadata.radius.value() == 1);
+    assert(radius_graph.metadata.edge_payload == "metric_distance");
+    assert(radius_graph.metadata.symmetrization == "none");
+    assert(radius_graph.metadata.normalization == "none");
+    assert(radius_graph.metadata.tie_break == "source_then_target_index");
 
     bool rejected_large_graph_k = false;
     try {


### PR DESCRIPTION
## Summary
- add C++ `GraphConstructionResult` / `GraphConstructionMetadata` result wrappers for exact kNN and radius graph construction
- add Python frozen dataclass result wrappers with matching metadata while keeping existing `*_edges` helpers as edge-list compatibility helpers
- document graph construction metadata and update the sparse graph roadmap so the next graph slice is symmetrization/weighting

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/graph-result-wheel-v2` from `python/`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/graph-result-wheel-v2/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`