### PR TITLE
Add graph out-degree pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add C++ and Python `exact_knn_graph_edges` and `exact_radius_graph_edges` helpers using exhaustive pairwise distances and deterministic edge ordering.
 - Add C++ and Python `exact_knn_graph` and `exact_radius_graph` result objects with construction metadata for exact graph helpers.
 - Add C++ and Python `symmetrize_graph` helpers for deterministic graph `union` and `mutual` policies with reciprocal distance weighting.
+- Add C++ and Python `prune_graph_out_degree` helpers for deterministic directed graph sparsification.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.
 - Add C++ `metric::operators::representative_indices` and `representatives` helpers using the same deterministic farthest-first traversal.
 - Add C++ and Python `medoid_index` and `medoid` helpers using deterministic minimum-total-distance selection.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::exact_radius_graph`
 - `metric::operators::exact_radius_graph_edges`
 - `metric::operators::symmetrize_graph`
+- `metric::operators::prune_graph_out_degree`
 - `metric::operators::representative_indices`
 - `metric::operators::representatives`
 - `metric::operators::medoid_index`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -70,6 +70,9 @@ auto knn_edges = metric::operators::exact_knn_graph_edges(records, metric::Edit<
 auto radius_graph = metric::operators::exact_radius_graph(records, metric::Edit<std::string>{}, 1);
 auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
+auto pruned = metric::operators::prune_graph_out_degree(
+    metric::operators::exact_knn_graph(records, metric::Edit<std::string>{}, 2),
+    1);
 auto selected_ids = metric::operators::representative_indices(records, metric::Edit<std::string>{}, 2);
 auto selected_records = metric::operators::representatives(records, metric::Edit<std::string>{}, 2);
 auto center_id = metric::operators::medoid_index(records, metric::Edit<std::string>{});
@@ -81,7 +84,7 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -89,9 +92,11 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
-`exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` values with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+`exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` values with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, sparsification policy, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
 
 `symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
+
+`prune_graph_out_degree` keeps at most `max_out_degree` existing directed edges per source record. It sorts each source's candidate edges by `(distance, target_index)`, keeps the first entries, and records `sparsification="out_degree"` plus `max_out_degree` in the returned metadata. It does not compute new distances and rejects already-undirected graph results because their stored source index is not an out-degree contract.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -60,6 +60,7 @@ from metric.operators import (
     medoid_index,
     nearest_neighbors,
     pairwise_distance_matrix,
+    prune_graph_out_degree,
     range_neighbors,
     representative_indices,
     representatives,
@@ -76,6 +77,7 @@ knn_edges = exact_knn_graph_edges(records, Edit(), k=1)
 radius_graph = exact_radius_graph(records, Edit(), radius=1)
 radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
+pruned = prune_graph_out_degree(exact_knn_graph(records, Edit(), k=2), max_out_degree=1)
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
 center_id = medoid_index(records, Edit())
@@ -93,9 +95,11 @@ dimension = intrinsic_dimension(records, Edit())
 
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
-`exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` objects with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+`exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` objects with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, sparsification policy, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
 
 `symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
+
+`prune_graph_out_degree` keeps at most `max_out_degree` existing directed edges per source record. It sorts each source's candidate edges by `(distance, target_index)`, keeps the first entries, and records `sparsification="out_degree"` plus `max_out_degree` in the returned metadata. It does not compute new distances and rejects already-undirected graph results because their stored source index is not an out-degree contract.
 
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,7 +4,7 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
-The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
+The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
 
 ## Required Metadata
 
@@ -16,6 +16,7 @@ Every promoted graph-construction result should state:
 - whether the edge set is exact or approximate
 - whether edges are directed, undirected, or symmetrized
 - whether edge payloads are metric distances, affinities, booleans, or normalized weights
+- any sparsification policy and degree cap applied after construction
 - tie-breaking rule for equal distances
 - deterministic seed or stochastic build policy when approximation is used
 
@@ -25,7 +26,7 @@ Without this metadata, a graph is an expert representation, not a promoted resul
 
 An exact k-nearest-neighbor graph has one outgoing neighbor set per source record. For each record, the selected neighbors are the `k` nearest other records under the metric, after applying a documented tie-breaking rule.
 
-`exact_knn_graph` and `exact_knn_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and resolve equal distances by target record order. The result metadata records strategy `exact_knn`, the record count, edge count, exact/directed policy, `k`, metric-distance payloads, no weighting, no symmetrization, no normalization, and the tie-breaking rule.
+`exact_knn_graph` and `exact_knn_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and resolve equal distances by target record order. The result metadata records strategy `exact_knn`, the record count, edge count, exact/directed policy, `k`, metric-distance payloads, no weighting, no sparsification, no symmetrization, no normalization, and the tie-breaking rule.
 
 Exactness must be supported by exhaustive pairwise distances, a proved exact algorithm, or deterministic tests that compare against dense pairwise distances on small fixtures.
 
@@ -43,11 +44,19 @@ Approximate graphs must not be documented as exact unless their edge sets are ve
 
 A radius graph connects records whose metric distance is within a threshold.
 
-`exact_radius_graph` and `exact_radius_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and emit every directed edge whose distance is within `radius`. The result metadata records strategy `exact_radius`, the record count, edge count, exact/directed policy, `radius`, metric-distance payloads, no weighting, no symmetrization, no normalization, and the source/target scan rule.
+`exact_radius_graph` and `exact_radius_graph_edges` use exhaustive pairwise distances, exclude self-loops, preserve source-record order, and emit every directed edge whose distance is within `radius`. The result metadata records strategy `exact_radius`, the record count, edge count, exact/directed policy, `radius`, metric-distance payloads, no weighting, no sparsification, no symmetrization, no normalization, and the source/target scan rule.
 
 An exact directed radius graph has edge `i -> j` when `distance(i, j) <= radius`, subject to a documented self-loop policy. An exact undirected radius graph uses the same threshold but stores one undirected relationship for each qualifying pair.
 
 A radius graph is approximate when it is built from candidate pruning, approximate neighbors, or any method that may miss qualifying pairs.
