### PR TITLE
Add graph connectivity diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Run every promoted Python metric-space example from the core Python API tests so wheel and PyPI build gates share the same example coverage.
 - Add C++ and Python `exact_knn_graph_edges` and `exact_radius_graph_edges` helpers using exhaustive pairwise distances and deterministic edge ordering.
 - Add C++ and Python `exact_knn_graph` and `exact_radius_graph` result objects with construction metadata for exact graph helpers.
+- Add C++ and Python `graph_connectivity_diagnostics` helpers for deterministic graph connectivity diagnostics.
 - Add C++ and Python `graph_degree_diagnostics` helpers for deterministic graph degree diagnostics.
 - Add C++ and Python `symmetrize_graph` helpers for deterministic graph `union` and `mutual` policies with reciprocal distance weighting.
 - Add C++ and Python `prune_graph_out_degree` helpers for deterministic directed graph sparsification.

--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::pairwise_distance_matrix`
 - `metric::operators::nearest_neighbors`
 - `metric::operators::range_neighbors`
+- `metric::operators::GraphConnectivityDiagnostics`
 - `metric::operators::GraphDegreeDiagnostics`
 - `metric::operators::GraphConstructionResult`
 - `metric::operators::GraphConstructionMetadata`
+- `metric::operators::graph_connectivity_diagnostics`
 - `metric::operators::graph_degree_diagnostics`
 - `metric::operators::exact_knn_graph`
 - `metric::operators::exact_knn_graph_edges`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -69,6 +69,7 @@ auto knn_graph = metric::operators::exact_knn_graph(records, metric::Edit<std::s
 auto knn_edges = metric::operators::exact_knn_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto radius_graph = metric::operators::exact_radius_graph(records, metric::Edit<std::string>{}, 1);
 auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
+auto connectivity_info = metric::operators::graph_connectivity_diagnostics(knn_graph);
 auto degree_info = metric::operators::graph_degree_diagnostics(knn_graph);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 auto pruned = metric::operators::prune_graph_out_degree(
@@ -85,7 +86,7 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -94,6 +95,8 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` values with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, sparsification policy, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+
+`graph_connectivity_diagnostics` returns `GraphConnectivityDiagnostics` for a graph construction result. It reports deterministic component labels, component count, isolated-record count, largest component size, connected status, and connectivity policy. Directed graph results use weak undirected reachability over stored edges; undirected graph results use endpoint reachability.
 
 `graph_degree_diagnostics` returns `GraphDegreeDiagnostics` for a graph construction result. Directed graphs report `out_degrees`, `in_degrees`, combined endpoint `degrees`, isolated count, max degree, average degree, and degree policy `directed_in_out`. Undirected graph results report endpoint `degrees` with zero-filled in/out vectors and degree policy `undirected_endpoint`.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph degree diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph connectivity diagnostics, graph degree diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -49,6 +49,7 @@ space.rnn(query, radius=1)
 from metric.operators import (
     GraphConstructionMetadata,
     GraphConstructionResult,
+    GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
     coverage_representative_indices,
     coverage_representatives,
@@ -56,6 +57,7 @@ from metric.operators import (
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     intrinsic_dimension,
     medoid,
@@ -78,6 +80,7 @@ knn_graph = exact_knn_graph(records, Edit(), k=1)
 knn_edges = exact_knn_graph_edges(records, Edit(), k=1)
 radius_graph = exact_radius_graph(records, Edit(), radius=1)
 radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
+connectivity_info = graph_connectivity_diagnostics(knn_graph)
 degree_info = graph_degree_diagnostics(knn_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 pruned = prune_graph_out_degree(exact_knn_graph(records, Edit(), k=2), max_out_degree=1)
@@ -99,6 +102,8 @@ dimension = intrinsic_dimension(records, Edit())
 `separated_representative_indices` and `separated_representatives` scan records in order and keep a candidate when it is at least `minimum_distance` from every selected representative. This is deterministic redundancy-threshold reduction, not an optimal packing proof.
 
 `exact_knn_graph` and `exact_radius_graph` return `GraphConstructionResult` objects with `.edges` and `.metadata`. The metadata records the construction strategy, record count, edge count, directed/self-loop/exact policy, the active `k` or `radius` parameter, edge payload meaning, sparsification policy, symmetrization policy, normalization policy, and the tie-breaking rule. `exact_knn_graph_edges` and `exact_radius_graph_edges` remain convenience helpers that return only directed edge tuples shaped as `(source_index, target_index, distance)`. Exact graph helpers exclude self-loops, preserve source-record order, and resolve equal kNN distances by target record order.
+
+`graph_connectivity_diagnostics` returns `GraphConnectivityDiagnostics` for a graph construction result. It reports deterministic component labels, component count, isolated-record count, largest component size, connected status, and connectivity policy. Directed graph results use weak undirected reachability over stored edges; undirected graph results use endpoint reachability.
 
 `graph_degree_diagnostics` returns `GraphDegreeDiagnostics` for a graph construction result. Directed graphs report `out_degrees`, `in_degrees`, combined endpoint `degrees`, isolated count, max degree, average degree, and degree policy `directed_in_out`. Undirected graph results report endpoint `degrees` with zero-filled in/out vectors and degree policy `undirected_endpoint`.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,7 +4,7 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
-The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `graph_degree_diagnostics` reports deterministic degree diagnostics for graph construction results. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
+The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `graph_connectivity_diagnostics` and `graph_degree_diagnostics` report deterministic diagnostics for graph construction results. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
 
 ## Required Metadata
 
@@ -61,6 +61,18 @@ For directed graph results, out-degree counts stored edges from each source, in-
 For undirected graph results, each stored edge contributes one endpoint count to each endpoint. The in/out vectors are zero-filled because the stored source and target are orientation conventions, not directed neighbor contracts. The degree policy is `undirected_endpoint`.
 
 The helper validates that every edge endpoint is within `metadata.record_count`. Invalid endpoint IDs are rejected because degree diagnostics must be tied to the source record set.
+
+## Connectivity Diagnostics
+
+Graph connectivity diagnostics describe connected components in an existing graph result. They do not prove neighbor recall, edge-stretch quality, or metric preservation by themselves.
+
+`graph_connectivity_diagnostics` returns record count, edge count, direction policy, deterministic per-record component labels, component count, isolated-record count, largest component size, connected status, and a named connectivity policy.
+
+For directed graph results, connectivity is weak connectivity over the stored edges. Direction is ignored for component membership because exact kNN and radius graph helpers emit directed edges even when the user wants to know whether the representation covers one connected record set. The connectivity policy is `weak_undirected_reachability`.
+
+For undirected graph results, each stored edge contributes one endpoint relationship between its source and target. The connectivity policy is `undirected_reachability`.
+
+Component labels are assigned by scanning source record IDs in order. A record with no incident stored edge is counted as isolated. The helper validates that every edge endpoint is within `metadata.record_count`.
 
 ## Degree Sparsification
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -26,6 +26,7 @@ auto radius_graph = metric::operators::exact_radius_graph(records, AbsoluteDista
 
 auto knn_edges = knn_graph.edges;
 auto radius_edges = radius_graph.edges;
+auto connectivity_info = metric::operators::graph_connectivity_diagnostics(knn_graph);
 auto degree_info = metric::operators::graph_degree_diagnostics(knn_graph);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 auto pruned = metric::operators::prune_graph_out_degree(
@@ -36,7 +37,7 @@ auto pruned = metric::operators::prune_graph_out_degree(
 Python shape:
 
 ```python
-from metric import exact_knn_graph, exact_radius_graph, graph_degree_diagnostics, prune_graph_out_degree, symmetrize_graph
+from metric import exact_knn_graph, exact_radius_graph, graph_connectivity_diagnostics, graph_degree_diagnostics, prune_graph_out_degree, symmetrize_graph
 
 records = [0, 1, 2, 3, 4]
 
@@ -48,6 +49,7 @@ radius_graph = exact_radius_graph(records, absolute_distance, radius=1)
 
 knn_edges = knn_graph.edges
 radius_edges = radius_graph.edges
+connectivity_info = graph_connectivity_diagnostics(knn_graph)
 degree_info = graph_degree_diagnostics(knn_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 pruned = prune_graph_out_degree(exact_knn_graph(records, absolute_distance, k=2), max_out_degree=1)
@@ -80,6 +82,8 @@ For `records = [0, 1, 2, 3, 4]`, symmetrizing the exact kNN graph with `k=1` and
 ```
 
 The directed `k=1` graph has out-degrees `(1, 1, 1, 1, 1)`, in-degrees `(1, 2, 1, 1, 0)`, endpoint degrees `(2, 3, 2, 2, 1)`, max degree `3`, average degree `2.0`, and degree policy `directed_in_out`.
+
+The same directed `k=1` graph has weak connectivity labels `(0, 0, 0, 0, 0)`, component count `1`, isolated count `0`, largest component size `5`, `connected=True`, and connectivity policy `weak_undirected_reachability`.
 
 For the same records, pruning the exact kNN graph from `k=2` to `max_out_degree=1` produces directed edges:
 

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -83,11 +83,12 @@ Current promoted base:
 - C++ and Python `symmetrize_graph` promotes deterministic `union` and `mutual` policies with minimum-distance and maximum-distance reciprocal weighting.
 - C++ and Python `prune_graph_out_degree` promotes deterministic out-degree sparsification for directed graph construction results.
 - C++ and Python `graph_degree_diagnostics` promotes deterministic degree diagnostics for directed and undirected graph construction results.
+- C++ and Python `graph_connectivity_diagnostics` promotes deterministic connectivity diagnostics for directed and undirected graph construction results.
 
 Candidate strategies:
 
 - additional sparsification primitives with documented connectivity or stretch assumptions
-- graph diagnostics such as connectivity and edge stretch
+- graph diagnostics such as edge stretch
 
 Promotion evidence:
 
@@ -185,6 +186,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph diagnostics such as connectivity and edge stretch
+- add graph diagnostics such as edge stretch
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -70,6 +70,18 @@ struct GraphDegreeDiagnostics {
 	std::string degree_policy;
 };
 
+struct GraphConnectivityDiagnostics {
+	std::size_t record_count{};
+	std::size_t edge_count{};
+	bool directed{true};
+	std::vector<std::size_t> component_labels;
+	std::size_t component_count{};
+	std::size_t isolated_count{};
+	std::size_t largest_component_size{};
+	bool connected{true};
+	std::string connectivity_policy;
+};
+
 template <typename Container, typename Metric>
 auto pairwise_distance_matrix(const Container &records, Metric distance)
 	-> std::vector<std::vector<typename detail::finite_space_t<Container, Metric>::distance_type>>
@@ -391,6 +403,84 @@ auto graph_degree_diagnostics(const GraphConstructionResult<Distance, RadiusValu
 	if (result.record_count != 0) {
 		result.average_degree = static_cast<double>(total_degree) / static_cast<double>(result.record_count);
 	}
+
+	return result;
+}
+
+template <typename Distance, typename RadiusValue>
+auto graph_connectivity_diagnostics(const GraphConstructionResult<Distance, RadiusValue> &graph)
+	-> GraphConnectivityDiagnostics
+{
+	GraphConnectivityDiagnostics result;
+	result.record_count = graph.metadata.record_count;
+	result.edge_count = graph.edges.size();
+	result.directed = graph.metadata.directed;
+	result.component_labels.assign(result.record_count, 0);
+	result.connectivity_policy =
+		graph.metadata.directed ? "weak_undirected_reachability" : "undirected_reachability";
+
+	std::vector<std::size_t> parents(result.record_count);
+	std::vector<bool> has_incident_edge(result.record_count, false);
+	for (std::size_t index = 0; index < result.record_count; ++index) {
+		parents[index] = index;
+	}
+
+	auto find_root = [&parents](std::size_t index) -> std::size_t {
+		while (parents[index] != index) {
+			parents[index] = parents[parents[index]];
+			index = parents[index];
+		}
+		return index;
+	};
+
+	auto union_components = [&parents, &find_root](std::size_t lhs, std::size_t rhs) {
+		const auto lhs_root = find_root(lhs);
+		const auto rhs_root = find_root(rhs);
+		if (lhs_root == rhs_root) {
+			return;
+		}
+		if (lhs_root < rhs_root) {
+			parents[rhs_root] = lhs_root;
+		} else {
+			parents[lhs_root] = rhs_root;
+		}
+	};
+
+	for (const auto &edge : graph.edges) {
+		const auto source_index = std::get<0>(edge);
+		const auto target_index = std::get<1>(edge);
+		if (source_index >= result.record_count || target_index >= result.record_count) {
+			throw std::invalid_argument("graph edge index exceeds metadata record_count");
+		}
+		has_incident_edge[source_index] = true;
+		has_incident_edge[target_index] = true;
+		union_components(source_index, target_index);
+	}
+
+	std::map<std::size_t, std::size_t> root_labels;
+	std::vector<std::size_t> component_sizes;
+	for (std::size_t index = 0; index < result.record_count; ++index) {
+		const auto root = find_root(index);
+		auto label_it = root_labels.find(root);
+		if (label_it == root_labels.end()) {
+			const auto label = root_labels.size();
+			label_it = root_labels.emplace(root, label).first;
+			component_sizes.push_back(0);
+		}
+
+		const auto label = label_it->second;
+		result.component_labels[index] = label;
+		++component_sizes[label];
+		if (!has_incident_edge[index]) {
+			++result.isolated_count;
+		}
+	}
+
+	result.component_count = component_sizes.size();
+	for (const auto component_size : component_sizes) {
+		result.largest_component_size = std::max(result.largest_component_size, component_size);
+	}
+	result.connected = result.component_count <= 1;
 
 	return result;
 }

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 from . import mappings, metrics, operators, spaces, transforms
 from .metrics import Edit
 from .operators import (
+    GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
@@ -29,6 +30,7 @@ from .operators import (
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     intrinsic_dimension,
     medoid,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -52,6 +52,21 @@ class GraphDegreeDiagnostics:
     degree_policy: str
 
 
+@dataclass(frozen=True)
+class GraphConnectivityDiagnostics:
+    """Connectivity diagnostics for a graph construction result."""
+
+    record_count: int
+    edge_count: int
+    directed: bool
+    component_labels: tuple
+    component_count: int
+    isolated_count: int
+    largest_component_size: int
+    connected: bool
+    connectivity_policy: str
+
+
 def pairwise_distance_matrix(records, metric):
     return FiniteMetricSpace(records, metric).pairwise_distances()
 
@@ -344,6 +359,77 @@ def graph_degree_diagnostics(graph):
     )
 
 
+def graph_connectivity_diagnostics(graph):
+    """Compute deterministic connectivity diagnostics for a graph construction result."""
+    record_count = graph.metadata.record_count
+    parents = list(range(record_count))
+    has_incident_edge = [False] * record_count
+
+    def find_root(index):
+        while parents[index] != index:
+            parents[index] = parents[parents[index]]
+            index = parents[index]
+        return index
+
+    def union_components(lhs, rhs):
+        lhs_root = find_root(lhs)
+        rhs_root = find_root(rhs)
+        if lhs_root == rhs_root:
+            return
+        if lhs_root < rhs_root:
+            parents[rhs_root] = lhs_root
+        else:
+            parents[lhs_root] = rhs_root
+
+    for source_index, target_index, _distance in graph.edges:
+        if (
+            source_index < 0
+            or target_index < 0
+            or source_index >= record_count
+            or target_index >= record_count
+        ):
+            raise ValueError("graph edge index exceeds metadata record_count")
+
+        has_incident_edge[source_index] = True
+        has_incident_edge[target_index] = True
+        union_components(source_index, target_index)
+
+    root_labels = {}
+    component_labels = [0] * record_count
+    component_sizes = []
+    isolated_count = 0
+    for index in range(record_count):
+        root = find_root(index)
+        if root not in root_labels:
+            root_labels[root] = len(root_labels)
+            component_sizes.append(0)
+
+        label = root_labels[root]
+        component_labels[index] = label
+        component_sizes[label] += 1
+        if not has_incident_edge[index]:
+            isolated_count += 1
+
+    component_count = len(component_sizes)
+    connectivity_policy = (
+        "weak_undirected_reachability"
+        if graph.metadata.directed
+        else "undirected_reachability"
+    )
+
+    return GraphConnectivityDiagnostics(
+        record_count=record_count,
+        edge_count=len(graph.edges),
+        directed=graph.metadata.directed,
+        component_labels=tuple(component_labels),
+        component_count=component_count,
+        isolated_count=isolated_count,
+        largest_component_size=max(component_sizes, default=0),
+        connected=component_count <= 1,
+        connectivity_policy=connectivity_policy,
+    )
+
+
 def representative_indices(records, metric, k, seed_index=0):
     """Select representative record IDs with deterministic farthest-first traversal."""
     records = list(records)
@@ -515,9 +601,11 @@ def intrinsic_dimension_from_distances(distances):
 
 
 __all__ = [
+    "GraphConnectivityDiagnostics",
     "GraphDegreeDiagnostics",
     "GraphConstructionMetadata",
     "GraphConstructionResult",
+    "graph_connectivity_diagnostics",
     "graph_degree_diagnostics",
     "intrinsic_dimension",
     "intrinsic_dimension_from_distances",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -9,6 +9,7 @@ import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
 from metric.operators import (
+    GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
@@ -18,6 +19,7 @@ from metric.operators import (
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     intrinsic_dimension,
     medoid,
@@ -64,6 +66,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.spaces.FiniteMetricSpace, FiniteMetricSpace)
         self.assertIs(metric.operators.nearest_neighbors, nearest_neighbors)
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
+        self.assertIs(metric.operators.GraphConnectivityDiagnostics, GraphConnectivityDiagnostics)
         self.assertIs(metric.operators.GraphDegreeDiagnostics, GraphDegreeDiagnostics)
         self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
@@ -71,6 +74,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.operators.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.operators.exact_radius_graph_edges, exact_radius_graph_edges)
+        self.assertIs(metric.operators.graph_connectivity_diagnostics, graph_connectivity_diagnostics)
         self.assertIs(metric.operators.graph_degree_diagnostics, graph_degree_diagnostics)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.operators.prune_graph_out_degree, prune_graph_out_degree)
@@ -86,6 +90,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.mappings, mappings)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
+        self.assertIs(metric.GraphConnectivityDiagnostics, GraphConnectivityDiagnostics)
         self.assertIs(metric.GraphDegreeDiagnostics, GraphDegreeDiagnostics)
         self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
@@ -93,6 +98,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.exact_radius_graph, exact_radius_graph)
         self.assertIs(metric.exact_radius_graph_edges, exact_radius_graph_edges)
+        self.assertIs(metric.graph_connectivity_diagnostics, graph_connectivity_diagnostics)
         self.assertIs(metric.graph_degree_diagnostics, graph_degree_diagnostics)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.prune_graph_out_degree, prune_graph_out_degree)
@@ -112,6 +118,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("Space", metric.__all__)
         self.assertIn("mappings", metric.__all__)
         self.assertIn("transforms", metric.__all__)
+        self.assertIn("GraphConnectivityDiagnostics", metric.__all__)
         self.assertIn("GraphDegreeDiagnostics", metric.__all__)
         self.assertIn("GraphConstructionMetadata", metric.__all__)
         self.assertIn("GraphConstructionResult", metric.__all__)
@@ -119,6 +126,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("exact_knn_graph_edges", metric.__all__)
         self.assertIn("exact_radius_graph", metric.__all__)
         self.assertIn("exact_radius_graph_edges", metric.__all__)
+        self.assertIn("graph_connectivity_diagnostics", metric.__all__)
         self.assertIn("graph_degree_diagnostics", metric.__all__)
         self.assertIn("prune_graph_out_degree", metric.__all__)
         self.assertIn("medoid_index", metric.__all__)
@@ -263,6 +271,18 @@ class RevivalApiTest(unittest.TestCase):
         self.assertAlmostEqual(degree_diagnostics.average_degree, 2.0)
         self.assertEqual(degree_diagnostics.degree_policy, "directed_in_out")
 
+        connectivity_diagnostics = graph_connectivity_diagnostics(knn_graph)
+        self.assertIsInstance(connectivity_diagnostics, GraphConnectivityDiagnostics)
+        self.assertEqual(connectivity_diagnostics.record_count, len(records))
+        self.assertEqual(connectivity_diagnostics.edge_count, len(knn_graph.edges))
+        self.assertTrue(connectivity_diagnostics.directed)
+        self.assertEqual(connectivity_diagnostics.component_labels, (0, 0, 0, 0, 0))
+        self.assertEqual(connectivity_diagnostics.component_count, 1)
+        self.assertEqual(connectivity_diagnostics.isolated_count, 0)
+        self.assertEqual(connectivity_diagnostics.largest_component_size, 5)
+        self.assertTrue(connectivity_diagnostics.connected)
+        self.assertEqual(connectivity_diagnostics.connectivity_policy, "weak_undirected_reachability")
+
         union_graph = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
         self.assertEqual(
             list(union_graph.edges),
@@ -287,6 +307,15 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(undirected_diagnostics.max_degree, 2)
         self.assertAlmostEqual(undirected_diagnostics.average_degree, 1.6)
         self.assertEqual(undirected_diagnostics.degree_policy, "undirected_endpoint")
+
+        undirected_connectivity = graph_connectivity_diagnostics(union_graph)
+        self.assertFalse(undirected_connectivity.directed)
+        self.assertEqual(undirected_connectivity.component_labels, (0, 0, 0, 0, 0))
+        self.assertEqual(undirected_connectivity.component_count, 1)
+        self.assertEqual(undirected_connectivity.isolated_count, 0)
+        self.assertEqual(undirected_connectivity.largest_component_size, 5)
+        self.assertTrue(undirected_connectivity.connected)
+        self.assertEqual(undirected_connectivity.connectivity_policy, "undirected_reachability")
 
         mutual_graph = symmetrize_graph(knn_graph, policy="mutual", weighting="minimum_distance")
         self.assertEqual(list(mutual_graph.edges), [(0, 3, 0.5)])
@@ -334,6 +363,8 @@ class RevivalApiTest(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             graph_degree_diagnostics(invalid_graph)
+        with self.assertRaises(ValueError):
+            graph_connectivity_diagnostics(invalid_graph)
 
         self.assertEqual(
             exact_radius_graph_edges(records, cumulative_transport_distance, 0.5),
@@ -394,6 +425,13 @@ class RevivalApiTest(unittest.TestCase):
             exact_radius_graph_edges(records, absolute_distance, 2),
             [(0, 1, 1), (0, 2, 2), (1, 0, 1), (1, 2, 1), (2, 0, 2), (2, 1, 1)],
         )
+        disconnected_graph = exact_radius_graph([0, 1, 10], absolute_distance, 1)
+        disconnected_connectivity = graph_connectivity_diagnostics(disconnected_graph)
+        self.assertEqual(disconnected_connectivity.component_labels, (0, 0, 1))
+        self.assertEqual(disconnected_connectivity.component_count, 2)
+        self.assertEqual(disconnected_connectivity.isolated_count, 1)
+        self.assertEqual(disconnected_connectivity.largest_component_size, 2)
+        self.assertFalse(disconnected_connectivity.connected)
         self.assertEqual(exact_knn_graph_edges(records, absolute_distance, 0), [])
         self.assertEqual(exact_knn_graph(records, absolute_distance, 0).edges, ())
         self.assertEqual(exact_knn_graph(records, absolute_distance, 0).metadata.k, 0)

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -196,6 +196,17 @@ int main()
     assert(std::abs(directed_degrees.average_degree - 2.0) < 1e-12);
     assert(directed_degrees.degree_policy == "directed_in_out");
 
+    const auto directed_connectivity = metric::operators::graph_connectivity_diagnostics(one_neighbor_graph);
+    assert(directed_connectivity.record_count == line.size());
+    assert(directed_connectivity.edge_count == one_neighbor_graph.edges.size());
+    assert(directed_connectivity.directed);
+    assert((directed_connectivity.component_labels == std::vector<std::size_t>{0, 0, 0, 0, 0}));
+    assert(directed_connectivity.component_count == 1);
+    assert(directed_connectivity.isolated_count == 0);
+    assert(directed_connectivity.largest_component_size == 5);
+    assert(directed_connectivity.connected);
+    assert(directed_connectivity.connectivity_policy == "weak_undirected_reachability");
+
     const auto union_graph = metric::operators::symmetrize_graph(one_neighbor_graph, "union", "minimum_distance");
     const std::vector<std::tuple<std::size_t, std::size_t, int>> expected_union_edges = {
         {0, 1, 1},
@@ -221,6 +232,15 @@ int main()
     assert(undirected_degrees.max_degree == 2);
     assert(std::abs(undirected_degrees.average_degree - 1.6) < 1e-12);
     assert(undirected_degrees.degree_policy == "undirected_endpoint");
+
+    const auto undirected_connectivity = metric::operators::graph_connectivity_diagnostics(union_graph);
+    assert(!undirected_connectivity.directed);
+    assert((undirected_connectivity.component_labels == std::vector<std::size_t>{0, 0, 0, 0, 0}));
+    assert(undirected_connectivity.component_count == 1);
+    assert(undirected_connectivity.isolated_count == 0);
+    assert(undirected_connectivity.largest_component_size == 5);
+    assert(undirected_connectivity.connected);
+    assert(undirected_connectivity.connectivity_policy == "undirected_reachability");
 
     bool rejected_undirected_pruning = false;
     try {
@@ -270,6 +290,14 @@ int main()
         rejected_invalid_degree_graph = true;
     }
     assert(rejected_invalid_degree_graph);
+
+    bool rejected_invalid_connectivity_graph = false;
+    try {
+        metric::operators::graph_connectivity_diagnostics(invalid_graph);
+    } catch (const std::invalid_argument &) {
+        rejected_invalid_connectivity_graph = true;
+    }
+    assert(rejected_invalid_connectivity_graph);
 
     const auto minimum_weighted_graph =
         metric::operators::symmetrize_graph(asymmetric_graph, "union", "minimum_distance");
@@ -334,6 +362,15 @@ int main()
     assert(radius_graph.metadata.symmetrization == "none");
     assert(radius_graph.metadata.normalization == "none");
     assert(radius_graph.metadata.tie_break == "source_then_target_index");
+
+    const std::vector<int> separated_line = {0, 1, 10};
+    const auto disconnected_graph = metric::operators::exact_radius_graph(separated_line, AbsoluteDistance{}, 1);
+    const auto disconnected_connectivity = metric::operators::graph_connectivity_diagnostics(disconnected_graph);
+    assert((disconnected_connectivity.component_labels == std::vector<std::size_t>{0, 0, 1}));
+    assert(disconnected_connectivity.component_count == 2);
+    assert(disconnected_connectivity.isolated_count == 1);
+    assert(disconnected_connectivity.largest_component_size == 2);
+    assert(!disconnected_connectivity.connected);
 
     bool rejected_large_graph_k = false;
     try {


### PR DESCRIPTION
## Summary
- add C++ and Python graph connectivity diagnostics with deterministic component labels
- document weak connectivity for directed graph results and endpoint connectivity for undirected results
- add C++ smoke and Python core coverage for connected, disconnected, and invalid endpoint cases

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure
- METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/graph-connectivity-diagnostics-wheel
- build/python-venv/bin/python -m pip install --force-reinstall build/graph-connectivity-diagnostics-wheel/metric_space-0.3.2-*.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v