### PR TITLE
Add Python engine intent facade methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add a C++ engine reduce intent backed by the PCFA strategy.
 - Add a C++ engine `describe_structure` intent with exact finite-space diagnostics and intrinsic-dimension metadata.
 - Add a C++ engine `find_representatives` intent backed by deterministic farthest-first selection.
+- Add Python `Space.describe()` and `Space.representatives()` intent methods with named result objects and a `FarthestFirst` strategy.
 
 ### Algorithm Changes
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -2,7 +2,7 @@
 
 The current Python core API exposes metric constructors, a minimal `Space` facade, finite-space helpers, and small operator helpers. It is intentionally small while the broader engine facade is restored.
 
-The stable entry point is `Space`: a finite record set plus a metric with cached pairwise distances and intent-named neighbor helpers. `FiniteMetricSpace` and `MatrixSpace` remain available for explicit representation vocabulary.
+The stable entry point is `Space`: a finite record set plus a metric with cached pairwise distances and intent-named helpers for neighbors, representatives, and structure diagnostics. `FiniteMetricSpace` and `MatrixSpace` remain available for explicit representation vocabulary.
 
 ## Basic Use
 
@@ -25,6 +25,7 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
 - `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph connectivity diagnostics, graph degree diagnostics, graph stretch diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `strategies`: strategy objects for intent methods, starting with `FarthestFirst`
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -38,6 +39,10 @@ space.pairwise_distances()
 space.neighbors(query, k=10)
 space.nearest(query)
 space.within_radius(query, radius=1)
+space.representatives(k=3)
+space.representatives(k=3, strategy=FarthestFirst(seed_index=1))
+space.describe()
+space.describe_structure()
 space.knn(query, k=10)
 space.nn(query)
 space.rnn(query, radius=1)
@@ -52,12 +57,16 @@ from metric.operators import (
     GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
     GraphStretchDiagnostics,
+    RepresentativeSet,
+    StructureDescription,
     coverage_representative_indices,
     coverage_representatives,
+    describe_structure,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    find_representatives,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     graph_stretch_diagnostics,
@@ -74,6 +83,7 @@ from metric.operators import (
     separated_representatives,
     symmetrize_graph,
 )
+from metric.strategies import FarthestFirst
 
 distances = pairwise_distance_matrix(records, Edit())
 neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
@@ -96,9 +106,13 @@ separated_records = separated_representatives(records, Edit(), minimum_distance=
 covered_ids = coverage_representative_indices(records, Edit(), radius=1)
 covered_records = coverage_representatives(records, Edit(), radius=1)
 dimension = intrinsic_dimension(records, Edit())
+representative_result = find_representatives(records, Edit(), k=2, strategy=FarthestFirst(seed_index=0))
+structure = describe_structure(records, Edit())
 ```
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
+
+`find_representatives` returns a `RepresentativeSet` with selected source indices, nearest-representative distances for every record, coverage radius, average nearest-representative distance, strategy metadata, and representation metadata. `Space.representatives(...)` exposes the same result from the `Space` facade.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
 
@@ -119,6 +133,8 @@ dimension = intrinsic_dimension(records, Edit())
 `coverage_representative_indices` and `coverage_representatives` use deterministic greedy radius coverage. They scan records in order, choose the first uncovered record as a representative, and mark every record within `radius` as covered.
 
 `intrinsic_dimension` returns an expansion-dimension estimate based on finite-space neighborhood growth. Treat it as a diagnostic that depends on the metric, sample density, duplicates, and available radii.
+
+`describe_structure` returns a `StructureDescription` with record count, evaluated pair count, zero-distance pair count, minimum nonzero distance, maximum distance, average distance, and intrinsic-dimension estimate. `Space.describe()` and `Space.describe_structure()` expose the same diagnostics from the `Space` facade.
 
 ## Custom Metrics
 
@@ -155,7 +171,7 @@ print(space.distance(0, 1))
 
 ## Engine Roadmap
 
-The implemented facade currently covers neighbor access. Additional intent names such as `groups`, `embed`, `map`, `reduce`, `denoise`, `outliers`, and `compare` describe the public direction and should be promoted only when they are backed by stable strategies, result objects, examples, and CI.
+The implemented facade currently covers neighbor access, representative selection, and structure diagnostics. Additional intent names such as `groups`, `embed`, `map`, `reduce`, `denoise`, `outliers`, and `compare` describe the public direction and should be promoted only when they are backed by stable strategies, result objects, examples, and CI.
 
 ## Compatibility
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -23,9 +23,9 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
 - C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphStretchDiagnostics`, `graph_stretch_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
-- Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`
+- Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`, and `metric.strategies.FarthestFirst`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, representative-selection, and Python `Space.describe()` / `Space.representatives()` helpers
 - entropy and MGC core examples
 
 ## Stability Tiers

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -17,7 +17,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from . import mappings, metrics, operators, spaces, transforms
+from . import mappings, metrics, operators, spaces, strategies, transforms
 from .metrics import Edit
 from .operators import (
     GraphConnectivityDiagnostics,
@@ -25,12 +25,16 @@ from .operators import (
     GraphStretchDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
+    RepresentativeSet,
+    StructureDescription,
     coverage_representative_indices,
     coverage_representatives,
+    describe_structure,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    find_representatives,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     graph_stretch_diagnostics,
@@ -48,6 +52,7 @@ from .operators import (
     symmetrize_graph,
 )
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
+from .strategies import FarthestFirst
 
 __all__ = sorted(
     name

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -5,6 +5,7 @@ import math
 import operator
 
 from metric.spaces import FiniteMetricSpace
+from metric.strategies import FarthestFirst
 
 
 @dataclass(frozen=True)
@@ -81,6 +82,38 @@ class GraphStretchDiagnostics:
     max_stretch: float
     average_stretch: float
     stretch_policy: str
+
+
+@dataclass(frozen=True)
+class RepresentativeSet:
+    """Representative-selection result with coverage diagnostics."""
+
+    representatives: tuple
+    nearest_representative_distances: tuple
+    record_count: int
+    requested_count: int
+    coverage_radius: object
+    average_nearest_distance: float
+    exact: bool
+    strategy: str
+    representation: str
+
+
+@dataclass(frozen=True)
+class StructureDescription:
+    """Exact finite-space structure diagnostics."""
+
+    record_count: int
+    pair_count: int
+    zero_distance_pair_count: int
+    minimum_nonzero_distance: object
+    maximum_distance: object
+    average_distance: float
+    intrinsic_dimension: float
+    has_nonzero_distances: bool
+    exact: bool
+    strategy: str
+    representation: str
 
 
 def pairwise_distance_matrix(records, metric):
@@ -557,6 +590,11 @@ def graph_stretch_diagnostics(records, metric, graph):
 
 def representative_indices(records, metric, k, seed_index=0):
     """Select representative record IDs with deterministic farthest-first traversal."""
+    selected, _nearest_selected_distances, _records = _farthest_first_selection(records, metric, k, seed_index)
+    return selected
+
+
+def _farthest_first_selection(records, metric, k, seed_index=0):
     records = list(records)
     try:
         k = operator.index(k)
@@ -567,7 +605,7 @@ def representative_indices(records, metric, k, seed_index=0):
     if k < 0:
         raise ValueError("k must be non-negative")
     if k == 0:
-        return []
+        return [], [], records
     if not records:
         raise ValueError("cannot select representatives from an empty record set")
     if k > len(records):
@@ -604,7 +642,45 @@ def representative_indices(records, metric, k, seed_index=0):
                 space.distance(index, next_index),
             )
 
-    return selected
+    return selected, nearest_selected_distances, records
+
+
+def _coerce_farthest_first(strategy):
+    if strategy is None:
+        return FarthestFirst()
+    if isinstance(strategy, FarthestFirst):
+        return strategy
+    if hasattr(strategy, "seed_index"):
+        return FarthestFirst(seed_index=strategy.seed_index)
+    raise TypeError("strategy must be a FarthestFirst strategy")
+
+
+def find_representatives(records, metric, k, strategy=None):
+    """Select representatives and return an engine-style result object."""
+    strategy = _coerce_farthest_first(strategy)
+    selected, nearest_selected_distances, records = _farthest_first_selection(
+        records,
+        metric,
+        k,
+        strategy.seed_index,
+    )
+    coverage_radius = max(nearest_selected_distances, default=0)
+    average_nearest_distance = (
+        sum(float(distance) for distance in nearest_selected_distances) / len(nearest_selected_distances)
+        if nearest_selected_distances
+        else 0.0
+    )
+    return RepresentativeSet(
+        representatives=tuple(selected),
+        nearest_representative_distances=tuple(nearest_selected_distances),
+        record_count=len(records),
+        requested_count=operator.index(k),
+        coverage_radius=coverage_radius,
+        average_nearest_distance=average_nearest_distance,
+        exact=True,
+        strategy="farthest_first",
+        representation="metric_space",
+    )
 
 
 def representatives(records, metric, k, seed_index=0):
@@ -711,6 +787,45 @@ def intrinsic_dimension(records, metric):
     return intrinsic_dimension_from_distances(pairwise_distance_matrix(records, metric))
 
 
+def describe_structure(records, metric):
+    """Describe exact finite-space structure with all-pairs diagnostics."""
+    records = list(records)
+    distances = pairwise_distance_matrix(records, metric)
+    pair_count = 0
+    zero_distance_pair_count = 0
+    minimum_nonzero_distance = 0
+    maximum_distance = 0
+    distance_sum = 0.0
+    has_nonzero_distances = False
+
+    for lhs_index in range(len(records)):
+        for rhs_index in range(lhs_index + 1, len(records)):
+            distance = distances[lhs_index][rhs_index]
+            pair_count += 1
+            distance_sum += float(distance)
+            if distance <= 0:
+                zero_distance_pair_count += 1
+            elif not has_nonzero_distances or distance < minimum_nonzero_distance:
+                minimum_nonzero_distance = distance
+                has_nonzero_distances = True
+            if pair_count == 1 or maximum_distance < distance:
+                maximum_distance = distance
+
+    return StructureDescription(
+        record_count=len(records),
+        pair_count=pair_count,
+        zero_distance_pair_count=zero_distance_pair_count,
+        minimum_nonzero_distance=minimum_nonzero_distance,
+        maximum_distance=maximum_distance,
+        average_distance=distance_sum / pair_count if pair_count else 0.0,
+        intrinsic_dimension=intrinsic_dimension_from_distances(distances),
+        has_nonzero_distances=has_nonzero_distances,
+        exact=True,
+        strategy="exact_all_pairs",
+        representation="metric_space",
+    )
+
+
 def intrinsic_dimension_from_distances(distances):
     maximum_dimension = 0.0
     for row in distances:
@@ -731,6 +846,10 @@ __all__ = [
     "GraphStretchDiagnostics",
     "GraphConstructionMetadata",
     "GraphConstructionResult",
+    "RepresentativeSet",
+    "StructureDescription",
+    "describe_structure",
+    "find_representatives",
     "graph_connectivity_diagnostics",
     "graph_degree_diagnostics",
     "graph_stretch_diagnostics",

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -63,6 +63,19 @@ class Space(FiniteMetricSpace):
     def within_radius(self, query, radius):
         return self.rnn(query, radius)
 
+    def representatives(self, k, strategy=None):
+        from metric.operators import find_representatives
+
+        return find_representatives(self.records, self.metric, k, strategy=strategy)
+
+    def describe(self):
+        from metric.operators import describe_structure
+
+        return describe_structure(self.records, self.metric)
+
+    def describe_structure(self):
+        return self.describe()
+
 
 MatrixSpace = FiniteMetricSpace
 

--- a/python/pkg/metric/strategies.py
+++ b/python/pkg/metric/strategies.py
@@ -1,0 +1,13 @@
+"""Strategy objects for the revived Python engine facade."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FarthestFirst:
+    """Deterministic farthest-first representative-selection strategy."""
+
+    seed_index: int = 0
+
+
+__all__ = ["FarthestFirst"]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -14,12 +14,16 @@ from metric.operators import (
     GraphStretchDiagnostics,
     GraphConstructionMetadata,
     GraphConstructionResult,
+    RepresentativeSet,
+    StructureDescription,
     coverage_representative_indices,
     coverage_representatives,
+    describe_structure,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    find_representatives,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     graph_stretch_diagnostics,
@@ -37,6 +41,7 @@ from metric.operators import (
     symmetrize_graph,
 )
 from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
+from metric.strategies import FarthestFirst
 
 
 class RevivalApiTest(unittest.TestCase):
@@ -73,6 +78,10 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.operators.RepresentativeSet, RepresentativeSet)
+        self.assertIs(metric.operators.StructureDescription, StructureDescription)
+        self.assertIs(metric.operators.describe_structure, describe_structure)
+        self.assertIs(metric.operators.find_representatives, find_representatives)
         self.assertIs(metric.operators.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.operators.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.operators.exact_radius_graph, exact_radius_graph)
@@ -92,6 +101,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.coverage_representative_indices, coverage_representative_indices)
         self.assertIs(metric.operators.coverage_representatives, coverage_representatives)
         self.assertIs(metric.mappings, mappings)
+        self.assertIs(metric.strategies.FarthestFirst, FarthestFirst)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
         self.assertIs(metric.GraphConnectivityDiagnostics, GraphConnectivityDiagnostics)
@@ -99,6 +109,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.RepresentativeSet, RepresentativeSet)
+        self.assertIs(metric.StructureDescription, StructureDescription)
+        self.assertIs(metric.describe_structure, describe_structure)
+        self.assertIs(metric.find_representatives, find_representatives)
+        self.assertIs(metric.FarthestFirst, FarthestFirst)
         self.assertIs(metric.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.exact_radius_graph, exact_radius_graph)
@@ -129,6 +144,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("GraphStretchDiagnostics", metric.__all__)
         self.assertIn("GraphConstructionMetadata", metric.__all__)
         self.assertIn("GraphConstructionResult", metric.__all__)
+        self.assertIn("RepresentativeSet", metric.__all__)
+        self.assertIn("StructureDescription", metric.__all__)
+        self.assertIn("describe_structure", metric.__all__)
+        self.assertIn("find_representatives", metric.__all__)
+        self.assertIn("FarthestFirst", metric.__all__)
         self.assertIn("exact_knn_graph", metric.__all__)
         self.assertIn("exact_knn_graph_edges", metric.__all__)
         self.assertIn("exact_radius_graph", metric.__all__)
@@ -189,6 +209,34 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(nearest_neighbors(self.records, self.metric, "cut", 2), [(0, 1), (1, 1)])
         self.assertEqual(range_neighbors(self.records, self.metric, "cut", 1), [(0, 1), (1, 1)])
         self.assertEqual(pairwise_distance_matrix(self.records, self.metric)[0][1], 1)
+
+    def test_space_intent_methods_return_named_results(self):
+        space = Space([0, 1, 2, 3, 4], metric=lambda lhs, rhs: abs(lhs - rhs))
+
+        representatives_result = space.representatives(3)
+        self.assertIsInstance(representatives_result, RepresentativeSet)
+        self.assertEqual(representatives_result.representatives, (0, 4, 2))
+        self.assertEqual(representatives_result.nearest_representative_distances, (0, 1, 0, 1, 0))
+        self.assertEqual(representatives_result.record_count, 5)
+        self.assertEqual(representatives_result.requested_count, 3)
+        self.assertEqual(representatives_result.coverage_radius, 1)
+        self.assertAlmostEqual(representatives_result.average_nearest_distance, 0.4)
+        self.assertEqual(representatives_result.strategy, "farthest_first")
+        self.assertEqual(representatives_result.representation, "metric_space")
+
+        seeded = space.representatives(2, strategy=FarthestFirst(seed_index=2))
+        self.assertEqual(seeded.representatives, (2, 0))
+
+        description = space.describe()
+        self.assertIsInstance(description, StructureDescription)
+        self.assertEqual(description.record_count, 5)
+        self.assertEqual(description.pair_count, 10)
+        self.assertEqual(description.zero_distance_pair_count, 0)
+        self.assertEqual(description.minimum_nonzero_distance, 1)
+        self.assertEqual(description.maximum_distance, 4)
+        self.assertAlmostEqual(description.average_distance, 2.0)
+        self.assertAlmostEqual(description.intrinsic_dimension, np.log2(5.0 / 3.0))
+        self.assertEqual(space.describe_structure(), description)
 
     def test_intrinsic_dimension_estimates_distance_growth(self):
         records = [0, 1, 2, 3, 4]


### PR DESCRIPTION
## Summary
- add Python `FarthestFirst`, `RepresentativeSet`, and `StructureDescription` public objects
- add `find_representatives`, `describe_structure`, `Space.representatives`, `Space.describe`, and `Space.describe_structure`
- expand Python core tests and API docs for the intent-style facade

## Tests
- `cmake --preset python-cmake`
- `cmake --build --preset python-cmake --parallel 2`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
