### PR TITLE
Document engine DBSCAN status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -37,7 +37,7 @@ The current local tree implements the first revival slice:
 - initial C++ engine skeleton with `MetricSpace`, stable `RecordId`s, metric traits, and engine concept traits
 - initial C++ engine representation adapters for implicit distance lookup, matrix caching, exact neighbor-index scaffolds, kNN graph adjacency, graph topology edges, and stale detection
 - initial C++ engine nearest operators with `NeighborSet`, `operators::knn`, and `operators::range` over spaces, distance providers, and neighbor indexes
-- initial C++ engine clustering operator with `ClusteringResult` and deterministic `operators::kmedoids` over spaces and distance providers
+- initial C++ engine clustering operators with `ClusteringResult`, deterministic `operators::kmedoids`, and deterministic `operators::dbscan` over spaces and distance providers
 - documentation for concepts, APIs, examples, stability, testing, and release gates
 - CI workflows for C++ core, Python wheels, docs/formatting, revived-source formatting, and GitHub Pages artifacts
 - release artifact workflow for source archive, Python sdist, Python wheel built from that sdist, and C++ core/downstream evidence
@@ -200,6 +200,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - initial C++ engine representation adapters with core smoke coverage for matrix caching, exact neighbor-index scaffolds, kNN graph adjacency, graph topology edges, and stale detection, merged as `f5eebadea22e7b4f312632c3a4c10e731fffbdf1`
 - initial C++ engine nearest operators with `NeighborSet`, space/provider/index overloads, and core smoke coverage, merged as `9819d89fded5f0947c21de974410c0b9c56393fd`
 - initial C++ engine clustering operator with `ClusteringResult`, deterministic k-medoids over spaces and distance providers, and core smoke coverage, merged as `0bb5a0b695c88ef91dd997d4f59275e04908462f`
+- deterministic C++ engine DBSCAN clustering over spaces and distance providers with noise/core record metadata and core smoke coverage, merged as `d523f18a34383206f17b1a699d6a4e819da0d801`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- update revival status to include the merged engine DBSCAN operator
- record the DBSCAN merge commit in the post-v0.3.2 ledger

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb