### PR TITLE
Add engine intent strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add first C++ engine nearest operators with `NeighborSet`, `operators::knn`, and `operators::range` overloads for spaces, distance providers, and neighbor indexes.
 - Add first C++ engine clustering operator with `ClusteringResult` and `operators::kmedoids` overloads for spaces and distance providers.
 - Add deterministic C++ engine density clustering with `operators::dbscan` overloads for spaces and distance providers.
+- Add first C++ engine intent helpers and strategy objects for semantic neighbor and grouping workflows.
 
 ### Algorithm Changes
 

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -92,6 +92,17 @@ The promoted C++ operator helpers are `pairwise_distance_matrix`, `nearest_neigh
 
 The engine operator layer also exposes `metric::operators::knn`, `metric::operators::range`, `metric::operators::kmedoids`, and `metric::operators::dbscan` through `<metric/engine.hpp>` or the specific headers under `<metric/operators/>`. These overloads accept `metric::MetricSpace`, engine distance providers such as `MatrixCache`, and neighbor indexes such as `CoverTreeIndex` where appropriate. They return named results such as `metric::NeighborSet<Distance>` and `metric::ClusteringResult<Distance>` with stable `RecordId` payloads.
 
+The engine intent layer exposes semantic helpers for the same building blocks:
+
+```cpp
+auto neighbors = metric::find_neighbors(space, std::string("cut"), 2);
+auto indexed = metric::find_neighbors(space, std::string("cut"), 2, metric::strategies::cover_tree{});
+auto groups = metric::find_groups(space, metric::strategies::k_medoids(2));
+auto density_groups = metric::find_groups(space, metric::strategies::dbscan(1.0, 2));
+```
+
+These helpers keep algorithm names in `metric::strategies` while returning the same engine result objects as the lower-level operator layer.
+
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -68,6 +68,8 @@ Strategies select algorithms:
 
 Algorithm names live here. A normal user can use the engine without learning the algorithm catalog first; an expert can choose strategies explicitly.
 
+The first C++ strategy objects are available under `metric::strategies` for implemented engine paths: `brute_force`, `matrix_cache`, `cover_tree`, `knn_graph`, `k_medoids`, and `dbscan`.
+
 ### Representation
 
 Representations are execution structures over the same metric space:
@@ -109,6 +111,8 @@ Result objects preserve:
 - source-to-target lineage when a derived space or mapping is produced
 
 The first engine operator results are `metric::NeighborSet<Distance>`, returned by nearest-neighbor operators over spaces, distance providers, and neighbor indexes, and `metric::ClusteringResult<Distance>`, returned by k-medoids and DBSCAN grouping operators.
+
+The first C++ intent helpers are `metric::find_neighbors` and `metric::find_groups`. They keep the user-facing vocabulary semantic while routing to explicit strategy objects such as `metric::strategies::cover_tree`, `metric::strategies::matrix_cache`, `metric::strategies::k_medoids`, and `metric::strategies::dbscan`.
 
 ## Capabilities
 

--- a/docs/engine/mental-model.md
+++ b/docs/engine/mental-model.md
@@ -56,6 +56,21 @@ The first engine operators live under `metric::operators` and return named resul
 This is still the implementation layer, not the final intent API. It lets the same nearest-neighbor operation run against an implicit `MetricSpace`, a materialized `MatrixCache`, or a neighbor index while returning stable `RecordId` values. It also lets the first grouping operators run against either a space or distance provider while returning stable `RecordId` payloads.
 Density clustering uses the same `ClusteringResult` contract and marks noise records with `ClusteringResult<Distance>::noise_label`.
 
+## Phase 3b Surface
+
+The first semantic intent helpers live at the `metric::find_*` layer:
+
+- `metric::find_neighbors(space, query, count)`
+- `metric::find_neighbors(space, query_id, count)`
+- `metric::find_neighbors(space, query, count, metric::strategies::cover_tree{})`
+- `metric::find_neighbors(space, query, count, metric::strategies::knn_graph(graph_neighbors))`
+- `metric::find_neighbors(space, query_id, count, metric::strategies::matrix_cache{})`
+- `metric::find_groups(space, group_count)`
+- `metric::find_groups(space, metric::strategies::k_medoids(group_count))`
+- `metric::find_groups(space, metric::strategies::dbscan(radius, min_points))`
+
+These are the first user-facing names that describe intent before algorithm. Strategy objects select implementation details while preserving the same result types returned by the operator layer.
+
 ## Current Contract
 
 The initial `MetricSpace` owns records by value. `RecordId` is an opaque wrapper over dense internal storage. `version()` exists and starts at `0`; later representation adapters can use it for stale-cache checks when mutating space operations are introduced.
@@ -87,6 +102,9 @@ auto indexed_neighbors = metric::operators::knn(tree, std::string("metricks"), 2
 
 auto groups = metric::operators::kmedoids(matrix, 2);
 auto dense_groups = metric::operators::dbscan(matrix, 1, 2);
+
+auto user_neighbors = metric::find_neighbors(space, std::string("metricks"), 2);
+auto user_groups = metric::find_groups(space, metric::strategies::k_medoids(2));
 ```
 
 The important shift is vocabulary: engine code starts from a metric space and stable record IDs. Algorithm names and representation choices come later as strategies and execution structures. A representation reports stale state when the source space version changes:

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -16,6 +16,7 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - C++ engine representation adapters: `metric::representations::ImplicitDistanceProvider`, `MatrixCache`, `CoverTreeIndex`, `KnnGraphIndex`, and `GraphTopology`
 - C++ engine nearest operators: `metric::NeighborSet`, `metric::operators::knn`, and `metric::operators::range`
 - C++ engine clustering operators: `metric::ClusteringResult`, `metric::operators::kmedoids`, and `metric::operators::dbscan`
