### PR TITLE
Document graph degree diagnostics status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -31,6 +31,7 @@ The current local tree implements the first revival slice:
 - C++ and Python exact graph result objects with construction metadata
 - C++ and Python graph symmetrization helpers with deterministic weighting policies
 - C++ and Python graph out-degree pruning helpers with deterministic sparsification metadata
+- C++ and Python graph degree diagnostics with deterministic degree-policy metadata
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -186,6 +187,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ and Python exact graph result objects with construction metadata and CI coverage, merged as `d1fcdb4243101d316df707b2e658657390bea42c`
 - C++ and Python graph symmetrization helpers with deterministic weighting-policy fixtures and CI coverage, merged as `ab09ce4662f0de46c86396752f7d22c8de42c7c9`
 - C++ and Python graph out-degree pruning helpers with deterministic sparsification fixtures and CI coverage, merged as `1bcbc7f818efea4014f54f6e8738436fe9d7c25d`
+- C++ and Python graph degree diagnostics with deterministic degree-policy fixtures and CI coverage, merged as `2947be9ec6faf2ffa1f1c3428598ea77e18bdbd5`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the merged graph degree diagnostics helpers in the revival status scope
- add the post-v0.3.2 master progress entry for PR #370

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`