### PR TITLE
Document engine representation status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -35,6 +35,7 @@ The current local tree implements the first revival slice:
 - C++ and Python graph connectivity diagnostics with deterministic component metadata
 - C++ and Python graph stretch diagnostics with deterministic shortest-path metadata
 - initial C++ engine skeleton with `MetricSpace`, stable `RecordId`s, metric traits, and engine concept traits
+- initial C++ engine representation adapters for implicit distance lookup, matrix caching, exact neighbor-index scaffolds, kNN graph adjacency, graph topology edges, and stale detection
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -194,6 +195,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ and Python graph connectivity diagnostics with deterministic component fixtures and CI coverage, merged as `6e37b20f2c5ec73501c2c66321719f617609001f`
 - C++ and Python graph stretch diagnostics with deterministic shortest-path fixtures and CI coverage, merged as `31e2ed52041712427edc9b9bce20b055ed68c345`
 - initial C++ engine skeleton with `MetricSpace`, stable `RecordId`s, metric traits, engine concept traits, and core smoke coverage, merged as `8592d1e636e27227ca083220d3d7e3abf4e04bcf`
+- initial C++ engine representation adapters with core smoke coverage for matrix caching, exact neighbor-index scaffolds, kNN graph adjacency, graph topology edges, and stale detection, merged as `f5eebadea22e7b4f312632c3a4c10e731fffbdf1`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the merged engine representation-adapter slice in revival status
- add the PR #378 merge SHA to post-v0.3.2 progress

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb