### PR TITLE
Document engine compare status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -40,6 +40,7 @@ The current local tree implements the first revival slice:
 - initial C++ engine clustering operators with `ClusteringResult`, deterministic `operators::kmedoids`, and deterministic `operators::dbscan` over spaces and distance providers
 - initial C++ engine intent helpers and strategies with semantic `find_neighbors` and `find_groups` entry points over implemented search and clustering paths
 - initial C++ engine entropy and MGC operators with named result objects over records and metric spaces
+- initial C++ engine compare/correlate intent helpers with explicit MGC strategy
 - initial C++ engine mapping conventions with `MappingResult` lineage metadata and clustered-space derivation
 - initial C++ engine PCFA mapping adapter with explicit fit, transform, and inverse-transform support
 - documentation for concepts, APIs, examples, stability, testing, and release gates
@@ -207,6 +208,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - deterministic C++ engine DBSCAN clustering over spaces and distance providers with noise/core record metadata and core smoke coverage, merged as `d523f18a34383206f17b1a699d6a4e819da0d801`
 - initial C++ engine intent helpers and strategy objects for semantic neighbor and grouping workflows, merged as `d3620cc63a4375ed248575d5a02114d778eb70a6`
 - initial C++ engine entropy and MGC operator wrappers with named result objects and core smoke coverage, merged as `68199bcf7443056b1ebed32fd00b57ca5fea676e`
+- C++ engine compare/correlate intent helpers with explicit MGC strategy and core smoke coverage, merged as `d90a7314a453df8b4499cebbfbc5c1f2f9d40c0d`
 - initial C++ engine mapping conventions with clustered-space derivation, `MappingResult` lineage metadata, and core smoke coverage, merged as `9e4b2d1a349d4b43e76e06ec7374f1d43a919296`
 - C++ engine PCFA mapping adapter with explicit inverse reconstruction and LAPACK-gated core smoke coverage, merged as `0aff5aea43433b4fe1b20dbc84cedf71b0e4559e`
 


### PR DESCRIPTION
## Summary
- record the merged compare/correlate engine intent helpers in revival status
- add the local scope item and post-v0.3.2 master ledger entry

## Tests
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb