### PR TITLE
Add graph degree diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add C++ and Python `exact_knn_graph_edges` and `exact_radius_graph_edges` helpers using exhaustive pairwise distances and deterministic edge ordering.
 - Add C++ and Python `exact_knn_graph` and `exact_radius_graph` result objects with construction metadata for exact graph helpers.
+- Add C++ and Python `graph_degree_diagnostics` helpers for deterministic graph degree diagnostics.
 - Add C++ and Python `symmetrize_graph` helpers for deterministic graph `union` and `mutual` policies with reciprocal distance weighting.
 - Add C++ and Python `prune_graph_out_degree` helpers for deterministic directed graph sparsification.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::pairwise_distance_matrix`
 - `metric::operators::nearest_neighbors`
 - `metric::operators::range_neighbors`
+- `metric::operators::GraphDegreeDiagnostics`
 - `metric::operators::GraphConstructionResult`
 - `metric::operators::GraphConstructionMetadata`
+- `metric::operators::graph_degree_diagnostics`
 - `metric::operators::exact_knn_graph`
 - `metric::operators::exact_knn_graph_edges`
 - `metric::operators::exact_radius_graph`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -69,6 +69,7 @@ auto knn_graph = metric::operators::exact_knn_graph(records, metric::Edit<std::s
 auto knn_edges = metric::operators::exact_knn_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto radius_graph = metric::operators::exact_radius_graph(records, metric::Edit<std::string>{}, 1);
 auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
+auto degree_info = metric::operators::graph_degree_diagnostics(knn_graph);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 auto pruned = metric::operators::prune_graph_out_degree(
     metric::operators::exact_knn_graph(records, metric::Edit<std::string>{}, 2),
@@ -84,7 +85,7 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -93,6 +94,8 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` values with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, sparsification policy, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+
+`graph_degree_diagnostics` returns `GraphDegreeDiagnostics` for a graph construction result. Directed graphs report `out_degrees`, `in_degrees`, combined endpoint `degrees`, isolated count, max degree, average degree, and degree policy `directed_in_out`. Undirected graph results report endpoint `degrees` with zero-filled in/out vectors and degree policy `undirected_endpoint`.
 
 `symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph degree diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -49,12 +49,14 @@ space.rnn(query, radius=1)
 from metric.operators import (
     GraphConstructionMetadata,
     GraphConstructionResult,
+    GraphDegreeDiagnostics,
     coverage_representative_indices,
     coverage_representatives,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    graph_degree_diagnostics,
     intrinsic_dimension,
     medoid,
     medoid_index,
@@ -76,6 +78,7 @@ knn_graph = exact_knn_graph(records, Edit(), k=1)
 knn_edges = exact_knn_graph_edges(records, Edit(), k=1)
 radius_graph = exact_radius_graph(records, Edit(), radius=1)
 radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
+degree_info = graph_degree_diagnostics(knn_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 pruned = prune_graph_out_degree(exact_knn_graph(records, Edit(), k=2), max_out_degree=1)
 selected_ids = representative_indices(records, Edit(), k=2)
@@ -96,6 +99,8 @@ dimension = intrinsic_dimension(records, Edit())
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` objects with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, sparsification policy, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+
+`graph_degree_diagnostics` returns `GraphDegreeDiagnostics` for a graph construction result. Directed graphs report `out_degrees`, `in_degrees`, combined endpoint `degrees`, isolated count, max degree, average degree, and degree policy `directed_in_out`. Undirected graph results report endpoint `degrees` with zero-filled in/out vectors and degree policy `undirected_endpoint`.
 
 `symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,7 +4,7 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
-The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
+The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `graph_degree_diagnostics` reports deterministic degree diagnostics for graph construction results. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
 
 ## Required Metadata
 
@@ -49,6 +49,18 @@ A radius graph connects records whose metric distance is within a threshold.
 An exact directed radius graph has edge `i -> j` when `distance(i, j) <= radius`, subject to a documented self-loop policy. An exact undirected radius graph uses the same threshold but stores one undirected relationship for each qualifying pair.
 
 A radius graph is approximate when it is built from candidate pruning, approximate neighbors, or any method that may miss qualifying pairs.
+
+## Degree Diagnostics
+
+Graph degree diagnostics are descriptive checks over an existing graph result. They do not prove connectivity, quality, recall, or metric preservation by themselves.
+
+`graph_degree_diagnostics` returns record count, edge count, direction policy, per-record endpoint degrees, per-record out-degrees, per-record in-degrees, isolated-record count, max degree, average degree, and a named degree policy.
+
+For directed graph results, out-degree counts stored edges from each source, in-degree counts stored edges into each target, and endpoint degree is `out + in`. The degree policy is `directed_in_out`.
+
+For undirected graph results, each stored edge contributes one endpoint count to each endpoint. The in/out vectors are zero-filled because the stored source and target are orientation conventions, not directed neighbor contracts. The degree policy is `undirected_endpoint`.
+
+The helper validates that every edge endpoint is within `metadata.record_count`. Invalid endpoint IDs are rejected because degree diagnostics must be tied to the source record set.
 
 ## Degree Sparsification
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -26,6 +26,7 @@ auto radius_graph = metric::operators::exact_radius_graph(records, AbsoluteDista
 
 auto knn_edges = knn_graph.edges;
 auto radius_edges = radius_graph.edges;
+auto degree_info = metric::operators::graph_degree_diagnostics(knn_graph);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 auto pruned = metric::operators::prune_graph_out_degree(
     metric::operators::exact_knn_graph(records, AbsoluteDistance{}, 2),
@@ -35,7 +36,7 @@ auto pruned = metric::operators::prune_graph_out_degree(
 Python shape:
 
 ```python
