### PR TITLE
Add graph symmetrization policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add C++ and Python `exact_knn_graph_edges` and `exact_radius_graph_edges` helpers using exhaustive pairwise distances and deterministic edge ordering.
 - Add C++ and Python `exact_knn_graph` and `exact_radius_graph` result objects with construction metadata for exact graph helpers.
+- Add C++ and Python `symmetrize_graph` helpers for deterministic graph `union` and `mutual` policies with reciprocal distance weighting.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
 - Add C++ and Python `medoid_index` and `medoid` helpers using deterministic minimum-total-distance selection.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::exact_knn_graph_edges`
 - `metric::operators::exact_radius_graph`
 - `metric::operators::exact_radius_graph_edges`
+- `metric::operators::symmetrize_graph`
 - `metric::operators::representative_indices`
 - `metric::operators::representatives`
 - `metric::operators::medoid_index`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -69,6 +69,7 @@ auto knn_graph = metric::operators::exact_knn_graph(records, metric::Edit<std::s
 auto knn_edges = metric::operators::exact_knn_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto radius_graph = metric::operators::exact_radius_graph(records, metric::Edit<std::string>{}, 1);
 auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
+auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
 auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
@@ -80,7 +81,7 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -89,6 +90,8 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` values with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+
+`symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -65,6 +65,7 @@ from metric.operators import (
     representatives,
     separated_representative_indices,
     separated_representatives,
+    symmetrize_graph,
 )
 
 distances = pairwise_distance_matrix(records, Edit())
@@ -74,6 +75,7 @@ knn_graph = exact_knn_graph(records, Edit(), k=1)
 knn_edges = exact_knn_graph_edges(records, Edit(), k=1)
 radius_graph = exact_radius_graph(records, Edit(), radius=1)
 radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
+undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
 center_id = medoid_index(records, Edit())
@@ -92,6 +94,8 @@ dimension = intrinsic_dimension(records, Edit())
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` objects with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+
+`symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,7 +4,7 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
-The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. All four helpers exclude self-loops and are tested against deterministic fixtures. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Symmetrization policies and normalized weights remain roadmap items.
+The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
 
 ## Required Metadata
 
@@ -25,7 +25,7 @@ Without this metadata, a graph is an expert representation, not a promoted resul
 
 An exact k-nearest-neighbor graph has one outgoing neighbor set per source record. For each record, the selected neighbors are the `k` nearest other records under the metric, after applying a documented tie-breaking rule.
 
-`exact_knn_graph` and `exact_knn_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and resolve equal distances by target record order. The result metadata records strategy `exact_knn`, the record count, edge count, exact/directed policy, `k`, metric-distance payloads, no symmetrization, no normalization, and the tie-breaking rule.
+`exact_knn_graph` and `exact_knn_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and resolve equal distances by target record order. The result metadata records strategy `exact_knn`, the record count, edge count, exact/directed policy, `k`, metric-distance payloads, no weighting, no symmetrization, no normalization, and the tie-breaking rule.
 
 Exactness must be supported by exhaustive pairwise distances, a proved exact algorithm, or deterministic tests that compare against dense pairwise distances on small fixtures.
 
@@ -43,7 +43,7 @@ Approximate graphs must not be documented as exact unless their edge sets are ve
 
 A radius graph connects records whose metric distance is within a threshold.
 
-`exact_radius_graph` and `exact_radius_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and emit every directed edge whose distance is within `radius`. The result metadata records strategy `exact_radius`, the record count, edge count, exact/directed policy, `radius`, metric-distance payloads, no symmetrization, no normalization, and the source/target scan rule.
+`exact_radius_graph` and `exact_radius_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and emit every directed edge whose distance is within `radius`. The result metadata records strategy `exact_radius`, the record count, edge count, exact/directed policy, `radius`, metric-distance payloads, no weighting, no symmetrization, no normalization, and the source/target scan rule.
 
 An exact directed radius graph has edge `i -> j` when `distance(i, j) <= radius`, subject to a documented self-loop policy. An exact undirected radius graph uses the same threshold but stores one undirected relationship for each qualifying pair.
 
@@ -60,6 +60,13 @@ Undirected or symmetrized graphs must document their policy:
 - `weighted merge`: combine both directed weights with a named reducer such as minimum, maximum, or average
 
 The policy changes graph connectivity and degree distributions, so it is part of the result contract.
+
+`symmetrize_graph` promotes two deterministic policies:
+
+- `union`: keep an undirected edge when either directed edge exists
+- `mutual`: keep an undirected edge only when both directed edges exist
+
+It emits undirected edges as `source_index < target_index`. When both directions provide a distance, the reciprocal weighting policy is either `minimum_distance` or `maximum_distance`. Normalized weights and affinity transforms remain separate roadmap items.
 
 ## Weights And Normalization
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -1,6 +1,6 @@
 # Exact Graph Edge Fixtures
 
-Exact graph helpers emit directed graph-construction results over a finite metric space. The result form carries directed edge tuples plus metadata for validating graph construction semantics before symmetrization or weighting policies are promoted.
+Exact graph helpers emit graph-construction results over a finite metric space. The result form carries edge tuples plus metadata for validating construction, symmetrization, and reciprocal weighting semantics.
 
 The edge tuple shape is `(source_index, target_index, distance)`. Self-loops are excluded. kNN ties are resolved by target record order.
 
@@ -21,31 +21,33 @@ struct AbsoluteDistance {
 
 std::vector<int> records = {0, 1, 2, 3, 4};
 
-auto knn_graph = metric::operators::exact_knn_graph(records, AbsoluteDistance{}, 2);
+auto knn_graph = metric::operators::exact_knn_graph(records, AbsoluteDistance{}, 1);
 auto radius_graph = metric::operators::exact_radius_graph(records, AbsoluteDistance{}, 1);
 
 auto knn_edges = knn_graph.edges;
 auto radius_edges = radius_graph.edges;
+auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 ```
 
 Python shape:
 
 ```python
-from metric import exact_knn_graph, exact_radius_graph
+from metric import exact_knn_graph, exact_radius_graph, symmetrize_graph
 
 records = [0, 1, 2, 3, 4]
 
 def absolute_distance(lhs, rhs):
     return abs(lhs - rhs)
 
-knn_graph = exact_knn_graph(records, absolute_distance, k=2)
+knn_graph = exact_knn_graph(records, absolute_distance, k=1)
 radius_graph = exact_radius_graph(records, absolute_distance, radius=1)
 
 knn_edges = knn_graph.edges
 radius_edges = radius_graph.edges
+undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 ```
 