+- C++ engine intent helpers and strategies: `metric::find_neighbors`, `metric::find_groups`, `metric::strategies::brute_force`, `matrix_cache`, `cover_tree`, `knn_graph`, `k_medoids`, and `dbscan`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
 - C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphStretchDiagnostics`, `graph_stretch_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
@@ -33,6 +34,7 @@ Stable revival surface:
 - initial C++ engine skeleton under `metric/engine.hpp`, `metric/core/`, and `metric/representations/`
 - initial C++ engine nearest operators under `metric/operators/nearest.hpp`
 - initial C++ engine clustering operators under `metric/operators/clustering.hpp`
+- initial C++ engine intent helpers under `metric/intent/` and strategy objects under `metric/strategies/`
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
@@ -67,7 +69,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Area | Representative paths | Status | Release meaning |
 |---|---|---|---|
 | Core C++ facade | `metric/concepts.hpp`, `metric/space.hpp`, `metric/operators.hpp`, `metric/metric.hpp` | Core Revival | Promoted API, covered by core CI, safe for new examples. |
-| C++ engine skeleton | `metric/engine.hpp`, `metric/core/`, `metric/representations/`, `metric/operators/nearest.hpp`, `metric/operators/clustering.hpp` | Core Revival | Initial engine object model for `MetricSpace`, stable record IDs, metric traits, concept traits, representation adapters, nearest operators, and k-medoids and DBSCAN clustering operators, covered by core CI. |
+| C++ engine skeleton | `metric/engine.hpp`, `metric/core/`, `metric/representations/`, `metric/operators/nearest.hpp`, `metric/operators/clustering.hpp`, `metric/intent/`, `metric/strategies/` | Core Revival | Initial engine object model for `MetricSpace`, stable record IDs, metric traits, concept traits, representation adapters, nearest and clustering operators, and semantic `find_neighbors` / `find_groups` intent helpers with strategy objects, covered by core CI. |
 | Core C++ spaces | `metric/space/matrix.hpp`, `metric/space/knn_graph.hpp`, `metric/space/tree.hpp` | Core Revival / Expert | Stable as explicit representations; lower-level names remain compatibility APIs. |
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |

--- a/metric/engine.hpp
+++ b/metric/engine.hpp
@@ -11,6 +11,8 @@
 #include "core/neighbor.hpp"
 #include "core/record_id.hpp"
 #include "core/result.hpp"
+#include "intent/groups.hpp"
+#include "intent/neighbors.hpp"
 #include "operators/clustering.hpp"
 #include "operators/nearest.hpp"
 #include "representations/cover_tree_index.hpp"
@@ -18,5 +20,7 @@
 #include "representations/implicit.hpp"
 #include "representations/knn_graph_index.hpp"
 #include "representations/matrix_cache.hpp"
+#include "strategies/clustering.hpp"
+#include "strategies/search.hpp"
 
 #endif

--- a/metric/intent/groups.hpp
+++ b/metric/intent/groups.hpp
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_INTENT_GROUPS_HPP
+#define _METRIC_INTENT_GROUPS_HPP
+
+#include <cstddef>
+#include <type_traits>
+
+#include "../core/concepts.hpp"
+#include "../core/result.hpp"
+#include "../operators/clustering.hpp"
+#include "../strategies/clustering.hpp"
+
+namespace metric::intent {
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_groups(const Space &space, strategies::k_medoids strategy) -> ClusteringResult<typename Space::distance_type>
+{
+	return operators::kmedoids(space, strategy.groups, strategy.max_iterations);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_groups(const Space &space, std::size_t groups) -> ClusteringResult<typename Space::distance_type>
+{
+	return find_groups(space, strategies::k_medoids(groups));
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_groups(const Space &space, strategies::dbscan strategy) -> ClusteringResult<typename Space::distance_type>
+{
+	return operators::dbscan(space, strategy.radius, strategy.min_points);
+}
+
+} // namespace metric::intent
+
+namespace metric {
+using intent::find_groups;
+} // namespace metric
+
+#endif

--- a/metric/intent/neighbors.hpp
+++ b/metric/intent/neighbors.hpp
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_INTENT_NEIGHBORS_HPP
+#define _METRIC_INTENT_NEIGHBORS_HPP
+
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+
+#include "../core/concepts.hpp"
+#include "../core/record_id.hpp"
+#include "../core/result.hpp"
+#include "../operators/nearest.hpp"
+#include "../representations/cover_tree_index.hpp"
+#include "../representations/knn_graph_index.hpp"
+#include "../representations/matrix_cache.hpp"
+#include "../strategies/search.hpp"
+
+namespace metric::intent {
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_neighbors(const Space &space, const typename Space::record_type &query, std::size_t count,
+					strategies::brute_force = {}) -> NeighborSet<typename Space::distance_type>
+{
+	return operators::knn(space, query, count);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_neighbors(const Space &space, RecordId query_id, std::size_t count, strategies::brute_force = {})
+	-> NeighborSet<typename Space::distance_type>
+{
+	return operators::knn(space, query_id, count);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_neighbors(const Space &space, RecordId query_id, std::size_t count, strategies::matrix_cache)
+	-> NeighborSet<typename Space::distance_type>
+{
+	representations::MatrixCache<Space> matrix(space);
+	auto result = operators::knn(matrix, query_id, count);
+	result.representation = "matrix_cache";
+	return result;
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_neighbors(const Space &space, const typename Space::record_type &query, std::size_t count,
+					strategies::cover_tree) -> NeighborSet<typename Space::distance_type>
+{
+	representations::CoverTreeIndex<Space> index(space);
+	auto result = operators::knn(index, query, count);
+	result.representation = "cover_tree_index";
+	return result;
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_neighbors(const Space &space, const typename Space::record_type &query, std::size_t count,
+					strategies::knn_graph strategy) -> NeighborSet<typename Space::distance_type>
+{
+	const auto graph_neighbors = strategy.graph_neighbors == 0 ? count : strategy.graph_neighbors;
+	representations::KnnGraphIndex<Space> index(space, graph_neighbors);
+	auto result = operators::knn(index, query, count);
+	result.representation = "knn_graph_index";
+	return result;
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto find_neighbors(const Space &space, RecordId query_id, std::size_t count, strategies::knn_graph strategy)
+	-> NeighborSet<typename Space::distance_type>
+{
+	if (query_id.index() >= space.size()) {
+		throw std::out_of_range("query record id is outside the metric space");
+	}
+	const auto graph_neighbors = strategy.graph_neighbors == 0 ? count : strategy.graph_neighbors;
+	representations::KnnGraphIndex<Space> index(space, graph_neighbors);
+
+	NeighborSet<typename Space::distance_type> result;
+	result.neighbors = index.neighbors(query_id);
+	if (result.neighbors.size() > count) {
+		result.neighbors.resize(count);
+	}
+	result.record_count = index.record_count();
+	result.requested_count = count;
+	result.exact = true;
+	result.operator_name = "knn";
+	result.representation = "knn_graph_index";
+	return result;
+}
+
+} // namespace metric::intent
+
+namespace metric {
+using intent::find_neighbors;
+} // namespace metric
+
+#endif

--- a/metric/strategies/clustering.hpp
+++ b/metric/strategies/clustering.hpp
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_STRATEGIES_CLUSTERING_HPP
+#define _METRIC_STRATEGIES_CLUSTERING_HPP
+
+#include <cstddef>
+
+namespace metric::strategies {
+
+struct k_medoids {
+	explicit k_medoids(std::size_t groups, std::size_t max_iterations = 100)
+		: groups(groups)
+		, max_iterations(max_iterations)
+	{
+	}
+
+	std::size_t groups{};
+	std::size_t max_iterations{100};
+};
+
+struct dbscan {
+	dbscan(double radius, std::size_t min_points)
+		: radius(radius)
+		, min_points(min_points)
+	{
+	}
+
+	double radius{};
+	std::size_t min_points{};
+};
+
+} // namespace metric::strategies
+
+#endif

--- a/metric/strategies/search.hpp
+++ b/metric/strategies/search.hpp
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_STRATEGIES_SEARCH_HPP
+#define _METRIC_STRATEGIES_SEARCH_HPP
+
+#include <cstddef>
+
+namespace metric::strategies {
+
+struct brute_force {
+};
+
+struct matrix_cache {
+};
+
+struct cover_tree {
+};
+
+struct knn_graph {
+	knn_graph() = default;
+
+	explicit knn_graph(std::size_t graph_neighbors)
+		: graph_neighbors(graph_neighbors)
+	{
+	}
+
+	std::size_t graph_neighbors{};
+};
+
+} // namespace metric::strategies
+
+#endif

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -30,6 +30,9 @@ target_link_libraries(engine_clustering_operators_smoke PRIVATE ${METRIC_TARGET_
 add_executable(engine_dbscan_operator_smoke engine_dbscan_operator_smoke.cpp)
 target_link_libraries(engine_dbscan_operator_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_intent_strategy_smoke engine_intent_strategy_smoke.cpp)
+target_link_libraries(engine_intent_strategy_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_test(NAME metric_core_smoke COMMAND metric_core_smoke)
 add_test(NAME metric_mgc_smoke COMMAND metric_mgc_smoke)
 if (METRIC_BUILD_CORE_ENTROPY)
@@ -42,3 +45,4 @@ add_test(NAME engine_representations_smoke COMMAND engine_representations_smoke)
 add_test(NAME engine_nearest_operators_smoke COMMAND engine_nearest_operators_smoke)
 add_test(NAME engine_clustering_operators_smoke COMMAND engine_clustering_operators_smoke)
 add_test(NAME engine_dbscan_operator_smoke COMMAND engine_dbscan_operator_smoke)
+add_test(NAME engine_intent_strategy_smoke COMMAND engine_intent_strategy_smoke)

--- a/tests/core_smoke/engine_intent_strategy_smoke.cpp
+++ b/tests/core_smoke/engine_intent_strategy_smoke.cpp
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "metric/engine.hpp"
+
+struct StringLengthDistance {
+	auto operator()(const std::string &lhs, const std::string &rhs) const -> int
+	{
+		const auto difference = static_cast<int>(lhs.size()) - static_cast<int>(rhs.size());
+		return difference < 0 ? -difference : difference;
+	}
+};
+
+struct AbsoluteDistance {
+	auto operator()(int lhs, int rhs) const -> int
+	{
+		const auto difference = lhs - rhs;
+		return difference < 0 ? -difference : difference;
+	}
+};
+
+int main()
+{
+	auto strings = metric::make_space(std::vector<std::string>{"a", "bb", "ccc", "dddd"}, StringLengthDistance{});
+
+	const auto direct_neighbors = metric::find_neighbors(strings, std::string("ee"), 2);
+	assert(direct_neighbors.operator_name == "knn");
+	assert(direct_neighbors.representation == "metric_space");
+	assert(direct_neighbors.size() == 2);
+	assert(direct_neighbors[0].id == strings.id(1));
+
+	const auto cached_neighbors =
+		metric::find_neighbors(strings, strings.id(0), 2, metric::strategies::matrix_cache{});
+	assert(cached_neighbors.representation == "matrix_cache");
+	assert(cached_neighbors.size() == 2);
+	assert(cached_neighbors[0].id == strings.id(1));
+
+	const auto tree_neighbors =
+		metric::find_neighbors(strings, std::string("ee"), 2, metric::strategies::cover_tree{});
+	assert(tree_neighbors.representation == "cover_tree_index");
+	assert(tree_neighbors.size() == direct_neighbors.size());
+	assert(tree_neighbors[0].id == direct_neighbors[0].id);
+	assert(tree_neighbors[0].distance == direct_neighbors[0].distance);
+	assert(tree_neighbors[1].id == direct_neighbors[1].id);
+	assert(tree_neighbors[1].distance == direct_neighbors[1].distance);
+
+	const auto graph_neighbors =
+		metric::find_neighbors(strings, strings.id(0), 2, metric::strategies::knn_graph(2));
+	assert(graph_neighbors.representation == "knn_graph_index");
+	assert(graph_neighbors.size() == cached_neighbors.size());
+	assert(graph_neighbors[0].id == cached_neighbors[0].id);
+	assert(graph_neighbors[0].distance == cached_neighbors[0].distance);
+	assert(graph_neighbors[1].id == cached_neighbors[1].id);
+	assert(graph_neighbors[1].distance == cached_neighbors[1].distance);
+
+	auto numbers = metric::make_space(std::vector<int>{0, 1, 10, 11, 30}, AbsoluteDistance{});
+	const auto medoid_groups = metric::find_groups(numbers, metric::strategies::k_medoids(2));
+	assert(medoid_groups.algorithm == "kmedoids");
+	assert(medoid_groups.cluster_count == 2);
+	assert(medoid_groups.representation == "metric_space");
+
+	const auto default_groups = metric::find_groups(numbers, 2);
+	assert(default_groups.algorithm == "kmedoids");
+	assert(default_groups.assignments == medoid_groups.assignments);
+
+	const auto density_groups = metric::find_groups(numbers, metric::strategies::dbscan(2.0, 2));
+	assert(density_groups.algorithm == "dbscan");
+	assert(density_groups.cluster_count == 2);
+	assert(density_groups.noise_count == 1);
+	assert(density_groups.noise_records[0] == numbers.id(4));
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add semantic C++ intent helpers for neighbors and groups
- add strategy objects for implemented search and clustering paths
- cover intent-to-strategy routing with a core smoke test and docs

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure
- cmake --install build/core --prefix build/install-core --config Debug && cmake -S tests/downstream_consumer -B build/downstream-consumer -DCMAKE_PREFIX_PATH="/Users/michaelwelsch/Documents/metric/build/install-core" && cmake --build build/downstream-consumer --parallel 2 --config Debug && ctest --test-dir build/downstream-consumer --output-on-failure --build-config Debug