-from metric import exact_knn_graph, exact_radius_graph, prune_graph_out_degree, symmetrize_graph
+from metric import exact_knn_graph, exact_radius_graph, graph_degree_diagnostics, prune_graph_out_degree, symmetrize_graph
 
 records = [0, 1, 2, 3, 4]
 
@@ -47,6 +48,7 @@ radius_graph = exact_radius_graph(records, absolute_distance, radius=1)
 
 knn_edges = knn_graph.edges
 radius_edges = radius_graph.edges
+degree_info = graph_degree_diagnostics(knn_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 pruned = prune_graph_out_degree(exact_knn_graph(records, absolute_distance, k=2), max_out_degree=1)
 ```
@@ -76,6 +78,8 @@ For `records = [0, 1, 2, 3, 4]`, symmetrizing the exact kNN graph with `k=1` and
 (2, 3, 1)
 (3, 4, 1)
 ```
+
+The directed `k=1` graph has out-degrees `(1, 1, 1, 1, 1)`, in-degrees `(1, 2, 1, 1, 0)`, endpoint degrees `(2, 3, 2, 2, 1)`, max degree `3`, average degree `2.0`, and degree policy `directed_in_out`.
 
 For the same records, pruning the exact kNN graph from `k=2` to `max_out_degree=1` produces directed edges:
 

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -82,11 +82,12 @@ Current promoted base:
 - C++ and Python `exact_knn_graph` / `exact_radius_graph` return graph construction result objects with directed edge lists and construction metadata.
 - C++ and Python `symmetrize_graph` promotes deterministic `union` and `mutual` policies with minimum-distance and maximum-distance reciprocal weighting.
 - C++ and Python `prune_graph_out_degree` promotes deterministic out-degree sparsification for directed graph construction results.
+- C++ and Python `graph_degree_diagnostics` promotes deterministic degree diagnostics for directed and undirected graph construction results.
 
 Candidate strategies:
 
 - additional sparsification primitives with documented connectivity or stretch assumptions
-- graph diagnostics such as connectivity, degree distribution, and edge stretch
+- graph diagnostics such as connectivity and edge stretch
 
 Promotion evidence:
 
@@ -184,6 +185,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph diagnostics such as connectivity and degree distribution
+- add graph diagnostics such as connectivity and edge stretch
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -57,6 +57,19 @@ template <typename Distance, typename RadiusValue = Distance> struct GraphConstr
 	GraphConstructionMetadata<Distance, RadiusValue> metadata;
 };
 
+struct GraphDegreeDiagnostics {
+	std::size_t record_count{};
+	std::size_t edge_count{};
+	bool directed{true};
+	std::vector<std::size_t> degrees;
+	std::vector<std::size_t> out_degrees;
+	std::vector<std::size_t> in_degrees;
+	std::size_t isolated_count{};
+	std::size_t max_degree{};
+	double average_degree{};
+	std::string degree_policy;
+};
+
 template <typename Container, typename Metric>
 auto pairwise_distance_matrix(const Container &records, Metric distance)
 	-> std::vector<std::vector<typename detail::finite_space_t<Container, Metric>::distance_type>>
@@ -334,6 +347,51 @@ auto prune_graph_out_degree(const GraphConstructionResult<Distance, RadiusValue>
 	}
 
 	result.metadata.edge_count = result.edges.size();
+	return result;
+}
+
+template <typename Distance, typename RadiusValue>
+auto graph_degree_diagnostics(const GraphConstructionResult<Distance, RadiusValue> &graph) -> GraphDegreeDiagnostics
+{
+	GraphDegreeDiagnostics result;
+	result.record_count = graph.metadata.record_count;
+	result.edge_count = graph.edges.size();
+	result.directed = graph.metadata.directed;
+	result.degrees.assign(result.record_count, 0);
+	result.out_degrees.assign(result.record_count, 0);
+	result.in_degrees.assign(result.record_count, 0);
+	result.degree_policy = graph.metadata.directed ? "directed_in_out" : "undirected_endpoint";
+
+	for (const auto &edge : graph.edges) {
+		const auto source_index = std::get<0>(edge);
+		const auto target_index = std::get<1>(edge);
+		if (source_index >= result.record_count || target_index >= result.record_count) {
+			throw std::invalid_argument("graph edge index exceeds metadata record_count");
+		}
+
+		if (graph.metadata.directed) {
+			++result.out_degrees[source_index];
+			++result.in_degrees[target_index];
+			++result.degrees[source_index];
+			++result.degrees[target_index];
+		} else {
+			++result.degrees[source_index];
+			++result.degrees[target_index];
+		}
+	}
+
+	std::size_t total_degree = 0;
+	for (const auto degree : result.degrees) {
+		total_degree += degree;
+		result.max_degree = std::max(result.max_degree, degree);
+		if (degree == 0) {
+			++result.isolated_count;
+		}
+	}
+	if (result.record_count != 0) {
+		result.average_degree = static_cast<double>(total_degree) / static_cast<double>(result.record_count);
+	}
+
 	return result;
 }
 

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 from . import mappings, metrics, operators, spaces, transforms
 from .metrics import Edit
 from .operators import (
+    GraphDegreeDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
     coverage_representative_indices,
@@ -28,6 +29,7 @@ from .operators import (
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    graph_degree_diagnostics,
     intrinsic_dimension,
     medoid,
     medoid_index,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -36,6 +36,22 @@ class GraphConstructionResult:
     metadata: GraphConstructionMetadata
 
 
+@dataclass(frozen=True)
+class GraphDegreeDiagnostics:
+    """Degree diagnostics for a graph construction result."""
+
+    record_count: int
+    edge_count: int
+    directed: bool
+    degrees: tuple
+    out_degrees: tuple
+    in_degrees: tuple
+    isolated_count: int
+    max_degree: int
+    average_degree: float
+    degree_policy: str
+
+
 def pairwise_distance_matrix(records, metric):
     return FiniteMetricSpace(records, metric).pairwise_distances()
 
@@ -284,6 +300,50 @@ def prune_graph_out_degree(graph, max_out_degree):
     )
 
 
+def graph_degree_diagnostics(graph):
+    """Compute deterministic degree diagnostics for a graph construction result."""
+    record_count = graph.metadata.record_count
+    degrees = [0] * record_count
+    out_degrees = [0] * record_count
+    in_degrees = [0] * record_count
+
+    for source_index, target_index, _distance in graph.edges:
+        if (
+            source_index < 0
+            or target_index < 0
+            or source_index >= record_count
+            or target_index >= record_count
+        ):
+            raise ValueError("graph edge index exceeds metadata record_count")
+
+        if graph.metadata.directed:
+            out_degrees[source_index] += 1
+            in_degrees[target_index] += 1
+            degrees[source_index] += 1
+            degrees[target_index] += 1
+        else:
+            degrees[source_index] += 1
+            degrees[target_index] += 1
+
+    isolated_count = sum(1 for degree in degrees if degree == 0)
+    max_degree = max(degrees, default=0)
+    average_degree = sum(degrees) / record_count if record_count else 0.0
+    degree_policy = "directed_in_out" if graph.metadata.directed else "undirected_endpoint"
+
+    return GraphDegreeDiagnostics(
+        record_count=record_count,
+        edge_count=len(graph.edges),
+        directed=graph.metadata.directed,
+        degrees=tuple(degrees),
+        out_degrees=tuple(out_degrees),
+        in_degrees=tuple(in_degrees),
+        isolated_count=isolated_count,
+        max_degree=max_degree,
+        average_degree=average_degree,
+        degree_policy=degree_policy,
+    )
+
+
 def representative_indices(records, metric, k, seed_index=0):
     """Select representative record IDs with deterministic farthest-first traversal."""
     records = list(records)
@@ -455,8 +515,10 @@ def intrinsic_dimension_from_distances(distances):
 
 
 __all__ = [
+    "GraphDegreeDiagnostics",
     "GraphConstructionMetadata",
     "GraphConstructionResult",
+    "graph_degree_diagnostics",
     "intrinsic_dimension",
     "intrinsic_dimension_from_distances",
     "coverage_representative_indices",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -9,6 +9,7 @@ import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
 from metric.operators import (
+    GraphDegreeDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
     coverage_representative_indices,
@@ -17,6 +18,7 @@ from metric.operators import (
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    graph_degree_diagnostics,
     intrinsic_dimension,
     medoid,
     medoid_index,
@@ -62,12 +64,14 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.spaces.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
+        self.assertIs(metric.operators.GraphDegreeDiagnostics, GraphDegreeDiagnostics)
         self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
         self.assertIs(metric.operators.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.operators.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.operators.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.operators.exact_radius_graph_edges, exact_radius_graph_edges)
+        self.assertIs(metric.operators.graph_degree_diagnostics, graph_degree_diagnostics)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.operators.prune_graph_out_degree, prune_graph_out_degree)
         self.assertIs(metric.operators.medoid_index, medoid_index)
@@ -82,12 +86,14 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
+        self.assertIs(metric.GraphDegreeDiagnostics, GraphDegreeDiagnostics)
         self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
         self.assertIs(metric.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.exact_radius_graph_edges, exact_radius_graph_edges)
+        self.assertIs(metric.graph_degree_diagnostics, graph_degree_diagnostics)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.prune_graph_out_degree, prune_graph_out_degree)
         self.assertIs(metric.medoid_index, medoid_index)
@@ -106,12 +112,14 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("Space", metric.__all__)
         self.assertIn("mappings", metric.__all__)
         self.assertIn("transforms", metric.__all__)
+        self.assertIn("GraphDegreeDiagnostics", metric.__all__)
         self.assertIn("GraphConstructionMetadata", metric.__all__)
         self.assertIn("GraphConstructionResult", metric.__all__)
         self.assertIn("exact_knn_graph", metric.__all__)
         self.assertIn("exact_knn_graph_edges", metric.__all__)
         self.assertIn("exact_radius_graph", metric.__all__)
         self.assertIn("exact_radius_graph_edges", metric.__all__)
+        self.assertIn("graph_degree_diagnostics", metric.__all__)
         self.assertIn("prune_graph_out_degree", metric.__all__)
         self.assertIn("medoid_index", metric.__all__)
         self.assertIn("medoid", metric.__all__)
@@ -242,6 +250,19 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(pruned_graph.metadata.tie_break, "source_index_then_distance_then_target_index")
         self.assertEqual(prune_graph_out_degree(wide_knn_graph, 0).edges, ())
 
+        degree_diagnostics = graph_degree_diagnostics(knn_graph)
+        self.assertIsInstance(degree_diagnostics, GraphDegreeDiagnostics)
+        self.assertEqual(degree_diagnostics.record_count, len(records))
+        self.assertEqual(degree_diagnostics.edge_count, len(knn_graph.edges))
+        self.assertTrue(degree_diagnostics.directed)
+        self.assertEqual(degree_diagnostics.out_degrees, (1, 1, 1, 1, 1))
+        self.assertEqual(degree_diagnostics.in_degrees, (1, 1, 0, 2, 1))
+        self.assertEqual(degree_diagnostics.degrees, (2, 2, 1, 3, 2))
+        self.assertEqual(degree_diagnostics.isolated_count, 0)
+        self.assertEqual(degree_diagnostics.max_degree, 3)
+        self.assertAlmostEqual(degree_diagnostics.average_degree, 2.0)
+        self.assertEqual(degree_diagnostics.degree_policy, "directed_in_out")
+
         union_graph = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
         self.assertEqual(
             list(union_graph.edges),
@@ -255,6 +276,17 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(union_graph.metadata.tie_break, "source_index_then_target_index")
         with self.assertRaises(ValueError):
             prune_graph_out_degree(union_graph, 1)
+
+        undirected_diagnostics = graph_degree_diagnostics(union_graph)
+        self.assertFalse(undirected_diagnostics.directed)
+        self.assertEqual(undirected_diagnostics.degrees, (1, 2, 1, 2, 2))
+        self.assertEqual(undirected_diagnostics.out_degrees, (0, 0, 0, 0, 0))
+        self.assertEqual(undirected_diagnostics.in_degrees, (0, 0, 0, 0, 0))
+        self.assertEqual(undirected_diagnostics.edge_count, len(union_graph.edges))
+        self.assertEqual(undirected_diagnostics.isolated_count, 0)
+        self.assertEqual(undirected_diagnostics.max_degree, 2)
+        self.assertAlmostEqual(undirected_diagnostics.average_degree, 1.6)
+        self.assertEqual(undirected_diagnostics.degree_policy, "undirected_endpoint")
 
         mutual_graph = symmetrize_graph(knn_graph, policy="mutual", weighting="minimum_distance")
         self.assertEqual(list(mutual_graph.edges), [(0, 3, 0.5)])
@@ -288,6 +320,20 @@ class RevivalApiTest(unittest.TestCase):
             symmetrize_graph(asymmetric_graph, policy="invalid", weighting="minimum_distance")
         with self.assertRaises(ValueError):
             symmetrize_graph(asymmetric_graph, policy="union", weighting="average_distance")
+
+        invalid_graph = GraphConstructionResult(
+            edges=((0, 3, 1),),
+            metadata=GraphConstructionMetadata(
+                strategy="synthetic",
+                record_count=2,
+                edge_count=1,
+                directed=True,
+                self_loops=False,
+                exact=True,
+            ),
+        )
+        with self.assertRaises(ValueError):
+            graph_degree_diagnostics(invalid_graph)
 
         self.assertEqual(
             exact_radius_graph_edges(records, cumulative_transport_distance, 0.5),

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -184,6 +184,18 @@ int main()
     assert(empty_pruned_graph.metadata.max_out_degree.value() == 0);
 
     const auto one_neighbor_graph = metric::operators::exact_knn_graph(line, AbsoluteDistance{}, 1);
+    const auto directed_degrees = metric::operators::graph_degree_diagnostics(one_neighbor_graph);
+    assert(directed_degrees.record_count == line.size());
+    assert(directed_degrees.edge_count == one_neighbor_graph.edges.size());
+    assert(directed_degrees.directed);
+    assert((directed_degrees.out_degrees == std::vector<std::size_t>{1, 1, 1, 1, 1}));
+    assert((directed_degrees.in_degrees == std::vector<std::size_t>{1, 2, 1, 1, 0}));
+    assert((directed_degrees.degrees == std::vector<std::size_t>{2, 3, 2, 2, 1}));
+    assert(directed_degrees.isolated_count == 0);
+    assert(directed_degrees.max_degree == 3);
+    assert(std::abs(directed_degrees.average_degree - 2.0) < 1e-12);
+    assert(directed_degrees.degree_policy == "directed_in_out");
+
     const auto union_graph = metric::operators::symmetrize_graph(one_neighbor_graph, "union", "minimum_distance");
     const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_union_edges = {
         {0, 1, 1},
@@ -198,6 +210,17 @@ int main()
     assert(union_graph.metadata.sparsification == "none");
     assert(union_graph.metadata.symmetrization == "union");
     assert(union_graph.metadata.tie_break == "source_index_then_target_index");
+
+    const auto undirected_degrees = metric::operators::graph_degree_diagnostics(union_graph);
+    assert(!undirected_degrees.directed);
+    assert((undirected_degrees.degrees == std::vector<std::size_t>{1, 2, 2, 2, 1}));
+    assert((undirected_degrees.out_degrees == std::vector<std::size_t>{0, 0, 0, 0, 0}));
+    assert((undirected_degrees.in_degrees == std::vector<std::size_t>{0, 0, 0, 0, 0}));
+    assert(undirected_degrees.edge_count == expected_union_edges.size());
+    assert(undirected_degrees.isolated_count == 0);
+    assert(undirected_degrees.max_degree == 2);
+    assert(std::abs(undirected_degrees.average_degree - 1.6) < 1e-12);
+    assert(undirected_degrees.degree_policy == "undirected_endpoint");
 
     bool rejected_undirected_pruning = false;
     try {
@@ -231,6 +254,22 @@ int main()
     asymmetric_graph.metadata.sparsification = "none";
     asymmetric_graph.metadata.symmetrization = "none";
     asymmetric_graph.metadata.normalization = "none";
+
+    metric::operators::GraphConstructionResult<int> invalid_graph;
+    invalid_graph.edges = {
+        {0, 3, 1},
+    };
+    invalid_graph.metadata.record_count = 2;
+    invalid_graph.metadata.edge_count = invalid_graph.edges.size();
+    invalid_graph.metadata.directed = true;
+
+    bool rejected_invalid_degree_graph = false;
+    try {
+        metric::operators::graph_degree_diagnostics(invalid_graph);
+    } catch (const std::invalid_argument &) {
+        rejected_invalid_degree_graph = true;
+    }
+    assert(rejected_invalid_degree_graph);
 
     const auto minimum_weighted_graph =
         metric::operators::symmetrize_graph(asymmetric_graph, "union", "minimum_distance");


### PR DESCRIPTION
## Summary
- add C++ and Python `graph_degree_diagnostics` helpers with `GraphDegreeDiagnostics` result objects
- report directed in/out/endpoint degrees and undirected endpoint degrees with deterministic policies
- cover expected degree fixtures, invalid endpoint validation, docs, roadmap, stability, and changelog

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`
- `METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/graph-degree-diagnostics-wheel`
- `build/python-venv/bin/python -m pip install --force-reinstall --no-deps build/graph-degree-diagnostics-wheel/metric_space-0.3.2-cp312-cp312-macosx_26_0_arm64.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`