-`knn_graph.metadata` records strategy `exact_knn`, `record_count`, `edge_count`, `directed=True`, `self_loops=False`, `exact=True`, `k`, `edge_payload="metric_distance"`, `symmetrization="none"`, `normalization="none"`, and the tie-breaking rule. `radius_graph.metadata` records the same policy fields with `radius` instead of `k`.
+`knn_graph.metadata` records strategy `exact_knn`, `record_count`, `edge_count`, `directed=True`, `self_loops=False`, `exact=True`, `k`, `edge_payload="metric_distance"`, `weighting="none"`, `symmetrization="none"`, `normalization="none"`, and the tie-breaking rule. `radius_graph.metadata` records the same policy fields with `radius` instead of `k`. `undirected.metadata` records `directed=False`, `symmetrization="union"`, and `weighting="minimum_distance"`.
 
 For `records = [0, 1, 2, 3, 4]`, the exact radius graph with radius `1` has directed edges:
 
@@ -61,3 +63,12 @@ For `records = [0, 1, 2, 3, 4]`, the exact radius graph with radius `1` has dire
 ```
 
 These helpers are exact because they evaluate the pairwise distances needed for every source record. The `*_edges` helpers remain available for callers that only need edge tuples. `metric::KNNGraph` remains an approximate compatibility representation and should not be used as evidence for exact graph construction unless its edge set is compared against dense pairwise distances for the fixture.
+
+For `records = [0, 1, 2, 3, 4]`, symmetrizing the exact kNN graph with `k=1` and the `union` policy produces undirected edges:
+
+```text
+(0, 1, 1)
+(1, 2, 1)
+(2, 3, 1)
+(3, 4, 1)
+```

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -80,10 +80,10 @@ Current promoted base:
 - Graph construction terminology documents exact versus approximate graph construction, directed versus symmetrized edges, edge payload meanings, normalization policies, and promotion requirements.
 - C++ and Python `exact_knn_graph_edges` / `exact_radius_graph_edges` expose deterministic directed edge-list fixtures backed by exhaustive pairwise distances.
 - C++ and Python `exact_knn_graph` / `exact_radius_graph` return graph construction result objects with directed edge lists and construction metadata.
+- C++ and Python `symmetrize_graph` promotes deterministic `union` and `mutual` policies with minimum-distance and maximum-distance reciprocal weighting.
 
 Candidate strategies:
 
-- symmetrization and weighting policies
 - sparsification primitives with documented assumptions
 - graph diagnostics such as connectivity, degree distribution, and edge stretch
 
@@ -183,6 +183,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph symmetrization and weighting policies
+- add graph sparsification primitives with documented assumptions
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-symmetrization, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <map>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -39,6 +40,7 @@ template <typename Distance, typename RadiusValue = Distance> struct GraphConstr
 	std::optional<std::size_t> k;
 	std::optional<RadiusValue> radius;
 	std::string edge_payload;
+	std::string weighting;
 	std::string symmetrization;
 	std::string normalization;
 	std::string tie_break;
@@ -88,6 +90,7 @@ auto exact_knn_graph(const Container &records, Metric distance, std::size_t k)
 	result.metadata.exact = true;
 	result.metadata.k = k;
 	result.metadata.edge_payload = "metric_distance";
+	result.metadata.weighting = "none";
 	result.metadata.symmetrization = "none";
 	result.metadata.normalization = "none";
 	result.metadata.tie_break = "distance_then_target_index";
@@ -164,6 +167,7 @@ auto exact_radius_graph(const Container &records, Metric distance, Radius radius
 	result.metadata.exact = true;
 	result.metadata.radius = static_cast<comparison_type>(radius);
 	result.metadata.edge_payload = "metric_distance";
+	result.metadata.weighting = "none";
 	result.metadata.symmetrization = "none";
 	result.metadata.normalization = "none";
 	result.metadata.tie_break = "source_then_target_index";
@@ -193,6 +197,91 @@ auto exact_radius_graph_edges(const Container &records, Metric distance, Radius 
 		std::tuple<std::size_t, std::size_t, typename detail::finite_space_t<Container, Metric>::distance_type>>
 {
 	return exact_radius_graph(records, std::move(distance), radius).edges;
+}
+
+template <typename Distance, typename RadiusValue>
+auto symmetrize_graph(const GraphConstructionResult<Distance, RadiusValue> &graph,
+					  const std::string &policy = "union",
+					  const std::string &weighting = "minimum_distance")
+	-> GraphConstructionResult<Distance, RadiusValue>
+{
+	if (policy != "union" && policy != "mutual") {
+		throw std::invalid_argument("symmetrization policy must be 'union' or 'mutual'");
+	}
+	if (weighting != "minimum_distance" && weighting != "maximum_distance") {
+		throw std::invalid_argument("weighting policy must be 'minimum_distance' or 'maximum_distance'");
+	}
+
+	struct Accumulator {
+		std::optional<Distance> forward;
+		std::optional<Distance> reverse;
+	};
+
+	auto merge_weight = [&weighting](Distance lhs, Distance rhs) {
+		if (weighting == "minimum_distance") {
+			return std::min(lhs, rhs);
+		}
+		return std::max(lhs, rhs);
+	};
+
+	auto assign_weight = [&merge_weight](std::optional<Distance> &slot, Distance value) {
+		if (slot.has_value()) {
+			slot = merge_weight(slot.value(), value);
+		} else {
+			slot = value;
+		}
+	};
+
+	std::map<std::pair<std::size_t, std::size_t>, Accumulator> edge_accumulators;
+	for (const auto &edge : graph.edges) {
+		const auto source_index = std::get<0>(edge);
+		const auto target_index = std::get<1>(edge);
+		const auto distance = std::get<2>(edge);
+
+		if (source_index == target_index) {
+			continue;
+		}
+
+		const auto lower_index = std::min(source_index, target_index);
+		const auto upper_index = std::max(source_index, target_index);
+		auto &accumulator = edge_accumulators[{lower_index, upper_index}];
+		if (source_index == lower_index) {
+			assign_weight(accumulator.forward, distance);
+		} else {
+			assign_weight(accumulator.reverse, distance);
+		}
+	}
+
+	GraphConstructionResult<Distance, RadiusValue> result;
+	result.metadata = graph.metadata;
+	result.metadata.directed = false;
+	result.metadata.self_loops = false;
+	result.metadata.symmetrization = policy;
+	result.metadata.weighting = weighting;
+	result.metadata.tie_break = "source_index_then_target_index";
+
+	for (const auto &entry : edge_accumulators) {
+		const auto &key = entry.first;
+		const auto &accumulator = entry.second;
+		const auto has_forward = accumulator.forward.has_value();
+		const auto has_reverse = accumulator.reverse.has_value();
+
+		if (policy == "mutual" && !(has_forward && has_reverse)) {
+			continue;
+		}
+
+		if (has_forward && has_reverse) {
+			result.edges.emplace_back(key.first, key.second,
+									  merge_weight(accumulator.forward.value(), accumulator.reverse.value()));
+		} else if (has_forward) {
+			result.edges.emplace_back(key.first, key.second, accumulator.forward.value());
+		} else {
+			result.edges.emplace_back(key.first, key.second, accumulator.reverse.value());
+		}
+	}
+
+	result.metadata.edge_count = result.edges.size();
+	return result;
 }
 
 template <typename Container, typename Metric>

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-symmetrization, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -38,6 +38,7 @@ from .operators import (
     representatives,
     separated_representative_indices,
     separated_representatives,
+    symmetrize_graph,
 )
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
 

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -20,6 +20,7 @@ class GraphConstructionMetadata:
     k: object = None
     radius: object = None
     edge_payload: str = ""
+    weighting: str = ""
     symmetrization: str = ""
     normalization: str = ""
     tie_break: str = ""
@@ -105,6 +106,7 @@ def exact_knn_graph(records, metric, k):
             exact=True,
             k=k,
             edge_payload="metric_distance",
+            weighting="none",
             symmetrization="none",
             normalization="none",
             tie_break="distance_then_target_index",
@@ -151,6 +153,7 @@ def exact_radius_graph(records, metric, radius):
             exact=True,
             radius=radius,
             edge_payload="metric_distance",
+            weighting="none",
             symmetrization="none",
             normalization="none",
             tie_break="source_then_target_index",
@@ -161,6 +164,70 @@ def exact_radius_graph(records, metric, radius):
 def exact_radius_graph_edges(records, metric, radius):
     """Build exact directed radius graph edges as source, target, distance tuples."""
     return list(exact_radius_graph(records, metric, radius).edges)
+
+
+def _merge_graph_weight(lhs, rhs, weighting):
+    if weighting == "minimum_distance":
+        return min(lhs, rhs)
+    if weighting == "maximum_distance":
+        return max(lhs, rhs)
+    raise ValueError("weighting policy must be 'minimum_distance' or 'maximum_distance'")
+
+
+def symmetrize_graph(graph, policy="union", weighting="minimum_distance"):
+    """Symmetrize a graph construction result with a documented merge policy."""
+    if policy not in {"union", "mutual"}:
+        raise ValueError("symmetrization policy must be 'union' or 'mutual'")
+    if weighting not in {"minimum_distance", "maximum_distance"}:
+        raise ValueError("weighting policy must be 'minimum_distance' or 'maximum_distance'")
+
+    edge_accumulators = {}
+    for source_index, target_index, distance in graph.edges:
+        if source_index == target_index:
+            continue
+
+        lower_index = min(source_index, target_index)
+        upper_index = max(source_index, target_index)
+        accumulator = edge_accumulators.setdefault((lower_index, upper_index), [None, None])
+        slot = 0 if source_index == lower_index else 1
+        if accumulator[slot] is None:
+            accumulator[slot] = distance
+        else:
+            accumulator[slot] = _merge_graph_weight(accumulator[slot], distance, weighting)
+
+    edges = []
+    for (source_index, target_index), (forward_distance, reverse_distance) in sorted(edge_accumulators.items()):
+        has_forward = forward_distance is not None
+        has_reverse = reverse_distance is not None
+        if policy == "mutual" and not (has_forward and has_reverse):
+            continue
+
+        if has_forward and has_reverse:
+            distance = _merge_graph_weight(forward_distance, reverse_distance, weighting)
+        elif has_forward:
+            distance = forward_distance
+        else:
+            distance = reverse_distance
+        edges.append((source_index, target_index, distance))
+
+    return GraphConstructionResult(
+        edges=tuple(edges),
+        metadata=GraphConstructionMetadata(
+            strategy=graph.metadata.strategy,
+            record_count=graph.metadata.record_count,
+            edge_count=len(edges),
+            directed=False,
+            self_loops=False,
+            exact=graph.metadata.exact,
+            k=graph.metadata.k,
+            radius=graph.metadata.radius,
+            edge_payload=graph.metadata.edge_payload,
+            weighting=weighting,
+            symmetrization=policy,
+            normalization=graph.metadata.normalization,
+            tie_break="source_index_then_target_index",
+        ),
+    )
 
 
 def representative_indices(records, metric, k, seed_index=0):
@@ -353,4 +420,5 @@ __all__ = [
     "representatives",
     "separated_representative_indices",
     "separated_representatives",
+    "symmetrize_graph",
 ]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -27,6 +27,7 @@ from metric.operators import (
     representatives,
     separated_representative_indices,
     separated_representatives,
+    symmetrize_graph,
 )
 from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
 
@@ -73,6 +74,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.representatives, representatives)
         self.assertIs(metric.operators.separated_representative_indices, separated_representative_indices)
         self.assertIs(metric.operators.separated_representatives, separated_representatives)
+        self.assertIs(metric.operators.symmetrize_graph, symmetrize_graph)
         self.assertIs(metric.operators.coverage_representative_indices, coverage_representative_indices)
         self.assertIs(metric.operators.coverage_representatives, coverage_representatives)
         self.assertIs(metric.mappings, mappings)
@@ -92,6 +94,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.representatives, representatives)
         self.assertIs(metric.separated_representative_indices, separated_representative_indices)
         self.assertIs(metric.separated_representatives, separated_representatives)
+        self.assertIs(metric.symmetrize_graph, symmetrize_graph)
         self.assertIs(metric.coverage_representative_indices, coverage_representative_indices)
         self.assertIs(metric.coverage_representatives, coverage_representatives)
         self.assertIs(metric.FiniteMetricSpace, FiniteMetricSpace)
@@ -112,6 +115,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("representatives", metric.__all__)
         self.assertIn("separated_representative_indices", metric.__all__)
         self.assertIn("separated_representatives", metric.__all__)
+        self.assertIn("symmetrize_graph", metric.__all__)
         self.assertIn("coverage_representative_indices", metric.__all__)
         self.assertIn("coverage_representatives", metric.__all__)
         self.assertEqual(mappings.STABILITY, "beta")
@@ -213,9 +217,54 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(knn_graph.metadata.k, 1)
         self.assertIsNone(knn_graph.metadata.radius)
         self.assertEqual(knn_graph.metadata.edge_payload, "metric_distance")
+        self.assertEqual(knn_graph.metadata.weighting, "none")
         self.assertEqual(knn_graph.metadata.symmetrization, "none")
         self.assertEqual(knn_graph.metadata.normalization, "none")
         self.assertEqual(knn_graph.metadata.tie_break, "distance_then_target_index")
+
+        union_graph = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
+        self.assertEqual(
+            list(union_graph.edges),
+            [(0, 3, 0.5), (1, 3, 0.5), (1, 4, 0.5), (2, 4, 1.5)],
+        )
+        self.assertFalse(union_graph.metadata.directed)
+        self.assertEqual(union_graph.metadata.edge_count, len(union_graph.edges))
+        self.assertEqual(union_graph.metadata.weighting, "minimum_distance")
+        self.assertEqual(union_graph.metadata.symmetrization, "union")
+        self.assertEqual(union_graph.metadata.tie_break, "source_index_then_target_index")
+
+        mutual_graph = symmetrize_graph(knn_graph, policy="mutual", weighting="minimum_distance")
+        self.assertEqual(list(mutual_graph.edges), [(0, 3, 0.5)])
+        self.assertEqual(mutual_graph.metadata.symmetrization, "mutual")
+
+        asymmetric_graph = GraphConstructionResult(
+            edges=((0, 1, 5), (1, 0, 3), (1, 2, 4)),
+            metadata=GraphConstructionMetadata(
+                strategy="synthetic",
+                record_count=3,
+                edge_count=3,
+                directed=True,
+                self_loops=False,
+                exact=True,
+                edge_payload="metric_distance",
+                weighting="none",
+                symmetrization="none",
+                normalization="none",
+            ),
+        )
+        self.assertEqual(
+            list(symmetrize_graph(asymmetric_graph, policy="union", weighting="minimum_distance").edges),
+            [(0, 1, 3), (1, 2, 4)],
+        )
+        self.assertEqual(
+            list(symmetrize_graph(asymmetric_graph, policy="union", weighting="maximum_distance").edges),
+            [(0, 1, 5), (1, 2, 4)],
+        )
+        with self.assertRaises(ValueError):
+            symmetrize_graph(asymmetric_graph, policy="invalid", weighting="minimum_distance")
+        with self.assertRaises(ValueError):
+            symmetrize_graph(asymmetric_graph, policy="union", weighting="average_distance")
+
         self.assertEqual(
             exact_radius_graph_edges(records, cumulative_transport_distance, 0.5),
             [(0, 3, 0.5), (1, 3, 0.5), (1, 4, 0.5), (3, 0, 0.5), (3, 1, 0.5), (4, 1, 0.5)],
@@ -232,6 +281,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIsNone(radius_graph.metadata.k)
         self.assertEqual(radius_graph.metadata.radius, 0.5)
         self.assertEqual(radius_graph.metadata.edge_payload, "metric_distance")
+        self.assertEqual(radius_graph.metadata.weighting, "none")
         self.assertEqual(radius_graph.metadata.symmetrization, "none")
         self.assertEqual(radius_graph.metadata.normalization, "none")
         self.assertEqual(radius_graph.metadata.tie_break, "source_then_target_index")

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -152,9 +152,81 @@ int main()
     assert(knn_graph.metadata.k.value() == 2);
     assert(!knn_graph.metadata.radius.has_value());
     assert(knn_graph.metadata.edge_payload == "metric_distance");
+    assert(knn_graph.metadata.weighting == "none");
     assert(knn_graph.metadata.symmetrization == "none");
     assert(knn_graph.metadata.normalization == "none");
     assert(knn_graph.metadata.tie_break == "distance_then_target_index");
+
+    const auto one_neighbor_graph = metric::operators::exact_knn_graph(line, AbsoluteDistance{}, 1);
+    const auto union_graph = metric::operators::symmetrize_graph(one_neighbor_graph, "union", "minimum_distance");
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_union_edges = {
+        {0, 1, 1},
+        {1, 2, 1},
+        {2, 3, 1},
+        {3, 4, 1},
+    };
+    assert(union_graph.edges == expected_union_edges);
+    assert(!union_graph.metadata.directed);
+    assert(union_graph.metadata.edge_count == expected_union_edges.size());
+    assert(union_graph.metadata.weighting == "minimum_distance");
+    assert(union_graph.metadata.symmetrization == "union");
+    assert(union_graph.metadata.tie_break == "source_index_then_target_index");
+
+    const auto mutual_graph = metric::operators::symmetrize_graph(one_neighbor_graph, "mutual", "minimum_distance");
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_mutual_edges = {
+        {0, 1, 1},
+    };
+    assert(mutual_graph.edges == expected_mutual_edges);
+    assert(mutual_graph.metadata.symmetrization == "mutual");
+
+    metric::operators::GraphConstructionResult<int> asymmetric_graph;
+    asymmetric_graph.edges = {
+        {0, 1, 5},
+        {1, 0, 3},
+        {1, 2, 4},
+    };
+    asymmetric_graph.metadata.strategy = "synthetic";
+    asymmetric_graph.metadata.record_count = 3;
+    asymmetric_graph.metadata.edge_count = asymmetric_graph.edges.size();
+    asymmetric_graph.metadata.directed = true;
+    asymmetric_graph.metadata.self_loops = false;
+    asymmetric_graph.metadata.exact = true;
+    asymmetric_graph.metadata.edge_payload = "metric_distance";
+    asymmetric_graph.metadata.weighting = "none";
+    asymmetric_graph.metadata.symmetrization = "none";
+    asymmetric_graph.metadata.normalization = "none";
+
+    const auto minimum_weighted_graph =
+        metric::operators::symmetrize_graph(asymmetric_graph, "union", "minimum_distance");
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_minimum_edges = {
+        {0, 1, 3},
+        {1, 2, 4},
+    };
+    assert(minimum_weighted_graph.edges == expected_minimum_edges);
+
+    const auto maximum_weighted_graph =
+        metric::operators::symmetrize_graph(asymmetric_graph, "union", "maximum_distance");
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_maximum_edges = {
+        {0, 1, 5},
+        {1, 2, 4},
+    };
+    assert(maximum_weighted_graph.edges == expected_maximum_edges);
+
+    bool rejected_symmetrization_policy = false;
+    try {
+        metric::operators::symmetrize_graph(asymmetric_graph, "invalid", "minimum_distance");
+    } catch (const std::invalid_argument &) {
+        rejected_symmetrization_policy = true;
+    }
+    assert(rejected_symmetrization_policy);
+
+    bool rejected_weighting_policy = false;
+    try {
+        metric::operators::symmetrize_graph(asymmetric_graph, "union", "average_distance");
+    } catch (const std::invalid_argument &) {
+        rejected_weighting_policy = true;
+    }
+    assert(rejected_weighting_policy);
 
     const auto exact_radius_edges = metric::operators::exact_radius_graph_edges(line, AbsoluteDistance{}, 1);
     const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_radius_edges = {
@@ -181,6 +253,7 @@ int main()
     assert(radius_graph.metadata.radius.has_value());
     assert(radius_graph.metadata.radius.value() == 1);
     assert(radius_graph.metadata.edge_payload == "metric_distance");
+    assert(radius_graph.metadata.weighting == "none");
     assert(radius_graph.metadata.symmetrization == "none");
     assert(radius_graph.metadata.normalization == "none");
     assert(radius_graph.metadata.tie_break == "source_then_target_index");


### PR DESCRIPTION
## Summary
- add C++ and Python `symmetrize_graph` helpers for deterministic `union` and `mutual` graph symmetrization
- add reciprocal weighting policies `minimum_distance` and `maximum_distance` and record the selected weighting in graph metadata
- cover union, mutual, min/max weighting, and invalid policy errors in C++ and Python core tests
- update graph docs, API docs, roadmap, stability docs, README, and changelog

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/graph-symmetry-wheel` from `python/`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/graph-symmetry-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`