+
+## Degree Sparsification
+
+Sparsification removes edges from an existing graph result. It does not make a graph exact by itself and it must report the rule used to remove edges.
+
+`prune_graph_out_degree` is the promoted deterministic sparsification primitive. It accepts a directed `GraphConstructionResult`, groups existing edges by `source_index`, sorts each group by `(distance, target_index)`, and keeps at most `max_out_degree` edges for each source. It preserves the source graph's construction metadata such as `strategy`, `k`, `radius`, edge payload, weighting, and exactness, then records `sparsification="out_degree"`, `max_out_degree`, the new edge count, and tie-break rule `source_index_then_distance_then_target_index`.
+
+Out-degree pruning is only defined for directed graph results. It rejects already-undirected or symmetrized graph results because `source_index` in an undirected stored edge is an orientation convention, not an outgoing-neighbor contract. Symmetrize after pruning when the workflow needs a smaller undirected graph.
 
 ## Direction And Symmetrization
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -27,12 +27,15 @@ auto radius_graph = metric::operators::exact_radius_graph(records, AbsoluteDista
 auto knn_edges = knn_graph.edges;
 auto radius_edges = radius_graph.edges;
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
+auto pruned = metric::operators::prune_graph_out_degree(
+    metric::operators::exact_knn_graph(records, AbsoluteDistance{}, 2),
+    1);
 ```
 
 Python shape:
 
 ```python
-from metric import exact_knn_graph, exact_radius_graph, symmetrize_graph
+from metric import exact_knn_graph, exact_radius_graph, prune_graph_out_degree, symmetrize_graph
 
 records = [0, 1, 2, 3, 4]
 
@@ -45,9 +48,10 @@ radius_graph = exact_radius_graph(records, absolute_distance, radius=1)
 knn_edges = knn_graph.edges
 radius_edges = radius_graph.edges
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
+pruned = prune_graph_out_degree(exact_knn_graph(records, absolute_distance, k=2), max_out_degree=1)
 ```
 
-`knn_graph.metadata` records strategy `exact_knn`, `record_count`, `edge_count`, `directed=True`, `self_loops=False`, `exact=True`, `k`, `edge_payload="metric_distance"`, `weighting="none"`, `symmetrization="none"`, `normalization="none"`, and the tie-breaking rule. `radius_graph.metadata` records the same policy fields with `radius` instead of `k`. `undirected.metadata` records `directed=False`, `symmetrization="union"`, and `weighting="minimum_distance"`.
+`knn_graph.metadata` records strategy `exact_knn`, `record_count`, `edge_count`, `directed=True`, `self_loops=False`, `exact=True`, `k`, `edge_payload="metric_distance"`, `weighting="none"`, `sparsification="none"`, `symmetrization="none"`, `normalization="none"`, and the tie-breaking rule. `radius_graph.metadata` records the same policy fields with `radius` instead of `k`. `undirected.metadata` records `directed=False`, `symmetrization="union"`, and `weighting="minimum_distance"`. `pruned.metadata` records `sparsification="out_degree"` and `max_out_degree=1` while preserving the source graph construction strategy.
 
 For `records = [0, 1, 2, 3, 4]`, the exact radius graph with radius `1` has directed edges:
 
@@ -71,4 +75,14 @@ For `records = [0, 1, 2, 3, 4]`, symmetrizing the exact kNN graph with `k=1` and
 (1, 2, 1)
 (2, 3, 1)
 (3, 4, 1)
+```
+
+For the same records, pruning the exact kNN graph from `k=2` to `max_out_degree=1` produces directed edges:
+
+```text
+(0, 1, 1)
+(1, 0, 1)
+(2, 1, 1)
+(3, 2, 1)
+(4, 3, 1)
 ```

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -81,10 +81,11 @@ Current promoted base:
 - C++ and Python `exact_knn_graph_edges` / `exact_radius_graph_edges` expose deterministic directed edge-list fixtures backed by exhaustive pairwise distances.
 - C++ and Python `exact_knn_graph` / `exact_radius_graph` return graph construction result objects with directed edge lists and construction metadata.
 - C++ and Python `symmetrize_graph` promotes deterministic `union` and `mutual` policies with minimum-distance and maximum-distance reciprocal weighting.
+- C++ and Python `prune_graph_out_degree` promotes deterministic out-degree sparsification for directed graph construction results.
 
 Candidate strategies:
 
-- sparsification primitives with documented assumptions
+- additional sparsification primitives with documented connectivity or stretch assumptions
 - graph diagnostics such as connectivity, degree distribution, and edge stretch
 
 Promotion evidence:
@@ -183,6 +184,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph sparsification primitives with documented assumptions
+- add graph diagnostics such as connectivity and degree distribution
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -41,7 +41,7 @@ Beta surface:
 - structured metrics with documented examples, such as TWED and EMD
 - mapping modules that still need broader deterministic fixtures
 - transforms used by documented workflows
-- graph sparsification primitives that are present but not yet promoted as first-page examples
+- graph sparsification utilities outside the promoted `prune_graph_out_degree` operator
 
 Experimental and historical surface:
 
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-symmetrization, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -44,6 +44,8 @@ template <typename Distance, typename RadiusValue = Distance> struct GraphConstr
 	std::string symmetrization;
 	std::string normalization;
 	std::string tie_break;
+	std::optional<std::size_t> max_out_degree;
+	std::string sparsification;
 };
 
 template <typename Distance, typename RadiusValue = Distance> struct GraphConstructionResult {
@@ -91,6 +93,7 @@ auto exact_knn_graph(const Container &records, Metric distance, std::size_t k)
 	result.metadata.k = k;
 	result.metadata.edge_payload = "metric_distance";
 	result.metadata.weighting = "none";
+	result.metadata.sparsification = "none";
 	result.metadata.symmetrization = "none";
 	result.metadata.normalization = "none";
 	result.metadata.tie_break = "distance_then_target_index";
@@ -168,6 +171,7 @@ auto exact_radius_graph(const Container &records, Metric distance, Radius radius
 	result.metadata.radius = static_cast<comparison_type>(radius);
 	result.metadata.edge_payload = "metric_distance";
 	result.metadata.weighting = "none";
+	result.metadata.sparsification = "none";
 	result.metadata.symmetrization = "none";
 	result.metadata.normalization = "none";
 	result.metadata.tie_break = "source_then_target_index";
@@ -277,6 +281,55 @@ auto symmetrize_graph(const GraphConstructionResult<Distance, RadiusValue> &grap
 			result.edges.emplace_back(key.first, key.second, accumulator.forward.value());
 		} else {
 			result.edges.emplace_back(key.first, key.second, accumulator.reverse.value());
+		}
+	}
+
+	result.metadata.edge_count = result.edges.size();
+	return result;
+}
+
+template <typename Distance, typename RadiusValue>
+auto prune_graph_out_degree(const GraphConstructionResult<Distance, RadiusValue> &graph,
+							std::size_t max_out_degree) -> GraphConstructionResult<Distance, RadiusValue>
+{
+	if (!graph.metadata.directed) {
+		throw std::invalid_argument("out-degree pruning requires a directed graph result");
+	}
+
+	GraphConstructionResult<Distance, RadiusValue> result;
+	result.metadata = graph.metadata;
+	result.metadata.max_out_degree = max_out_degree;
+	result.metadata.sparsification = "out_degree";
+	result.metadata.tie_break = "source_index_then_distance_then_target_index";
+
+	if (max_out_degree == 0) {
+		result.metadata.edge_count = 0;
+		return result;
+	}
+
+	std::map<std::size_t, std::vector<typename GraphConstructionResult<Distance, RadiusValue>::edge_type>>
+		edges_by_source;
+	for (const auto &edge : graph.edges) {
+		edges_by_source[std::get<0>(edge)].push_back(edge);
+	}
+
+	for (auto &entry : edges_by_source) {
+		auto &source_edges = entry.second;
+		std::sort(source_edges.begin(), source_edges.end(), [](const auto &lhs, const auto &rhs) {
+			const auto lhs_distance = std::get<2>(lhs);
+			const auto rhs_distance = std::get<2>(rhs);
+			if (lhs_distance < rhs_distance) {
+				return true;
+			}
+			if (rhs_distance < lhs_distance) {
+				return false;
+			}
+			return std::get<1>(lhs) < std::get<1>(rhs);
+		});
+
+		const auto selected_count = std::min(max_out_degree, source_edges.size());
+		for (std::size_t edge_index = 0; edge_index < selected_count; ++edge_index) {
+			result.edges.push_back(source_edges[edge_index]);
 		}
 	}
 

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-symmetrization, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -33,6 +33,7 @@ from .operators import (
     medoid_index,
     nearest_neighbors,
     pairwise_distance_matrix,
+    prune_graph_out_degree,
     range_neighbors,
     representative_indices,
     representatives,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -24,6 +24,8 @@ class GraphConstructionMetadata:
     symmetrization: str = ""
     normalization: str = ""
     tie_break: str = ""
+    max_out_degree: object = None
+    sparsification: str = ""
 
 
 @dataclass(frozen=True)
@@ -107,6 +109,7 @@ def exact_knn_graph(records, metric, k):
             k=k,
             edge_payload="metric_distance",
             weighting="none",
+            sparsification="none",
             symmetrization="none",
             normalization="none",
             tie_break="distance_then_target_index",
@@ -154,6 +157,7 @@ def exact_radius_graph(records, metric, radius):
             radius=radius,
             edge_payload="metric_distance",
             weighting="none",
+            sparsification="none",
             symmetrization="none",
             normalization="none",
             tie_break="source_then_target_index",
@@ -221,11 +225,61 @@ def symmetrize_graph(graph, policy="union", weighting="minimum_distance"):
             exact=graph.metadata.exact,
             k=graph.metadata.k,
             radius=graph.metadata.radius,
+            max_out_degree=graph.metadata.max_out_degree,
             edge_payload=graph.metadata.edge_payload,
             weighting=weighting,
+            sparsification=graph.metadata.sparsification,
             symmetrization=policy,
             normalization=graph.metadata.normalization,
             tie_break="source_index_then_target_index",
+        ),
+    )
+
+
+def prune_graph_out_degree(graph, max_out_degree):
+    """Prune a directed graph result to at most max_out_degree edges per source."""
+    try:
+        max_out_degree = operator.index(max_out_degree)
+    except TypeError:
+        raise TypeError("max_out_degree must be an integer") from None
+
+    if max_out_degree < 0:
+        raise ValueError("max_out_degree must be non-negative")
+    if not graph.metadata.directed:
+        raise ValueError("out-degree pruning requires a directed graph result")
+
+    if max_out_degree == 0:
+        edges = ()
+    else:
+        edges_by_source = {}
+        for edge in graph.edges:
+            source_index, _target_index, _distance = edge
+            edges_by_source.setdefault(source_index, []).append(edge)
+
+        selected_edges = []
+        for source_index in sorted(edges_by_source):
+            source_edges = sorted(edges_by_source[source_index], key=lambda edge: (edge[2], edge[1]))
+            selected_edges.extend(source_edges[:max_out_degree])
+        edges = tuple(selected_edges)
+
+    return GraphConstructionResult(
+        edges=edges,
+        metadata=GraphConstructionMetadata(
+            strategy=graph.metadata.strategy,
+            record_count=graph.metadata.record_count,
+            edge_count=len(edges),
+            directed=graph.metadata.directed,
+            self_loops=graph.metadata.self_loops,
+            exact=graph.metadata.exact,
+            k=graph.metadata.k,
+            radius=graph.metadata.radius,
+            max_out_degree=max_out_degree,
+            edge_payload=graph.metadata.edge_payload,
+            weighting=graph.metadata.weighting,
+            sparsification="out_degree",
+            symmetrization=graph.metadata.symmetrization,
+            normalization=graph.metadata.normalization,
+            tie_break="source_index_then_distance_then_target_index",
         ),
     )
 
