### PR TITLE
Document graph stretch status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -33,6 +33,7 @@ The current local tree implements the first revival slice:
 - C++ and Python graph out-degree pruning helpers with deterministic sparsification metadata
 - C++ and Python graph degree diagnostics with deterministic degree-policy metadata
 - C++ and Python graph connectivity diagnostics with deterministic component metadata
+- C++ and Python graph stretch diagnostics with deterministic shortest-path metadata
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -190,6 +191,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ and Python graph out-degree pruning helpers with deterministic sparsification fixtures and CI coverage, merged as `1bcbc7f818efea4014f54f6e8738436fe9d7c25d`
 - C++ and Python graph degree diagnostics with deterministic degree-policy fixtures and CI coverage, merged as `2947be9ec6faf2ffa1f1c3428598ea77e18bdbd5`
 - C++ and Python graph connectivity diagnostics with deterministic component fixtures and CI coverage, merged as `6e37b20f2c5ec73501c2c66321719f617609001f`
+- C++ and Python graph stretch diagnostics with deterministic shortest-path fixtures and CI coverage, merged as `31e2ed52041712427edc9b9bce20b055ed68c345`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record graph stretch diagnostics in the Revival local scope
- add the #374 merge commit to post-v0.3.2 master progress

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'