### PR TITLE
Add graph stretch diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add C++ and Python `exact_knn_graph` and `exact_radius_graph` result objects with construction metadata for exact graph helpers.
 - Add C++ and Python `graph_connectivity_diagnostics` helpers for deterministic graph connectivity diagnostics.
 - Add C++ and Python `graph_degree_diagnostics` helpers for deterministic graph degree diagnostics.
+- Add C++ and Python `graph_stretch_diagnostics` helpers for deterministic graph shortest-path stretch diagnostics.
 - Add C++ and Python `symmetrize_graph` helpers for deterministic graph `union` and `mutual` policies with reciprocal distance weighting.
 - Add C++ and Python `prune_graph_out_degree` helpers for deterministic directed graph sparsification.
 - Add Python `representative_indices` and `representatives` helpers using deterministic farthest-first traversal over finite metric spaces.

--- a/README.md
+++ b/README.md
@@ -117,10 +117,12 @@ The lower-level C++ representations remain available for expert control and comp
 - `metric::operators::range_neighbors`
 - `metric::operators::GraphConnectivityDiagnostics`
 - `metric::operators::GraphDegreeDiagnostics`
+- `metric::operators::GraphStretchDiagnostics`
 - `metric::operators::GraphConstructionResult`
 - `metric::operators::GraphConstructionMetadata`
 - `metric::operators::graph_connectivity_diagnostics`
 - `metric::operators::graph_degree_diagnostics`
+- `metric::operators::graph_stretch_diagnostics`
 - `metric::operators::exact_knn_graph`
 - `metric::operators::exact_knn_graph_edges`
 - `metric::operators::exact_radius_graph`

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -71,6 +71,7 @@ auto radius_graph = metric::operators::exact_radius_graph(records, metric::Edit<
 auto radius_edges = metric::operators::exact_radius_graph_edges(records, metric::Edit<std::string>{}, 1);
 auto connectivity_info = metric::operators::graph_connectivity_diagnostics(knn_graph);
 auto degree_info = metric::operators::graph_degree_diagnostics(knn_graph);
+auto stretch_info = metric::operators::graph_stretch_diagnostics(records, metric::Edit<std::string>{}, radius_graph);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
 auto pruned = metric::operators::prune_graph_out_degree(
     metric::operators::exact_knn_graph(records, metric::Edit<std::string>{}, 2),
@@ -86,7 +87,7 @@ auto covered_records = metric::operators::coverage_representatives(records, metr
 auto dimension = metric::operators::intrinsic_dimension(records, metric::Edit<std::string>{});
 ```
 
-The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
+The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphStretchDiagnostics`, `graph_stretch_diagnostics`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -99,6 +100,8 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 `graph_connectivity_diagnostics` returns `GraphConnectivityDiagnostics` for a graph construction result. It reports deterministic component labels, component count, isolated-record count, largest component size, connected status, and connectivity policy. Directed graph results use weak undirected reachability over stored edges; undirected graph results use endpoint reachability.
 
 `graph_degree_diagnostics` returns `GraphDegreeDiagnostics` for a graph construction result. Directed graphs report `out_degrees`, `in_degrees`, combined endpoint `degrees`, isolated count, max degree, average degree, and degree policy `directed_in_out`. Undirected graph results report endpoint `degrees` with zero-filled in/out vectors and degree policy `undirected_endpoint`.
+
+`graph_stretch_diagnostics` returns `GraphStretchDiagnostics` for a graph construction result plus the source records and metric. It computes shortest-path distances over the stored graph, compares them to the metric distance, and reports evaluated pairs, reachable pairs, unreachable pairs, zero-metric pairs, max stretch, average stretch over reachable pairs, and stretch policy. Directed graph results use directed shortest paths; undirected graph results use bidirectional endpoint paths.
 
 `symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -24,7 +24,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph connectivity diagnostics, graph degree diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph connectivity diagnostics, graph degree diagnostics, graph stretch diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -51,6 +51,7 @@ from metric.operators import (
     GraphConstructionResult,
     GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
+    GraphStretchDiagnostics,
     coverage_representative_indices,
     coverage_representatives,
     exact_knn_graph,
@@ -59,6 +60,7 @@ from metric.operators import (
     exact_radius_graph_edges,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
+    graph_stretch_diagnostics,
     intrinsic_dimension,
     medoid,
     medoid_index,
@@ -82,6 +84,7 @@ radius_graph = exact_radius_graph(records, Edit(), radius=1)
 radius_edges = exact_radius_graph_edges(records, Edit(), radius=1)
 connectivity_info = graph_connectivity_diagnostics(knn_graph)
 degree_info = graph_degree_diagnostics(knn_graph)
+stretch_info = graph_stretch_diagnostics(records, Edit(), radius_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 pruned = prune_graph_out_degree(exact_knn_graph(records, Edit(), k=2), max_out_degree=1)
 selected_ids = representative_indices(records, Edit(), k=2)
@@ -106,6 +109,8 @@ dimension = intrinsic_dimension(records, Edit())
 `graph_connectivity_diagnostics` returns `GraphConnectivityDiagnostics` for a graph construction result. It reports deterministic component labels, component count, isolated-record count, largest component size, connected status, and connectivity policy. Directed graph results use weak undirected reachability over stored edges; undirected graph results use endpoint reachability.
 
 `graph_degree_diagnostics` returns `GraphDegreeDiagnostics` for a graph construction result. Directed graphs report `out_degrees`, `in_degrees`, combined endpoint `degrees`, isolated count, max degree, average degree, and degree policy `directed_in_out`. Undirected graph results report endpoint `degrees` with zero-filled in/out vectors and degree policy `undirected_endpoint`.
+
+`graph_stretch_diagnostics` returns `GraphStretchDiagnostics` for a graph construction result plus the source records and metric. It computes shortest-path distances over the stored graph, compares them to the metric distance, and reports evaluated pairs, reachable pairs, unreachable pairs, zero-metric pairs, max stretch, average stretch over reachable pairs, and stretch policy. Directed graph results use directed shortest paths; undirected graph results use bidirectional endpoint paths.
 
 `symmetrize_graph` converts a graph construction result to undirected `source_index < target_index` edges. The supported symmetrization policies are `union` and `mutual`; the supported reciprocal weighting policies are `minimum_distance` and `maximum_distance`. The returned metadata records the selected symmetrization and weighting policies.
 

--- a/docs/concepts/graph-representations.md
+++ b/docs/concepts/graph-representations.md
@@ -4,7 +4,7 @@ Graph representations are derived structures over a finite metric space. They ke
 
 This page defines the terms METRIC docs use before graph construction becomes a first-page operator API.
 
-The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `graph_connectivity_diagnostics` and `graph_degree_diagnostics` report deterministic diagnostics for graph construction results. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
+The promoted core result helpers are `exact_knn_graph` and `exact_radius_graph`. They return `GraphConstructionResult` values with directed `(source_index, target_index, distance)` edges plus construction metadata. The edge-list helpers `exact_knn_graph_edges` and `exact_radius_graph_edges` remain available when callers only need the directed edge tuples. `graph_connectivity_diagnostics`, `graph_degree_diagnostics`, and `graph_stretch_diagnostics` report deterministic diagnostics for graph construction results. `prune_graph_out_degree` applies deterministic out-degree sparsification to directed graph results. `symmetrize_graph` converts a graph construction result into deterministic undirected edges with documented symmetrization and reciprocal weighting policies. See [Exact Graph Edge Fixtures](../examples/graph-construction.md) for the fixture shape. Normalized weights remain a roadmap item.
 
 ## Required Metadata
 
@@ -73,6 +73,16 @@ For directed graph results, connectivity is weak connectivity over the stored ed
 For undirected graph results, each stored edge contributes one endpoint relationship between its source and target. The connectivity policy is `undirected_reachability`.
 
 Component labels are assigned by scanning source record IDs in order. A record with no incident stored edge is counted as isolated. The helper validates that every edge endpoint is within `metadata.record_count`.
+
+## Stretch Diagnostics
+
+Graph stretch diagnostics compare shortest paths through an existing graph with direct metric distances in the source finite metric space. They help detect whether a sparse graph preserves pairwise distances for the evaluated records, but they do not prove approximate-neighbor recall or quality outside the supplied record set.
+
+`graph_stretch_diagnostics` accepts source records, the metric callable, and a graph construction result. It returns record count, edge count, direction policy, evaluated pair count, reachable pair count, unreachable pair count, zero-metric pair count, max stretch, average stretch over reachable pairs, and a named stretch policy.
+
+For directed graph results, shortest paths follow stored edge direction and the stretch policy is `directed_shortest_path`. For undirected graph results, each stored edge is evaluated as a bidirectional endpoint relationship and the stretch policy is `undirected_shortest_path`.
+
+Pairs whose direct metric distance is zero are not divided into stretch ratios; they are counted as zero-metric pairs. Pairs that have nonzero metric distance but no graph path are counted as unreachable. The helper validates that `metadata.record_count` matches the supplied records and that every edge endpoint is within that count.
 
 ## Degree Sparsification
 

--- a/docs/examples/graph-construction.md
+++ b/docs/examples/graph-construction.md
@@ -29,6 +29,7 @@ auto radius_edges = radius_graph.edges;
 auto connectivity_info = metric::operators::graph_connectivity_diagnostics(knn_graph);
 auto degree_info = metric::operators::graph_degree_diagnostics(knn_graph);
 auto undirected = metric::operators::symmetrize_graph(knn_graph, "union", "minimum_distance");
+auto stretch_info = metric::operators::graph_stretch_diagnostics(records, AbsoluteDistance{}, undirected);
 auto pruned = metric::operators::prune_graph_out_degree(
     metric::operators::exact_knn_graph(records, AbsoluteDistance{}, 2),
     1);
@@ -37,7 +38,7 @@ auto pruned = metric::operators::prune_graph_out_degree(
 Python shape:
 
 ```python
-from metric import exact_knn_graph, exact_radius_graph, graph_connectivity_diagnostics, graph_degree_diagnostics, prune_graph_out_degree, symmetrize_graph
+from metric import exact_knn_graph, exact_radius_graph, graph_connectivity_diagnostics, graph_degree_diagnostics, graph_stretch_diagnostics, prune_graph_out_degree, symmetrize_graph
 
 records = [0, 1, 2, 3, 4]
 
@@ -52,6 +53,7 @@ radius_edges = radius_graph.edges
 connectivity_info = graph_connectivity_diagnostics(knn_graph)
 degree_info = graph_degree_diagnostics(knn_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
+stretch_info = graph_stretch_diagnostics(records, absolute_distance, undirected)
 pruned = prune_graph_out_degree(exact_knn_graph(records, absolute_distance, k=2), max_out_degree=1)
 ```
 
@@ -84,6 +86,8 @@ For `records = [0, 1, 2, 3, 4]`, symmetrizing the exact kNN graph with `k=1` and
 The directed `k=1` graph has out-degrees `(1, 1, 1, 1, 1)`, in-degrees `(1, 2, 1, 1, 0)`, endpoint degrees `(2, 3, 2, 2, 1)`, max degree `3`, average degree `2.0`, and degree policy `directed_in_out`.
 
 The same directed `k=1` graph has weak connectivity labels `(0, 0, 0, 0, 0)`, component count `1`, isolated count `0`, largest component size `5`, `connected=True`, and connectivity policy `weak_undirected_reachability`.
+
+The symmetrized `union` graph has undirected shortest-path stretch over `10` unordered nonzero-distance pairs. All pairs are reachable, no zero-distance pairs are skipped, max stretch is `1.0`, average stretch is `1.0`, and stretch policy is `undirected_shortest_path`.
 
 For the same records, pruning the exact kNN graph from `k=2` to `max_out_degree=1` produces directed edges:
 

--- a/docs/research-roadmap.md
+++ b/docs/research-roadmap.md
@@ -84,11 +84,11 @@ Current promoted base:
 - C++ and Python `prune_graph_out_degree` promotes deterministic out-degree sparsification for directed graph construction results.
 - C++ and Python `graph_degree_diagnostics` promotes deterministic degree diagnostics for directed and undirected graph construction results.
 - C++ and Python `graph_connectivity_diagnostics` promotes deterministic connectivity diagnostics for directed and undirected graph construction results.
+- C++ and Python `graph_stretch_diagnostics` promotes deterministic shortest-path stretch diagnostics for directed and undirected graph construction results.
 
 Candidate strategies:
 
 - additional sparsification primitives with documented connectivity or stretch assumptions
-- graph diagnostics such as edge stretch
 
 Promotion evidence:
 
@@ -186,6 +186,6 @@ The revival should not:
 Near-term branches should stay small and evidence-driven:
 
 - add k-medoids or compression-summary representative fixtures now that farthest-first, medoid, separated, and radius-coverage fixtures exist
-- add graph diagnostics such as edge stretch
+- add additional graph sparsification primitives with documented connectivity or stretch assumptions
 - add MGC interpretation docs for paired metric spaces
 - add an industrial-record fixture that combines strings, process curves, histograms, and numeric penalties

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -13,11 +13,11 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - custom metric callables
 - C++ metric adapter: `metric::Metric<Record, Callable>` and `metric::make_metric<Record>(callable)`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
-- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
+- C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphStretchDiagnostics`, `graph_stretch_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
 - Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -29,7 +29,7 @@ Stable revival surface:
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
 - Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
@@ -64,7 +64,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/metric/operators.hpp
+++ b/metric/operators.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <map>
 #include <optional>
 #include <stdexcept>
@@ -80,6 +81,19 @@ struct GraphConnectivityDiagnostics {
 	std::size_t largest_component_size{};
 	bool connected{true};
 	std::string connectivity_policy;
+};
+
+struct GraphStretchDiagnostics {
+	std::size_t record_count{};
+	std::size_t edge_count{};
+	bool directed{true};
+	std::size_t pair_count{};
+	std::size_t reachable_pair_count{};
+	std::size_t unreachable_pair_count{};
+	std::size_t zero_metric_pair_count{};
+	double max_stretch{};
+	double average_stretch{};
+	std::string stretch_policy;
 };
 
 template <typename Container, typename Metric>
@@ -481,6 +495,104 @@ auto graph_connectivity_diagnostics(const GraphConstructionResult<Distance, Radi
 		result.largest_component_size = std::max(result.largest_component_size, component_size);
 	}
 	result.connected = result.component_count <= 1;
+
+	return result;
+}
+
+template <typename Container, typename Metric, typename Distance, typename RadiusValue>
+auto graph_stretch_diagnostics(const Container &records, Metric distance,
+							   const GraphConstructionResult<Distance, RadiusValue> &graph)
+	-> GraphStretchDiagnostics
+{
+	GraphStretchDiagnostics result;
+	result.record_count = graph.metadata.record_count;
+	result.edge_count = graph.edges.size();
+	result.directed = graph.metadata.directed;
+	result.stretch_policy = graph.metadata.directed ? "directed_shortest_path" : "undirected_shortest_path";
+
+	if (records.size() != result.record_count) {
+		throw std::invalid_argument("graph metadata record_count must match records size");
+	}
+
+	const auto infinity = std::numeric_limits<double>::infinity();
+	std::vector<std::vector<double>> shortest_paths(result.record_count,
+												   std::vector<double>(result.record_count, infinity));
+	for (std::size_t index = 0; index < result.record_count; ++index) {
+		shortest_paths[index][index] = 0.0;
+	}
+
+	for (const auto &edge : graph.edges) {
+		const auto source_index = std::get<0>(edge);
+		const auto target_index = std::get<1>(edge);
+		if (source_index >= result.record_count || target_index >= result.record_count) {
+			throw std::invalid_argument("graph edge index exceeds metadata record_count");
+		}
+
+		const auto edge_distance = static_cast<double>(std::get<2>(edge));
+		shortest_paths[source_index][target_index] = std::min(shortest_paths[source_index][target_index], edge_distance);
+		if (!graph.metadata.directed) {
+			shortest_paths[target_index][source_index] =
+				std::min(shortest_paths[target_index][source_index], edge_distance);
+		}
+	}
+
+	for (std::size_t through = 0; through < result.record_count; ++through) {
+		for (std::size_t source_index = 0; source_index < result.record_count; ++source_index) {
+			if (shortest_paths[source_index][through] == infinity) {
+				continue;
+			}
+			for (std::size_t target_index = 0; target_index < result.record_count; ++target_index) {
+				if (shortest_paths[through][target_index] == infinity) {
+					continue;
+				}
+				shortest_paths[source_index][target_index] =
+					std::min(shortest_paths[source_index][target_index],
+							 shortest_paths[source_index][through] + shortest_paths[through][target_index]);
+			}
+		}
+	}
+
+	const auto space = ::metric::Space::from_records(records, std::move(distance));
+	double total_stretch = 0.0;
+	auto evaluate_pair = [&](std::size_t source_index, std::size_t target_index) {
+		const auto metric_distance = static_cast<double>(space.distance(source_index, target_index));
+		if (metric_distance == 0.0) {
+			++result.zero_metric_pair_count;
+			return;
+		}
+
+		++result.pair_count;
+		const auto path_distance = shortest_paths[source_index][target_index];
+		if (path_distance == infinity) {
+			++result.unreachable_pair_count;
+			return;
+		}
+
+		const auto stretch = path_distance / metric_distance;
+		++result.reachable_pair_count;
+		total_stretch += stretch;
+		result.max_stretch = std::max(result.max_stretch, stretch);
+	};
+
+	if (graph.metadata.directed) {
+		for (std::size_t source_index = 0; source_index < result.record_count; ++source_index) {
+			for (std::size_t target_index = 0; target_index < result.record_count; ++target_index) {
+				if (source_index != target_index) {
+					evaluate_pair(source_index, target_index);
+				}
+			}
+		}
+	} else {
+		for (std::size_t source_index = 0; source_index < result.record_count; ++source_index) {
+			for (std::size_t target_index = source_index + 1; target_index < result.record_count; ++target_index) {
+				evaluate_pair(source_index, target_index);
+			}
+		}
+	}
+
+	if (result.reachable_pair_count != 0) {
+		result.average_stretch = total_stretch / static_cast<double>(result.reachable_pair_count);
+	}
 
 	return result;
 }

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ The revived core package exposes the project concepts explicitly:
 - `metric.metrics`: metric constructors such as `Edit`
 - `metric.Space`: minimal intent-first finite metric space facade
 - `metric.spaces`: finite metric-space helpers such as `FiniteMetricSpace`
-- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
+- `metric.operators`: pairwise-distance, nearest-neighbor, range-neighbor, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers
 - `metric.mappings`: beta compatibility bridge for installed mapping bindings
 - `metric.transforms`: beta compatibility bridge for installed transform bindings
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -22,6 +22,7 @@ from .metrics import Edit
 from .operators import (
     GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
+    GraphStretchDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
     coverage_representative_indices,
@@ -32,6 +33,7 @@ from .operators import (
     exact_radius_graph_edges,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
+    graph_stretch_diagnostics,
     intrinsic_dimension,
     medoid,
     medoid_index,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -67,6 +67,22 @@ class GraphConnectivityDiagnostics:
     connectivity_policy: str
 
 
+@dataclass(frozen=True)
+class GraphStretchDiagnostics:
+    """Shortest-path stretch diagnostics for a graph construction result."""
+
+    record_count: int
+    edge_count: int
+    directed: bool
+    pair_count: int
+    reachable_pair_count: int
+    unreachable_pair_count: int
+    zero_metric_pair_count: int
+    max_stretch: float
+    average_stretch: float
+    stretch_policy: str
+
+
 def pairwise_distance_matrix(records, metric):
     return FiniteMetricSpace(records, metric).pairwise_distances()
 
@@ -430,6 +446,115 @@ def graph_connectivity_diagnostics(graph):
     )
 
 
+def graph_stretch_diagnostics(records, metric, graph):
+    """Compute deterministic shortest-path stretch diagnostics for a graph result."""
+    records = list(records)
+    record_count = graph.metadata.record_count
+    if len(records) != record_count:
+        raise ValueError("graph metadata record_count must match records size")
+
+    shortest_paths = [
+        [math.inf] * record_count
+        for _index in range(record_count)
+    ]
+    for index in range(record_count):
+        shortest_paths[index][index] = 0.0
+
+    for source_index, target_index, edge_distance in graph.edges:
+        if (
+            source_index < 0
+            or target_index < 0
+            or source_index >= record_count
+            or target_index >= record_count
+        ):
+            raise ValueError("graph edge index exceeds metadata record_count")
+
+        edge_distance = float(edge_distance)
+        shortest_paths[source_index][target_index] = min(
+            shortest_paths[source_index][target_index],
+            edge_distance,
+        )
+        if not graph.metadata.directed:
+            shortest_paths[target_index][source_index] = min(
+                shortest_paths[target_index][source_index],
+                edge_distance,
+            )
+
+    for through in range(record_count):
+        for source_index in range(record_count):
+            if math.isinf(shortest_paths[source_index][through]):
+                continue
+            for target_index in range(record_count):
+                if math.isinf(shortest_paths[through][target_index]):
+                    continue
+                shortest_paths[source_index][target_index] = min(
+                    shortest_paths[source_index][target_index],
+                    shortest_paths[source_index][through] + shortest_paths[through][target_index],
+                )
+
+    space = FiniteMetricSpace(records, metric)
+    pair_count = 0
+    reachable_pair_count = 0
+    unreachable_pair_count = 0
+    zero_metric_pair_count = 0
+    max_stretch = 0.0
+    total_stretch = 0.0
+
+    def evaluate_pair(source_index, target_index):
+        nonlocal pair_count
+        nonlocal reachable_pair_count
+        nonlocal unreachable_pair_count
+        nonlocal zero_metric_pair_count
+        nonlocal max_stretch
+        nonlocal total_stretch
+
+        metric_distance = float(space.distance(source_index, target_index))
+        if metric_distance == 0.0:
+            zero_metric_pair_count += 1
+            return
+
+        pair_count += 1
+        path_distance = shortest_paths[source_index][target_index]
+        if math.isinf(path_distance):
+            unreachable_pair_count += 1
+            return
+
+        stretch = path_distance / metric_distance
+        reachable_pair_count += 1
+        total_stretch += stretch
+        max_stretch = max(max_stretch, stretch)
+
+    if graph.metadata.directed:
+        for source_index in range(record_count):
+            for target_index in range(record_count):
+                if source_index != target_index:
+                    evaluate_pair(source_index, target_index)
+    else:
+        for source_index in range(record_count):
+            for target_index in range(source_index + 1, record_count):
+                evaluate_pair(source_index, target_index)
+
+    stretch_policy = (
+        "directed_shortest_path"
+        if graph.metadata.directed
+        else "undirected_shortest_path"
+    )
+    average_stretch = total_stretch / reachable_pair_count if reachable_pair_count else 0.0
+
+    return GraphStretchDiagnostics(
+        record_count=record_count,
+        edge_count=len(graph.edges),
+        directed=graph.metadata.directed,
+        pair_count=pair_count,
+        reachable_pair_count=reachable_pair_count,
+        unreachable_pair_count=unreachable_pair_count,
+        zero_metric_pair_count=zero_metric_pair_count,
+        max_stretch=max_stretch,
+        average_stretch=average_stretch,
+        stretch_policy=stretch_policy,
+    )
+
+
 def representative_indices(records, metric, k, seed_index=0):
     """Select representative record IDs with deterministic farthest-first traversal."""
     records = list(records)
@@ -603,10 +728,12 @@ def intrinsic_dimension_from_distances(distances):
 __all__ = [
     "GraphConnectivityDiagnostics",
     "GraphDegreeDiagnostics",
+    "GraphStretchDiagnostics",
     "GraphConstructionMetadata",
     "GraphConstructionResult",
     "graph_connectivity_diagnostics",
     "graph_degree_diagnostics",
+    "graph_stretch_diagnostics",
     "intrinsic_dimension",
     "intrinsic_dimension_from_distances",
     "coverage_representative_indices",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -11,6 +11,7 @@ from metric import mappings, transforms
 from metric.operators import (
     GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
+    GraphStretchDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
     coverage_representative_indices,
@@ -21,6 +22,7 @@ from metric.operators import (
     exact_radius_graph_edges,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
+    graph_stretch_diagnostics,
     intrinsic_dimension,
     medoid,
     medoid_index,
@@ -68,6 +70,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.range_neighbors, range_neighbors)
         self.assertIs(metric.operators.GraphConnectivityDiagnostics, GraphConnectivityDiagnostics)
         self.assertIs(metric.operators.GraphDegreeDiagnostics, GraphDegreeDiagnostics)
+        self.assertIs(metric.operators.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
         self.assertIs(metric.operators.exact_knn_graph, exact_knn_graph)
@@ -76,6 +79,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.operators.graph_connectivity_diagnostics, graph_connectivity_diagnostics)
         self.assertIs(metric.operators.graph_degree_diagnostics, graph_degree_diagnostics)
+        self.assertIs(metric.operators.graph_stretch_diagnostics, graph_stretch_diagnostics)
         self.assertIs(metric.operators.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.operators.prune_graph_out_degree, prune_graph_out_degree)
         self.assertIs(metric.operators.medoid_index, medoid_index)
@@ -92,6 +96,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.Edit, Edit)
         self.assertIs(metric.GraphConnectivityDiagnostics, GraphConnectivityDiagnostics)
         self.assertIs(metric.GraphDegreeDiagnostics, GraphDegreeDiagnostics)
+        self.assertIs(metric.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
         self.assertIs(metric.exact_knn_graph, exact_knn_graph)
@@ -100,6 +105,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.exact_radius_graph_edges, exact_radius_graph_edges)
         self.assertIs(metric.graph_connectivity_diagnostics, graph_connectivity_diagnostics)
         self.assertIs(metric.graph_degree_diagnostics, graph_degree_diagnostics)
+        self.assertIs(metric.graph_stretch_diagnostics, graph_stretch_diagnostics)
         self.assertIs(metric.intrinsic_dimension, intrinsic_dimension)
         self.assertIs(metric.prune_graph_out_degree, prune_graph_out_degree)
         self.assertIs(metric.medoid_index, medoid_index)
@@ -120,6 +126,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("transforms", metric.__all__)
         self.assertIn("GraphConnectivityDiagnostics", metric.__all__)
         self.assertIn("GraphDegreeDiagnostics", metric.__all__)
+        self.assertIn("GraphStretchDiagnostics", metric.__all__)
         self.assertIn("GraphConstructionMetadata", metric.__all__)
         self.assertIn("GraphConstructionResult", metric.__all__)
         self.assertIn("exact_knn_graph", metric.__all__)
@@ -128,6 +135,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("exact_radius_graph_edges", metric.__all__)
         self.assertIn("graph_connectivity_diagnostics", metric.__all__)
         self.assertIn("graph_degree_diagnostics", metric.__all__)
+        self.assertIn("graph_stretch_diagnostics", metric.__all__)
         self.assertIn("prune_graph_out_degree", metric.__all__)
         self.assertIn("medoid_index", metric.__all__)
         self.assertIn("medoid", metric.__all__)
@@ -317,6 +325,19 @@ class RevivalApiTest(unittest.TestCase):
         self.assertTrue(undirected_connectivity.connected)
         self.assertEqual(undirected_connectivity.connectivity_policy, "undirected_reachability")
 
+        undirected_stretch = graph_stretch_diagnostics(records, cumulative_transport_distance, union_graph)
+        self.assertIsInstance(undirected_stretch, GraphStretchDiagnostics)
+        self.assertFalse(undirected_stretch.directed)
+        self.assertEqual(undirected_stretch.record_count, len(records))
+        self.assertEqual(undirected_stretch.edge_count, len(union_graph.edges))
+        self.assertEqual(undirected_stretch.pair_count, 10)
+        self.assertEqual(undirected_stretch.reachable_pair_count, 10)
+        self.assertEqual(undirected_stretch.unreachable_pair_count, 0)
+        self.assertEqual(undirected_stretch.zero_metric_pair_count, 0)
+        self.assertAlmostEqual(undirected_stretch.max_stretch, 1.0)
+        self.assertAlmostEqual(undirected_stretch.average_stretch, 1.0)
+        self.assertEqual(undirected_stretch.stretch_policy, "undirected_shortest_path")
+
         mutual_graph = symmetrize_graph(knn_graph, policy="mutual", weighting="minimum_distance")
         self.assertEqual(list(mutual_graph.edges), [(0, 3, 0.5)])
         self.assertEqual(mutual_graph.metadata.symmetrization, "mutual")
@@ -365,6 +386,10 @@ class RevivalApiTest(unittest.TestCase):
             graph_degree_diagnostics(invalid_graph)
         with self.assertRaises(ValueError):
             graph_connectivity_diagnostics(invalid_graph)
+        with self.assertRaises(ValueError):
+            graph_stretch_diagnostics([0, 1], cumulative_transport_distance, invalid_graph)
+        with self.assertRaises(ValueError):
+            graph_stretch_diagnostics(records, cumulative_transport_distance, invalid_graph)
 
         self.assertEqual(
             exact_radius_graph_edges(records, cumulative_transport_distance, 0.5),
@@ -388,6 +413,16 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(radius_graph.metadata.symmetrization, "none")
         self.assertEqual(radius_graph.metadata.normalization, "none")
         self.assertEqual(radius_graph.metadata.tie_break, "source_then_target_index")
+        complete_radius_graph = exact_radius_graph(records, cumulative_transport_distance, 3.0)
+        directed_stretch = graph_stretch_diagnostics(records, cumulative_transport_distance, complete_radius_graph)
+        self.assertTrue(directed_stretch.directed)
+        self.assertEqual(directed_stretch.pair_count, 20)
+        self.assertEqual(directed_stretch.reachable_pair_count, 20)
+        self.assertEqual(directed_stretch.unreachable_pair_count, 0)
+        self.assertEqual(directed_stretch.zero_metric_pair_count, 0)
+        self.assertAlmostEqual(directed_stretch.max_stretch, 1.0)
+        self.assertAlmostEqual(directed_stretch.average_stretch, 1.0)
+        self.assertEqual(directed_stretch.stretch_policy, "directed_shortest_path")
         self.assertEqual(coverage_representative_indices(records, cumulative_transport_distance, 1.5), [0, 2])
         self.assertEqual(
             coverage_representatives(records, cumulative_transport_distance, 1.5),
@@ -432,6 +467,13 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(disconnected_connectivity.isolated_count, 1)
         self.assertEqual(disconnected_connectivity.largest_component_size, 2)
         self.assertFalse(disconnected_connectivity.connected)
+        disconnected_stretch = graph_stretch_diagnostics([0, 1, 10], absolute_distance, disconnected_graph)
+        self.assertEqual(disconnected_stretch.pair_count, 6)
+        self.assertEqual(disconnected_stretch.reachable_pair_count, 2)
+        self.assertEqual(disconnected_stretch.unreachable_pair_count, 4)
+        self.assertEqual(disconnected_stretch.zero_metric_pair_count, 0)
+        self.assertAlmostEqual(disconnected_stretch.max_stretch, 1.0)
+        self.assertAlmostEqual(disconnected_stretch.average_stretch, 1.0)
         self.assertEqual(exact_knn_graph_edges(records, absolute_distance, 0), [])
         self.assertEqual(exact_knn_graph(records, absolute_distance, 0).edges, ())
         self.assertEqual(exact_knn_graph(records, absolute_distance, 0).metadata.k, 0)

--- a/tests/core_smoke/metric_core_smoke.cpp
+++ b/tests/core_smoke/metric_core_smoke.cpp
@@ -242,6 +242,18 @@ int main()
     assert(undirected_connectivity.connected);
     assert(undirected_connectivity.connectivity_policy == "undirected_reachability");
 
+    const auto undirected_stretch = metric::operators::graph_stretch_diagnostics(line, AbsoluteDistance{}, union_graph);
+    assert(!undirected_stretch.directed);
+    assert(undirected_stretch.record_count == line.size());
+    assert(undirected_stretch.edge_count == union_graph.edges.size());
+    assert(undirected_stretch.pair_count == 10);
+    assert(undirected_stretch.reachable_pair_count == 10);
+    assert(undirected_stretch.unreachable_pair_count == 0);
+    assert(undirected_stretch.zero_metric_pair_count == 0);
+    assert(std::abs(undirected_stretch.max_stretch - 1.0) < 1e-12);
+    assert(std::abs(undirected_stretch.average_stretch - 1.0) < 1e-12);
+    assert(undirected_stretch.stretch_policy == "undirected_shortest_path");
+
     bool rejected_undirected_pruning = false;
     try {
         metric::operators::prune_graph_out_degree(union_graph, 1);
@@ -298,6 +310,23 @@ int main()
         rejected_invalid_connectivity_graph = true;
     }
     assert(rejected_invalid_connectivity_graph);
+
+    const std::vector<int> two_record_line = {0, 1};
+    bool rejected_invalid_stretch_graph = false;
+    try {
+        metric::operators::graph_stretch_diagnostics(two_record_line, AbsoluteDistance{}, invalid_graph);
+    } catch (const std::invalid_argument &) {
+        rejected_invalid_stretch_graph = true;
+    }
+    assert(rejected_invalid_stretch_graph);
+
+    bool rejected_stretch_record_mismatch = false;
+    try {
+        metric::operators::graph_stretch_diagnostics(line, AbsoluteDistance{}, invalid_graph);
+    } catch (const std::invalid_argument &) {
+        rejected_stretch_record_mismatch = true;
+    }
+    assert(rejected_stretch_record_mismatch);
 
     const auto minimum_weighted_graph =
         metric::operators::symmetrize_graph(asymmetric_graph, "union", "minimum_distance");
@@ -363,6 +392,18 @@ int main()
     assert(radius_graph.metadata.normalization == "none");
     assert(radius_graph.metadata.tie_break == "source_then_target_index");
 
+    const auto directed_stretch = metric::operators::graph_stretch_diagnostics(line, AbsoluteDistance{}, radius_graph);
+    assert(directed_stretch.directed);
+    assert(directed_stretch.record_count == line.size());
+    assert(directed_stretch.edge_count == radius_graph.edges.size());
+    assert(directed_stretch.pair_count == 20);
+    assert(directed_stretch.reachable_pair_count == 20);
+    assert(directed_stretch.unreachable_pair_count == 0);
+    assert(directed_stretch.zero_metric_pair_count == 0);
+    assert(std::abs(directed_stretch.max_stretch - 1.0) < 1e-12);
+    assert(std::abs(directed_stretch.average_stretch - 1.0) < 1e-12);
+    assert(directed_stretch.stretch_policy == "directed_shortest_path");
+
     const std::vector<int> separated_line = {0, 1, 10};
     const auto disconnected_graph = metric::operators::exact_radius_graph(separated_line, AbsoluteDistance{}, 1);
     const auto disconnected_connectivity = metric::operators::graph_connectivity_diagnostics(disconnected_graph);
@@ -371,6 +412,15 @@ int main()
     assert(disconnected_connectivity.isolated_count == 1);
     assert(disconnected_connectivity.largest_component_size == 2);
     assert(!disconnected_connectivity.connected);
+
+    const auto disconnected_stretch =
+        metric::operators::graph_stretch_diagnostics(separated_line, AbsoluteDistance{}, disconnected_graph);
+    assert(disconnected_stretch.pair_count == 6);
+    assert(disconnected_stretch.reachable_pair_count == 2);
+    assert(disconnected_stretch.unreachable_pair_count == 4);
+    assert(disconnected_stretch.zero_metric_pair_count == 0);
+    assert(std::abs(disconnected_stretch.max_stretch - 1.0) < 1e-12);
+    assert(std::abs(disconnected_stretch.average_stretch - 1.0) < 1e-12);
 
     bool rejected_large_graph_k = false;
     try {


### PR DESCRIPTION
## Summary
- add C++ and Python graph shortest-path stretch diagnostics
- report reachable, unreachable, and zero-metric pair counts with directed/undirected path policies
- document the promoted stretch diagnostics across API, graph concepts, examples, roadmap, stability, and changelog

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure
- METRIC_PYTHON_USE_BLAS=OFF ../build/python-venv/bin/python -m build --wheel --outdir ../build/graph-stretch-diagnostics-wheel
- build/python-venv/bin/python -m pip install --force-reinstall build/graph-stretch-diagnostics-wheel/metric_space-0.3.2-*.whl && PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v