@@ -414,6 +468,7 @@ __all__ = [
     "medoid",
     "medoid_index",
     "pairwise_distance_matrix",
+    "prune_graph_out_degree",
     "nearest_neighbors",
     "range_neighbors",
     "representative_indices",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -22,6 +22,7 @@ from metric.operators import (
     medoid_index,
     nearest_neighbors,
     pairwise_distance_matrix,
+    prune_graph_out_degree,
     range_neighbors,
     representative_indices,
     representatives,
@@ -68,6 +69,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.operators.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
+        self.assertIs(metric.operators.prune_graph_out_degree, prune_graph_out_degree)
         self.assertIs(metric.operators.medoid_index, medoid_index)
         self.assertIs(metric.operators.medoid, medoid)
         self.assertIs(metric.operators.representative_indices, representative_indices)
@@ -87,6 +89,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
+        self.assertIs(metric.prune_graph_out_degree, prune_graph_out_degree)
         self.assertIs(metric.medoid_index, medoid_index)
         self.assertIs(metric.medoid, medoid)
         self.assertIs(metric.range_neighbors, range_neighbors)
@@ -109,6 +112,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("exact_knn_graph_edges", metric.__all__)
         self.assertIn("exact_radius_graph", metric.__all__)
         self.assertIn("exact_radius_graph_edges", metric.__all__)
+        self.assertIn("prune_graph_out_degree", metric.__all__)
         self.assertIn("medoid_index", metric.__all__)
         self.assertIn("medoid", metric.__all__)
         self.assertIn("representative_indices", metric.__all__)
@@ -218,9 +222,25 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIsNone(knn_graph.metadata.radius)
         self.assertEqual(knn_graph.metadata.edge_payload, "metric_distance")
         self.assertEqual(knn_graph.metadata.weighting, "none")
+        self.assertIsNone(knn_graph.metadata.max_out_degree)
+        self.assertEqual(knn_graph.metadata.sparsification, "none")
         self.assertEqual(knn_graph.metadata.symmetrization, "none")
         self.assertEqual(knn_graph.metadata.normalization, "none")
         self.assertEqual(knn_graph.metadata.tie_break, "distance_then_target_index")
+
+        wide_knn_graph = exact_knn_graph(records, cumulative_transport_distance, 2)
+        pruned_graph = prune_graph_out_degree(wide_knn_graph, max_out_degree=1)
+        self.assertEqual(
+            list(pruned_graph.edges),
+            [(0, 3, 0.5), (1, 3, 0.5), (2, 4, 1.5), (3, 0, 0.5), (4, 1, 0.5)],
+        )
+        self.assertTrue(pruned_graph.metadata.directed)
+        self.assertEqual(pruned_graph.metadata.edge_count, len(pruned_graph.edges))
+        self.assertEqual(pruned_graph.metadata.k, 2)
+        self.assertEqual(pruned_graph.metadata.max_out_degree, 1)
+        self.assertEqual(pruned_graph.metadata.sparsification, "out_degree")
+        self.assertEqual(pruned_graph.metadata.tie_break, "source_index_then_distance_then_target_index")
+        self.assertEqual(prune_graph_out_degree(wide_knn_graph, 0).edges, ())
 
         union_graph = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
         self.assertEqual(
@@ -230,8 +250,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertFalse(union_graph.metadata.directed)
         self.assertEqual(union_graph.metadata.edge_count, len(union_graph.edges))
         self.assertEqual(union_graph.metadata.weighting, "minimum_distance")
+        self.assertEqual(union_graph.metadata.sparsification, "none")
         self.assertEqual(union_graph.metadata.symmetrization, "union")
         self.assertEqual(union_graph.metadata.tie_break, "source_index_then_target_index")
+        with self.assertRaises(ValueError):
+            prune_graph_out_degree(union_graph, 1)
 
         mutual_graph = symmetrize_graph(knn_graph, policy="mutual", weighting="minimum_distance")
         self.assertEqual(list(mutual_graph.edges), [(0, 3, 0.5)])
@@ -248,6 +271,7 @@ class RevivalApiTest(unittest.TestCase):
                 exact=True,
                 edge_payload="metric_distance",
                 weighting="none",
+                sparsification="none",
                 symmetrization="none",
                 normalization="none",
             ),
@@ -282,6 +306,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(radius_graph.metadata.radius, 0.5)
         self.assertEqual(radius_graph.metadata.edge_payload, "metric_distance")
         self.assertEqual(radius_graph.metadata.weighting, "none")
+        self.assertIsNone(radius_graph.metadata.max_out_degree)
+        self.assertEqual(radius_graph.metadata.sparsification, "none")
         self.assertEqual(radius_graph.metadata.symmetrization, "none")
         self.assertEqual(radius_graph.metadata.normalization, "none")
         self.assertEqual(radius_graph.metadata.tie_break, "source_then_target_index")
@@ -350,8 +376,12 @@ class RevivalApiTest(unittest.TestCase):
             exact_knn_graph_edges(records, absolute_distance, 4)
         with self.assertRaises(TypeError):
             exact_knn_graph_edges(records, absolute_distance, 1.5)
+        with self.assertRaises(TypeError):
+            prune_graph_out_degree(exact_knn_graph(records, absolute_distance, 1), 1.5)
         with self.assertRaises(ValueError):
             exact_radius_graph_edges(records, absolute_distance, -1)
+        with self.assertRaises(ValueError):
+            prune_graph_out_degree(exact_knn_graph(records, absolute_distance, 1), -1)
         with self.assertRaises(IndexError):
             representative_indices(records, absolute_distance, 1, seed_index=-1)
         with self.assertRaises(IndexError):

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -153,9 +153,35 @@ int main()
     assert(!knn_graph.metadata.radius.has_value());
     assert(knn_graph.metadata.edge_payload == "metric_distance");
     assert(knn_graph.metadata.weighting == "none");
+    assert(!knn_graph.metadata.max_out_degree.has_value());
+    assert(knn_graph.metadata.sparsification == "none");
     assert(knn_graph.metadata.symmetrization == "none");
     assert(knn_graph.metadata.normalization == "none");
     assert(knn_graph.metadata.tie_break == "distance_then_target_index");
+
+    const auto pruned_knn_graph = metric::operators::prune_graph_out_degree(knn_graph, 1);
+    const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_pruned_knn_edges = {
+        {0, 1, 1},
+        {1, 0, 1},
+        {2, 1, 1},
+        {3, 2, 1},
+        {4, 3, 1},
+    };
+    assert(pruned_knn_graph.edges == expected_pruned_knn_edges);
+    assert(pruned_knn_graph.metadata.directed);
+    assert(pruned_knn_graph.metadata.edge_count == expected_pruned_knn_edges.size());
+    assert(pruned_knn_graph.metadata.k.has_value());
+    assert(pruned_knn_graph.metadata.k.value() == 2);
+    assert(pruned_knn_graph.metadata.max_out_degree.has_value());
+    assert(pruned_knn_graph.metadata.max_out_degree.value() == 1);
+    assert(pruned_knn_graph.metadata.sparsification == "out_degree");
+    assert(pruned_knn_graph.metadata.tie_break == "source_index_then_distance_then_target_index");
+
+    const auto empty_pruned_graph = metric::operators::prune_graph_out_degree(knn_graph, 0);
+    assert(empty_pruned_graph.edges.empty());
+    assert(empty_pruned_graph.metadata.edge_count == 0);
+    assert(empty_pruned_graph.metadata.max_out_degree.has_value());
+    assert(empty_pruned_graph.metadata.max_out_degree.value() == 0);
 
     const auto one_neighbor_graph = metric::operators::exact_knn_graph(line, AbsoluteDistance{}, 1);
     const auto union_graph = metric::operators::symmetrize_graph(one_neighbor_graph, "union", "minimum_distance");
@@ -169,8 +195,17 @@ int main()
     assert(!union_graph.metadata.directed);
     assert(union_graph.metadata.edge_count == expected_union_edges.size());
     assert(union_graph.metadata.weighting == "minimum_distance");
+    assert(union_graph.metadata.sparsification == "none");
     assert(union_graph.metadata.symmetrization == "union");
     assert(union_graph.metadata.tie_break == "source_index_then_target_index");
+
+    bool rejected_undirected_pruning = false;
+    try {
+        metric::operators::prune_graph_out_degree(union_graph, 1);
+    } catch (const std::invalid_argument &) {
+        rejected_undirected_pruning = true;
+    }
+    assert(rejected_undirected_pruning);
 
     const auto mutual_graph = metric::operators::symmetrize_graph(one_neighbor_graph, "mutual", "minimum_distance");
     const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_mutual_edges = {
@@ -193,6 +228,7 @@ int main()
     asymmetric_graph.metadata.exact = true;
     asymmetric_graph.metadata.edge_payload = "metric_distance";
     asymmetric_graph.metadata.weighting = "none";
+    asymmetric_graph.metadata.sparsification = "none";
     asymmetric_graph.metadata.symmetrization = "none";
     asymmetric_graph.metadata.normalization = "none";
 
@@ -254,6 +290,8 @@ int main()
     assert(radius_graph.metadata.radius.value() == 1);
     assert(radius_graph.metadata.edge_payload == "metric_distance");
     assert(radius_graph.metadata.weighting == "none");
+    assert(!radius_graph.metadata.max_out_degree.has_value());
+    assert(radius_graph.metadata.sparsification == "none");
     assert(radius_graph.metadata.symmetrization == "none");
     assert(radius_graph.metadata.normalization == "none");
     assert(radius_graph.metadata.tie_break == "source_then_target_index");


### PR DESCRIPTION
## Summary
- add C++ and Python `prune_graph_out_degree` helpers for deterministic directed graph sparsification
- extend graph construction metadata with `max_out_degree` and `sparsification`
- cover exact expected pruning fixtures, invalid undirected pruning, docs, roadmap, and changelog

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `cmake --preset core && cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/graph-prune-wheel`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/graph-prune-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`