### PR TITLE
Document engine reduce status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -41,6 +41,7 @@ The current local tree implements the first revival slice:
 - initial C++ engine intent helpers and strategies with semantic `find_neighbors` and `find_groups` entry points over implemented search and clustering paths
 - initial C++ engine entropy and MGC operators with named result objects over records and metric spaces
 - initial C++ engine compare/correlate intent helpers with explicit MGC strategy
+- initial C++ engine reduce intent backed by the PCFA strategy
 - initial C++ engine mapping conventions with `MappingResult` lineage metadata and clustered-space derivation
 - initial C++ engine PCFA mapping adapter with explicit fit, transform, and inverse-transform support
 - documentation for concepts, APIs, examples, stability, testing, and release gates
@@ -211,6 +212,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ engine compare/correlate intent helpers with explicit MGC strategy and core smoke coverage, merged as `d90a7314a453df8b4499cebbfbc5c1f2f9d40c0d`
 - initial C++ engine mapping conventions with clustered-space derivation, `MappingResult` lineage metadata, and core smoke coverage, merged as `9e4b2d1a349d4b43e76e06ec7374f1d43a919296`
 - C++ engine PCFA mapping adapter with explicit inverse reconstruction and LAPACK-gated core smoke coverage, merged as `0aff5aea43433b4fe1b20dbc84cedf71b0e4559e`
+- C++ engine reduce intent backed by the PCFA strategy with LAPACK-gated core smoke coverage, merged as `cf1ceef290f73fac95943f0b7132953fe9d0c698`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the PCFA-backed reduce intent in the revival local scope
- add the merged reduce-intent SHA to the post-v0.3.2 master progress ledger

## Tests
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
