### PR TITLE
Add engine clustered-space mapping model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add deterministic C++ engine density clustering with `operators::dbscan` overloads for spaces and distance providers.
 - Add first C++ engine intent helpers and strategy objects for semantic neighbor and grouping workflows.
 - Add C++ engine entropy and MGC operator wrappers with named `EntropyResult` and `CorrelationResult` objects.
+- Add the first C++ engine mapping model conventions with `MappingResult` and a clustered-space mapping adapter.
 
 ### Algorithm Changes
 

--- a/docs/api/cpp.md
+++ b/docs/api/cpp.md
@@ -103,6 +103,8 @@ auto density_groups = metric::find_groups(space, metric::strategies::dbscan(1.0,
 
 These helpers keep algorithm names in `metric::strategies` while returning the same engine result objects as the lower-level operator layer.
 
+The first engine mapping adapter lives under `metric::mappings`. `make_clustered_space_mapping(clustering)` follows the `fit(space) -> model` and `model.transform(space) -> MappingResult<DerivedSpace>` convention. The derived clustered space stores one record per non-noise cluster, keeps the source `RecordId` lineage in `source_records`, uses the cluster representative distance as the derived metric, and marks inverse reconstruction as unsupported.
+
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -110,9 +110,11 @@ Result objects preserve:
 - metric assumptions
 - source-to-target lineage when a derived space or mapping is produced
 
-The first engine operator results are `metric::NeighborSet<Distance>`, returned by nearest-neighbor operators over spaces, distance providers, and neighbor indexes; `metric::ClusteringResult<Distance>`, returned by k-medoids and DBSCAN grouping operators; `metric::EntropyResult<double>`, returned by entropy diagnostics; and `metric::CorrelationResult<double>`, returned by MGC cross-space statistics.
+The first engine operator results are `metric::NeighborSet<Distance>`, returned by nearest-neighbor operators over spaces, distance providers, and neighbor indexes; `metric::ClusteringResult<Distance>`, returned by k-medoids and DBSCAN grouping operators; `metric::EntropyResult<double>`, returned by entropy diagnostics; `metric::CorrelationResult<double>`, returned by MGC cross-space statistics; and `metric::MappingResult<DerivedSpace>`, returned by mapping adapters that produce derived metric spaces.
 
 The first C++ intent helpers are `metric::find_neighbors` and `metric::find_groups`. They keep the user-facing vocabulary semantic while routing to explicit strategy objects such as `metric::strategies::cover_tree`, `metric::strategies::matrix_cache`, `metric::strategies::k_medoids`, and `metric::strategies::dbscan`.
+
+The first C++ mapping adapter is `metric::mappings::make_clustered_space_mapping`. It fits a clustering result to a source space and transforms it into a derived clustered metric space while preserving source `RecordId` lineage.
 
 ## Capabilities
 

--- a/docs/engine/mental-model.md
+++ b/docs/engine/mental-model.md
@@ -77,6 +77,20 @@ The first semantic intent helpers live at the `metric::find_*` layer:
 
 These are the first user-facing names that describe intent before algorithm. Strategy objects select implementation details while preserving the same result types returned by the operator layer.
 
+## Phase 4 Surface
+
+The first mapping convention lives under `metric::mappings`:
+
+- `metric::MappingResult<DerivedSpace>`
+- `metric::Mapping<Mapping, Space>`
+- `metric::MappingModel<Model, Space>`
+- `metric::mappings::fit(mapping, space)`
+- `metric::mappings::transform(model, space)`
+- `metric::mappings::make_clustered_space_mapping(clustering)`
+- `metric::mappings::clustered_space(space, clustering)`
+
+Clustered-space mapping turns a `ClusteringResult` into a derived `MetricSpace`. Each derived record represents one non-noise cluster, stores the source `RecordId`s that formed it, and uses the source-space distance between cluster representatives as the derived metric. Inverse reconstruction is explicit and currently marked unsupported.
+
 ## Current Contract
 
 The initial `MetricSpace` owns records by value. `RecordId` is an opaque wrapper over dense internal storage. `version()` exists and starts at `0`; later representation adapters can use it for stale-cache checks when mutating space operations are introduced.
@@ -111,6 +125,7 @@ auto groups = metric::operators::kmedoids(matrix, 2);
 auto dense_groups = metric::operators::dbscan(matrix, 1, 2);
 auto structure_entropy = metric::operators::entropy(space);
 auto dependency = metric::operators::mgc(space, space);
+auto clustered = metric::mappings::clustered_space(space, groups);
 
 auto user_neighbors = metric::find_neighbors(space, std::string("metricks"), 2);
 auto user_groups = metric::find_groups(space, metric::strategies::k_medoids(2));

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -18,6 +18,7 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - C++ engine clustering operators: `metric::ClusteringResult`, `metric::operators::kmedoids`, and `metric::operators::dbscan`
 - C++ engine diagnostic/statistical operators: `metric::EntropyResult`, `metric::CorrelationResult`, `metric::operators::entropy`, and `metric::operators::mgc`
 - C++ engine intent helpers and strategies: `metric::find_neighbors`, `metric::find_groups`, `metric::strategies::brute_force`, `matrix_cache`, `cover_tree`, `knn_graph`, `k_medoids`, and `dbscan`
+- C++ engine mapping model conventions: `metric::MappingResult`, `metric::Mapping`, `metric::MappingModel`, and clustered-space mapping helpers under `metric::mappings`
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
 - C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphStretchDiagnostics`, `graph_stretch_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
@@ -37,6 +38,7 @@ Stable revival surface:
 - initial C++ engine clustering operators under `metric/operators/clustering.hpp`
 - initial C++ engine entropy and correlation operators under `metric/operators/entropy.hpp` and `metric/operators/correlation.hpp`
 - initial C++ engine intent helpers under `metric/intent/` and strategy objects under `metric/strategies/`
+- initial C++ engine mapping conventions and clustered-space adapter under `metric/mappings/`
 - minimal C++ `Space` facade for `from_records`, `neighbors`, `nearest`, and `within_radius`
 - C++ operator helpers under `metric::operators`
 - explicit finite-space representations: matrix, graph, and tree
@@ -71,7 +73,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Area | Representative paths | Status | Release meaning |
 |---|---|---|---|
 | Core C++ facade | `metric/concepts.hpp`, `metric/space.hpp`, `metric/operators.hpp`, `metric/metric.hpp` | Core Revival | Promoted API, covered by core CI, safe for new examples. |
-| C++ engine skeleton | `metric/engine.hpp`, `metric/core/`, `metric/representations/`, `metric/operators/nearest.hpp`, `metric/operators/clustering.hpp`, `metric/operators/entropy.hpp`, `metric/operators/correlation.hpp`, `metric/intent/`, `metric/strategies/` | Core Revival | Initial engine object model for `MetricSpace`, stable record IDs, metric traits, concept traits, representation adapters, nearest, clustering, entropy, and MGC operators, and semantic `find_neighbors` / `find_groups` intent helpers with strategy objects, covered by core CI. |
+| C++ engine skeleton | `metric/engine.hpp`, `metric/core/`, `metric/representations/`, `metric/operators/nearest.hpp`, `metric/operators/clustering.hpp`, `metric/operators/entropy.hpp`, `metric/operators/correlation.hpp`, `metric/intent/`, `metric/strategies/`, `metric/mappings/` | Core Revival | Initial engine object model for `MetricSpace`, stable record IDs, metric traits, concept traits, representation adapters, nearest, clustering, entropy, and MGC operators, semantic `find_neighbors` / `find_groups` intent helpers with strategy objects, and mapping result conventions with clustered-space derivation, covered by core CI. |
 | Core C++ spaces | `metric/space/matrix.hpp`, `metric/space/knn_graph.hpp`, `metric/space/tree.hpp` | Core Revival / Expert | Stable as explicit representations; lower-level names remain compatibility APIs. |
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |

--- a/metric/core/concepts.hpp
+++ b/metric/core/concepts.hpp
@@ -91,6 +91,30 @@ struct GraphTopology<Topology,
 template <typename Topology>
 constexpr bool GraphTopology_v = GraphTopology<Topology>::value;
 
+template <typename MappingT, typename Space, typename = void> struct Mapping : std::false_type {
+};
+
+template <typename MappingT, typename Space>
+struct Mapping<MappingT, Space,
+			   std::void_t<decltype(std::declval<const MappingT &>().fit(std::declval<const Space &>()))>>
+	: std::true_type {
+};
+
+template <typename MappingT, typename Space>
+constexpr bool Mapping_v = Mapping<MappingT, Space>::value;
+
+template <typename ModelT, typename Space, typename = void> struct MappingModel : std::false_type {
+};
+
+template <typename ModelT, typename Space>
+struct MappingModel<ModelT, Space,
+					std::void_t<decltype(std::declval<const ModelT &>().transform(std::declval<const Space &>()))>>
+	: std::true_type {
+};
+
+template <typename ModelT, typename Space>
+constexpr bool MappingModel_v = MappingModel<ModelT, Space>::value;
+
 } // namespace metric::core
 
 namespace metric {
@@ -99,6 +123,10 @@ using core::DistanceProvider_v;
 using core::GraphTopology;
 using core::GraphTopology_v;
 using core::metric_result_t;
+using core::Mapping;
+using core::Mapping_v;
+using core::MappingModel;
+using core::MappingModel_v;
 using core::MetricCallable;
 using core::MetricCallable_v;
 using core::MetricSpaceLike;

--- a/metric/core/result.hpp
+++ b/metric/core/result.hpp
@@ -77,6 +77,22 @@ template <typename Value = double> struct CorrelationResult {
 	std::string right_representation;
 };
 
+template <typename Space> struct MappingResult {
+	using space_type = Space;
+
+	Space space;
+	std::vector<std::vector<RecordId>> source_records;
+	std::vector<RecordId> representative_records;
+	std::size_t source_record_count{};
+	bool inverse_supported{false};
+	std::string mapping;
+	std::string strategy;
+	std::string representation;
+
+	auto size() const -> std::size_t { return space.size(); }
+	auto empty() const -> bool { return space.empty(); }
+};
+
 } // namespace metric::core
 
 namespace metric {
@@ -84,6 +100,7 @@ template <typename Distance> using NeighborSet = core::NeighborSet<Distance>;
 template <typename Distance> using ClusteringResult = core::ClusteringResult<Distance>;
 template <typename Value = double> using EntropyResult = core::EntropyResult<Value>;
 template <typename Value = double> using CorrelationResult = core::CorrelationResult<Value>;
+template <typename Space> using MappingResult = core::MappingResult<Space>;
 } // namespace metric
 
 #endif

--- a/metric/engine.hpp
+++ b/metric/engine.hpp
@@ -13,6 +13,8 @@
 #include "core/result.hpp"
 #include "intent/groups.hpp"
 #include "intent/neighbors.hpp"
+#include "mappings/clustered_space.hpp"
+#include "mappings/mapping.hpp"
 #include "operators/clustering.hpp"
 #include "operators/correlation.hpp"
 #include "operators/nearest.hpp"

--- a/metric/mappings/clustered_space.hpp
+++ b/metric/mappings/clustered_space.hpp
@@ -1,0 +1,208 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_MAPPINGS_CLUSTERED_SPACE_HPP
+#define _METRIC_MAPPINGS_CLUSTERED_SPACE_HPP
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "../core/concepts.hpp"
+#include "../core/metric_space.hpp"
+#include "../core/record_id.hpp"
+#include "../core/result.hpp"
+#include "../representations/implicit.hpp"
+
+namespace metric::mappings {
+
+struct ClusterRecord {
+	std::size_t label{};
+	RecordId representative;
+	std::vector<RecordId> members;
+	bool noise{false};
+};
+
+template <typename Distance> class ClusterRepresentativeMetric {
+  public:
+	using distance_type = Distance;
+
+	ClusterRepresentativeMetric() = default;
+
+	explicit ClusterRepresentativeMetric(std::vector<std::vector<distance_type>> distances)
+		: distances_(std::move(distances))
+	{
+	}
+
+	auto operator()(const ClusterRecord &lhs, const ClusterRecord &rhs) const -> distance_type
+	{
+		return distances_.at(lhs.label).at(rhs.label);
+	}
+
+	auto distances() const -> const std::vector<std::vector<distance_type>> & { return distances_; }
+
+  private:
+	std::vector<std::vector<distance_type>> distances_;
+};
+
+template <typename Distance> class ClusteredSpaceModel {
+  public:
+	using distance_type = Distance;
+	using metric_type = ClusterRepresentativeMetric<distance_type>;
+	using space_type = MetricSpace<ClusterRecord, metric_type>;
+	using result_type = MappingResult<space_type>;
+
+	ClusteredSpaceModel(std::vector<ClusterRecord> records, std::vector<std::vector<distance_type>> distances,
+						std::vector<std::vector<RecordId>> source_records,
+						std::vector<RecordId> representative_records, std::size_t source_record_count,
+						std::string strategy, std::string representation)
+		: records_(std::move(records))
+		, distances_(std::move(distances))
+		, source_records_(std::move(source_records))
+		, representative_records_(std::move(representative_records))
+		, source_record_count_(source_record_count)
+		, strategy_(std::move(strategy))
+		, representation_(std::move(representation))
+	{
+	}
+
+	template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+	auto transform(const Space &space) const -> result_type
+	{
+		if (space.size() != source_record_count_) {
+			throw std::invalid_argument("source space size does not match fitted clustered-space mapping");
+		}
+		return transform();
+	}
+
+	auto transform() const -> result_type
+	{
+		space_type derived_space(records_, metric_type(distances_));
+		result_type result{std::move(derived_space), source_records_, representative_records_, source_record_count_,
+						   false, "clustered_space", strategy_, representation_};
+		return result;
+	}
+
+	auto inverse_supported() const -> bool { return false; }
+
+  private:
+	std::vector<ClusterRecord> records_;
+	std::vector<std::vector<distance_type>> distances_;
+	std::vector<std::vector<RecordId>> source_records_;
+	std::vector<RecordId> representative_records_;
+	std::size_t source_record_count_{};
+	std::string strategy_;
+	std::string representation_;
+};
+
+template <typename Distance> class ClusteredSpaceMapping {
+  public:
+	using distance_type = Distance;
+	using clustering_type = ClusteringResult<distance_type>;
+
+	explicit ClusteredSpaceMapping(clustering_type clustering)
+		: clustering_(std::move(clustering))
+	{
+	}
+
+	template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+	auto fit(const Space &space) const -> ClusteredSpaceModel<distance_type>
+	{
+		representations::ImplicitDistanceProvider<Space> provider(space);
+		return fit_provider(provider);
+	}
+
+	template <typename Provider, typename std::enable_if<DistanceProvider_v<Provider>, int>::type = 0>
+	auto fit_provider(const Provider &provider) const -> ClusteredSpaceModel<distance_type>
+	{
+		return build_model(provider, clustering_);
+	}
+
+  private:
+	template <typename Provider>
+	static auto build_model(const Provider &provider, const clustering_type &clustering)
+		-> ClusteredSpaceModel<distance_type>
+	{
+		const auto noise_label = clustering_type::noise_label;
+		if (clustering.record_count != provider.record_count()) {
+			throw std::invalid_argument("clustering record count does not match source provider");
+		}
+		if (clustering.assignments.size() != clustering.record_count) {
+			throw std::invalid_argument("clustering assignments do not match record count");
+		}
+		if (clustering.cluster_count == 0) {
+			throw std::invalid_argument("cannot derive a clustered space without clusters");
+		}
+
+		std::vector<std::vector<RecordId>> source_records(clustering.cluster_count);
+		for (std::size_t index = 0; index < clustering.assignments.size(); ++index) {
+			const auto label = clustering.assignments[index];
+			if (label == noise_label) {
+				continue;
+			}
+			if (label >= clustering.cluster_count) {
+				throw std::invalid_argument("clustering assignment references an unknown cluster");
+			}
+			source_records[label].push_back(RecordId::from_index(index));
+		}
+
+		std::vector<RecordId> representative_records;
+		representative_records.reserve(clustering.cluster_count);
+		std::vector<ClusterRecord> records;
+		records.reserve(clustering.cluster_count);
+
+		for (std::size_t label = 0; label < clustering.cluster_count; ++label) {
+			if (source_records[label].empty()) {
+				throw std::invalid_argument("cannot derive a clustered space with empty clusters");
+			}
+			const auto representative =
+				label < clustering.medoids.size() ? clustering.medoids[label] : source_records[label][0];
+			representative_records.push_back(representative);
+			records.push_back(ClusterRecord{label, representative, source_records[label], false});
+		}
+
+		std::vector<std::vector<distance_type>> distances(clustering.cluster_count,
+														 std::vector<distance_type>(clustering.cluster_count));
+		for (std::size_t lhs = 0; lhs < clustering.cluster_count; ++lhs) {
+			for (std::size_t rhs = 0; rhs < clustering.cluster_count; ++rhs) {
+				distances[lhs][rhs] = provider.distance(representative_records[lhs], representative_records[rhs]);
+			}
+		}
+
+		return ClusteredSpaceModel<distance_type>(std::move(records), std::move(distances), std::move(source_records),
+												 std::move(representative_records), clustering.record_count,
+												 clustering.algorithm, clustering.representation);
+	}
+
+	clustering_type clustering_;
+};
+
+template <typename Distance>
+auto make_clustered_space_mapping(ClusteringResult<Distance> clustering) -> ClusteredSpaceMapping<Distance>
+{
+	return ClusteredSpaceMapping<Distance>(std::move(clustering));
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto clustered_space(const Space &space, ClusteringResult<typename Space::distance_type> clustering)
+	-> typename ClusteredSpaceModel<typename Space::distance_type>::result_type
+{
+	return make_clustered_space_mapping(std::move(clustering)).fit(space).transform(space);
+}
+
+template <typename Provider, typename std::enable_if<DistanceProvider_v<Provider>, int>::type = 0>
+auto clustered_space(const Provider &provider, ClusteringResult<typename Provider::distance_type> clustering)
+	-> typename ClusteredSpaceModel<typename Provider::distance_type>::result_type
+{
+	auto mapping = make_clustered_space_mapping(std::move(clustering));
+	auto model = mapping.fit_provider(provider);
+	return model.transform();
+}
+
+} // namespace metric::mappings
+
+#endif

--- a/metric/mappings/mapping.hpp
+++ b/metric/mappings/mapping.hpp
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_MAPPINGS_MAPPING_HPP
+#define _METRIC_MAPPINGS_MAPPING_HPP
+
+#include "../core/concepts.hpp"
+
+namespace metric::mappings {
+
+template <typename Mapping, typename Space, typename std::enable_if<Mapping_v<Mapping, Space>, int>::type = 0>
+auto fit(const Mapping &mapping, const Space &space) -> decltype(mapping.fit(space))
+{
+	return mapping.fit(space);
+}
+
+template <typename Model, typename Space, typename std::enable_if<MappingModel_v<Model, Space>, int>::type = 0>
+auto transform(const Model &model, const Space &space) -> decltype(model.transform(space))
+{
+	return model.transform(space);
+}
+
+} // namespace metric::mappings
+
+#endif

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -35,6 +35,9 @@ target_link_libraries(engine_dbscan_operator_smoke PRIVATE ${METRIC_TARGET_NAME}
 add_executable(engine_intent_strategy_smoke engine_intent_strategy_smoke.cpp)
 target_link_libraries(engine_intent_strategy_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_mapping_model_smoke engine_mapping_model_smoke.cpp)
+target_link_libraries(engine_mapping_model_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_test(NAME metric_core_smoke COMMAND metric_core_smoke)
 add_test(NAME metric_mgc_smoke COMMAND metric_mgc_smoke)
 if (METRIC_BUILD_CORE_ENTROPY)
@@ -49,3 +52,4 @@ add_test(NAME engine_nearest_operators_smoke COMMAND engine_nearest_operators_sm
 add_test(NAME engine_clustering_operators_smoke COMMAND engine_clustering_operators_smoke)
 add_test(NAME engine_dbscan_operator_smoke COMMAND engine_dbscan_operator_smoke)
 add_test(NAME engine_intent_strategy_smoke COMMAND engine_intent_strategy_smoke)
+add_test(NAME engine_mapping_model_smoke COMMAND engine_mapping_model_smoke)

--- a/tests/core_smoke/engine_mapping_model_smoke.cpp
+++ b/tests/core_smoke/engine_mapping_model_smoke.cpp
@@ -1,0 +1,66 @@
+#include <cassert>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include "metric/engine.hpp"
+
+struct AbsoluteDistance {
+	auto operator()(int lhs, int rhs) const -> int { return lhs > rhs ? lhs - rhs : rhs - lhs; }
+};
+
+int main()
+{
+	auto space = metric::make_space(std::vector<int>{0, 1, 10, 11, 30}, AbsoluteDistance{});
+	const auto groups = metric::operators::kmedoids(space, 2);
+
+	auto mapping = metric::mappings::make_clustered_space_mapping(groups);
+	static_assert(metric::Mapping_v<decltype(mapping), decltype(space)>);
+	auto model = metric::mappings::fit(mapping, space);
+	static_assert(metric::MappingModel_v<decltype(model), decltype(space)>);
+
+	const auto reduced = metric::mappings::transform(model, space);
+	using reduced_type = typename std::decay<decltype(reduced)>::type;
+	static_assert(std::is_same<typename reduced_type::space_type::distance_type, int>::value);
+	assert(reduced.mapping == "clustered_space");
+	assert(reduced.strategy == "kmedoids");
+	assert(reduced.representation == "metric_space");
+	assert(!reduced.inverse_supported);
+	assert(reduced.source_record_count == space.size());
+	assert(reduced.space.size() == 2);
+	assert(reduced.source_records.size() == 2);
+	assert(reduced.representative_records == groups.medoids);
+
+	const auto first_cluster = reduced.space.id(0);
+	const auto second_cluster = reduced.space.id(1);
+	assert(reduced.space.distance(first_cluster, first_cluster) == 0);
+	assert(reduced.space.distance(first_cluster, second_cluster) ==
+		   space.distance(groups.medoids[0], groups.medoids[1]));
+	assert(reduced.space.record(first_cluster).members == reduced.source_records[0]);
+	assert(reduced.space.record(second_cluster).representative == groups.medoids[1]);
+
+	const auto direct = metric::mappings::clustered_space(space, groups);
+	assert(direct.space.size() == reduced.space.size());
+	assert(direct.source_records == reduced.source_records);
+	assert(direct.space.distance(direct.space.id(0), direct.space.id(1)) ==
+		   reduced.space.distance(first_cluster, second_cluster));
+
+	const auto density_groups = metric::operators::dbscan(space, 2, 2);
+	const auto density_space = metric::mappings::clustered_space(space, density_groups);
+	assert(density_space.space.size() == 2);
+	assert(density_space.source_record_count == space.size());
+	assert(density_space.source_records[0].size() == 2);
+	assert(density_space.source_records[1].size() == 2);
+
+	auto invalid_groups = groups;
+	invalid_groups.assignments.pop_back();
+	bool rejected_invalid_clustering = false;
+	try {
+		(void)metric::mappings::clustered_space(space, invalid_groups);
+	} catch (const std::invalid_argument &) {
+		rejected_invalid_clustering = true;
+	}
+	assert(rejected_invalid_clustering);
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add Mapping and MappingModel engine concepts plus MappingResult lineage metadata
- add metric::mappings fit/transform helpers and a clustered-space mapping adapter from ClusteringResult to a derived MetricSpace
- add core smoke coverage and update engine API/stability docs

## Tests
- cmake --preset core
- cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'\n- cmake --install build/core --prefix build/install-core --config Debug && cmake -S tests/downstream_consumer -B build/downstream-consumer -DCMAKE_PREFIX_PATH="/Users/michaelwelsch/Documents/metric/build/install-core" && cmake --build build/downstream-consumer --parallel 2 --config Debug && ctest --test-dir build/downstream-consumer --output-on-failure --build-config Debug\n- c++ -std=c++17 -I. -Ibuild/core/_deps/blaze-src -x c++ -o /tmp/metric_engine_include_smoke - <<'CPP'\n#include <metric/engine.hpp>\nint main() { return 0; }\nCPP\n/tmp/metric_engine_include_smoke