### PR TITLE
Add Python groups intent facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add a C++ engine `describe_structure` intent with exact finite-space diagnostics and intrinsic-dimension metadata.
 - Add a C++ engine `find_representatives` intent backed by deterministic farthest-first selection.
 - Add Python `Space.describe()` and `Space.representatives()` intent methods with named result objects and a `FarthestFirst` strategy.
+- Add Python `Space.groups()` and `find_groups` intent methods with named `ClusteringResult` objects and `KMedoids` / `DBSCAN` strategies.
 
 ### Algorithm Changes
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -2,7 +2,7 @@
 
 The current Python core API exposes metric constructors, a minimal `Space` facade, finite-space helpers, and small operator helpers. It is intentionally small while the broader engine facade is restored.
 
-The stable entry point is `Space`: a finite record set plus a metric with cached pairwise distances and intent-named helpers for neighbors, representatives, and structure diagnostics. `FiniteMetricSpace` and `MatrixSpace` remain available for explicit representation vocabulary.
+The stable entry point is `Space`: a finite record set plus a metric with cached pairwise distances and intent-named helpers for neighbors, groups, representatives, and structure diagnostics. `FiniteMetricSpace` and `MatrixSpace` remain available for explicit representation vocabulary.
 
 ## Basic Use
 
@@ -24,8 +24,8 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `Space`: minimal intent-first finite metric space facade
 - `FiniteMetricSpace`: finite metric space over records
 - `MatrixSpace`: compatibility alias for `FiniteMetricSpace`
-- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph connectivity diagnostics, graph degree diagnostics, graph stretch diagnostics, graph pruning, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
-- `strategies`: strategy objects for intent methods, starting with `FarthestFirst`
+- `operators`: small helpers for pairwise distances, nearest neighbors, range neighbors, exact graph results and edges, graph connectivity diagnostics, graph degree diagnostics, graph stretch diagnostics, graph pruning, grouping, representative selection, medoids, separated representatives, and intrinsic-dimension diagnostics
+- `strategies`: strategy objects for intent methods, starting with `KMedoids`, `DBSCAN`, and `FarthestFirst`
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
@@ -39,6 +39,8 @@ space.pairwise_distances()
 space.neighbors(query, k=10)
 space.nearest(query)
 space.within_radius(query, radius=1)
+space.groups(strategy=KMedoids(groups=2))
+space.groups(strategy=DBSCAN(radius=1, min_points=2))
 space.representatives(k=3)
 space.representatives(k=3, strategy=FarthestFirst(seed_index=1))
 space.describe()
@@ -52,6 +54,7 @@ space.rnn(query, radius=1)
 
 ```python
 from metric.operators import (
+    ClusteringResult,
     GraphConstructionMetadata,
     GraphConstructionResult,
     GraphConnectivityDiagnostics,
@@ -61,16 +64,19 @@ from metric.operators import (
     StructureDescription,
     coverage_representative_indices,
     coverage_representatives,
+    dbscan,
     describe_structure,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    find_groups,
     find_representatives,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     graph_stretch_diagnostics,
     intrinsic_dimension,
+    kmedoids,
     medoid,
     medoid_index,
     nearest_neighbors,
@@ -83,7 +89,7 @@ from metric.operators import (
     separated_representatives,
     symmetrize_graph,
 )
-from metric.strategies import FarthestFirst
+from metric.strategies import DBSCAN, FarthestFirst, KMedoids
 
 distances = pairwise_distance_matrix(records, Edit())
 neighbors = nearest_neighbors(records, Edit(), "cut", k=2)
@@ -97,6 +103,8 @@ degree_info = graph_degree_diagnostics(knn_graph)
 stretch_info = graph_stretch_diagnostics(records, Edit(), radius_graph)
 undirected = symmetrize_graph(knn_graph, policy="union", weighting="minimum_distance")
 pruned = prune_graph_out_degree(exact_knn_graph(records, Edit(), k=2), max_out_degree=1)
+groups = find_groups(records, Edit(), KMedoids(groups=2))
+density_groups = find_groups(records, Edit(), DBSCAN(radius=1, min_points=2))
 selected_ids = representative_indices(records, Edit(), k=2)
 selected_records = representatives(records, Edit(), k=2)
 center_id = medoid_index(records, Edit())
@@ -109,6 +117,8 @@ dimension = intrinsic_dimension(records, Edit())
 representative_result = find_representatives(records, Edit(), k=2, strategy=FarthestFirst(seed_index=0))
 structure = describe_structure(records, Edit())
 ```
+
+`find_groups` returns a `ClusteringResult` with source-record assignments, medoid record IDs, cluster sizes, optional DBSCAN core/noise records, iteration metadata, algorithm metadata, and representation metadata. `Space.groups(...)` exposes the same result from the `Space` facade. Passing an integer group count selects deterministic `KMedoids`; passing `KMedoids` or `DBSCAN` makes the strategy explicit.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
@@ -171,7 +181,7 @@ print(space.distance(0, 1))
 
 ## Engine Roadmap
 
-The implemented facade currently covers neighbor access, representative selection, and structure diagnostics. Additional intent names such as `groups`, `embed`, `map`, `reduce`, `denoise`, `outliers`, and `compare` describe the public direction and should be promoted only when they are backed by stable strategies, result objects, examples, and CI.
+The implemented facade currently covers neighbor access, grouping, representative selection, and structure diagnostics. Additional intent names such as `embed`, `map`, `reduce`, `denoise`, `outliers`, and `compare` describe the public direction and should be promoted only when they are backed by stable strategies, result objects, examples, and CI.
 
 ## Compatibility
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -23,9 +23,9 @@ The Core Revival API is the currently promoted, CI-tested entry point.
 - C++ facade: `metric::Space::from_records` returning `metric::FiniteSpace`
 - C++ helpers: `metric::operators::pairwise_distance_matrix`, `nearest_neighbors`, `range_neighbors`, `GraphConnectivityDiagnostics`, `graph_connectivity_diagnostics`, `GraphDegreeDiagnostics`, `graph_degree_diagnostics`, `GraphStretchDiagnostics`, `graph_stretch_diagnostics`, `GraphConstructionResult`, `GraphConstructionMetadata`, `exact_knn_graph`, `exact_knn_graph_edges`, `exact_radius_graph`, `exact_radius_graph_edges`, `symmetrize_graph`, `prune_graph_out_degree`, `representative_indices`, `representatives`, `medoid_index`, `medoid`, `separated_representative_indices`, `separated_representatives`, `coverage_representative_indices`, `coverage_representatives`, and `intrinsic_dimension`
 - explicit C++ representations: `metric::MatrixSpace`, `metric::GraphSpace`, `metric::TreeSpace`
-- Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`, and `metric.strategies.FarthestFirst`
+- Python helpers: `metric.Space`, `metric.metrics`, `metric.spaces.FiniteMetricSpace`, `metric.operators`, `metric.strategies.KMedoids`, `metric.strategies.DBSCAN`, and `metric.strategies.FarthestFirst`
 - Python beta bridges: `metric.mappings`, `metric.transforms`
-- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, representative-selection, and Python `Space.describe()` / `Space.representatives()` helpers
+- nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, grouping, representative-selection, and Python `Space.groups()` / `Space.describe()` / `Space.representatives()` helpers
 - entropy and MGC core examples
 
 ## Stability Tiers
@@ -46,7 +46,7 @@ Stable revival surface:
 - nearest-neighbor, range-neighbor, pairwise-distance, exact graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, exact graph-edge, intrinsic-dimension, and representative-selection helpers
 - minimal Python `Space` facade for `neighbors`, `nearest`, and `within_radius`
 - entropy and MGC regression examples
-- Python core helpers under `metric.metrics`, `metric.spaces`, and `metric.operators`
+- Python core helpers under `metric.metrics`, `metric.spaces`, `metric.strategies`, and `metric.operators`
 - Python beta compatibility bridges under `metric.mappings` and `metric.transforms`
 - CMake install/export and downstream consumer support
 
@@ -79,7 +79,7 @@ This matrix labels the current tree by support status. It is deliberately path-b
 | Promoted C++ metrics | `metric/distance/k-related/Standards.hpp`, `metric/distance/k-structured/Edit.hpp`, `metric/distance/k-structured/TWED.hpp`, `metric/distance/k-structured/EMD.hpp` | Core Revival | Covered by promoted examples or smoke tests. Broader distance modules need their own fixtures before promotion. |
 | Core diagnostics | `metric/operators.hpp`, `metric/correlation/entropy.hpp`, `metric/correlation/mgc.hpp` | Core Revival | Covered by deterministic smoke tests and examples. |
 | Core C++ examples and tests | `examples/core/`, `tests/core_smoke/`, `tests/downstream_consumer/` | Core Revival | Required release gates. Every promoted example here is executed by CTest. |
-| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
+| Python core facade | `python/pkg/metric/metrics.py`, `python/pkg/metric/spaces.py`, `python/pkg/metric/strategies.py`, `python/pkg/metric/operators.py`, `python/pkg/metric/__init__.py` | Core Revival | Promoted Python API, including deterministic graph-result, graph-connectivity-diagnostics, graph-degree-diagnostics, graph-stretch-diagnostics, graph-symmetrization, graph-out-degree-pruning, graph-edge, grouping, representative-selection, medoid, separated-representative, and radius-coverage helpers, covered by wheel CI and core Python tests. |
 | Python beta bridges | `python/pkg/metric/mappings.py`, `python/pkg/metric/transforms.py` | Beta / Compatibility | Stable import locations that expose installed legacy names without promoting those algorithms into the core-wheel contract. |
 | Python compatibility bindings | `python/pkg/metric/distance/`, `python/pkg/metric/correlation/`, `python/pkg/metric/mapping/`, `python/pkg/metric/space/`, `python/pkg/metric/transform/`, `python/pkg/metric/utils/` | Compatibility | Import-compatible surface for existing users; new examples should prefer the revived facade. |
 | Mapping algorithms | `metric/mapping/`, `examples/mapping_examples/`, `tests/mapping_tests/` | Beta | Useful research code, not a default release gate until deterministic fixtures and public result contracts are added. |

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 from . import mappings, metrics, operators, spaces, strategies, transforms
 from .metrics import Edit
 from .operators import (
+    ClusteringResult,
     GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
     GraphStretchDiagnostics,
@@ -29,16 +30,19 @@ from .operators import (
     StructureDescription,
     coverage_representative_indices,
     coverage_representatives,
+    dbscan,
     describe_structure,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    find_groups,
     find_representatives,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     graph_stretch_diagnostics,
     intrinsic_dimension,
+    kmedoids,
     medoid,
     medoid_index,
     nearest_neighbors,
@@ -52,7 +56,7 @@ from .operators import (
     symmetrize_graph,
 )
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
-from .strategies import FarthestFirst
+from .strategies import DBSCAN, FarthestFirst, KMedoids
 
 __all__ = sorted(
     name

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -3,9 +3,10 @@
 from dataclasses import dataclass
 import math
 import operator
+from typing import ClassVar
 
 from metric.spaces import FiniteMetricSpace
-from metric.strategies import FarthestFirst
+from metric.strategies import DBSCAN, FarthestFirst, KMedoids
 
 
 @dataclass(frozen=True)
@@ -82,6 +83,26 @@ class GraphStretchDiagnostics:
     max_stretch: float
     average_stretch: float
     stretch_policy: str
+
+
+@dataclass(frozen=True)
+class ClusteringResult:
+    """Engine-style grouping result with assignments and cluster metadata."""
+
+    noise_label: ClassVar[int] = -1
+
+    assignments: tuple
+    medoids: tuple
+    core_records: tuple
+    noise_records: tuple
+    cluster_sizes: tuple
+    record_count: int
+    cluster_count: int
+    noise_count: int
+    iterations: int
+    converged: bool
+    algorithm: str
+    representation: str
 
 
 @dataclass(frozen=True)
@@ -588,6 +609,330 @@ def graph_stretch_diagnostics(records, metric, graph):
     )
 
 
+def _coerce_positive_integer(value, name):
+    try:
+        value = operator.index(value)
+    except TypeError:
+        raise TypeError(f"{name} must be an integer") from None
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _coerce_non_negative_integer(value, name):
+    try:
+        value = operator.index(value)
+    except TypeError:
+        raise TypeError(f"{name} must be an integer") from None
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
+
+
+def _total_distance_to_all(space, candidate_index):
+    return sum(
+        space.distance(candidate_index, other_index)
+        for other_index in range(len(space.records))
+    )
+
+
+def _nearest_medoid_distance(space, medoids, record_index):
+    best_distance = None
+    for medoid_index in medoids:
+        distance = space.distance(record_index, medoid_index)
+        if best_distance is None or distance < best_distance:
+            best_distance = distance
+    return best_distance
+
+
+def _initialize_medoids(space, group_count):
+    medoids = []
+    best_index = 0
+    best_total = None
+    for candidate_index in range(len(space.records)):
+        total = _total_distance_to_all(space, candidate_index)
+        if best_total is None or total < best_total:
+            best_index = candidate_index
+            best_total = total
+
+    medoids.append(best_index)
+    selected = {best_index}
+
+    while len(medoids) < group_count:
+        next_index = None
+        next_distance = None
+        for candidate_index in range(len(space.records)):
+            if candidate_index in selected:
+                continue
+            distance = _nearest_medoid_distance(space, medoids, candidate_index)
+            if (
+                next_distance is None
+                or distance > next_distance
+                or (distance == next_distance and candidate_index < next_index)
+            ):
+                next_index = candidate_index
+                next_distance = distance
+
+        if next_index is None:
+            raise RuntimeError("failed to initialize k-medoids")
+
+        medoids.append(next_index)
+        selected.add(next_index)
+
+    return sorted(medoids)
+
+
+def _assign_to_medoids(space, medoids):
+    assignments = [0] * len(space.records)
+    cluster_sizes = [0] * len(medoids)
+
+    for record_index in range(len(space.records)):
+        best_cluster = 0
+        best_distance = None
+        for cluster_index, medoid_index in enumerate(medoids):
+            distance = space.distance(record_index, medoid_index)
+            if (
+                best_distance is None
+                or distance < best_distance
+                or (distance == best_distance and medoid_index < medoids[best_cluster])
+            ):
+                best_cluster = cluster_index
+                best_distance = distance
+
+        assignments[record_index] = best_cluster
+        cluster_sizes[best_cluster] += 1
+
+    return assignments, cluster_sizes
+
+
+def _recompute_medoids(space, assignments, cluster_sizes, current_medoids):
+    medoids = []
+    for cluster_index, cluster_size in enumerate(cluster_sizes):
+        if cluster_size == 0:
+            medoids.append(current_medoids[cluster_index])
+            continue
+
+        best_index = None
+        best_total = None
+        for candidate_index, assignment in enumerate(assignments):
+            if assignment != cluster_index:
+                continue
+            total = sum(
+                space.distance(candidate_index, other_index)
+                for other_index, other_assignment in enumerate(assignments)
+                if other_assignment == cluster_index
+            )
+            if best_total is None or total < best_total or (total == best_total and candidate_index < best_index):
+                best_index = candidate_index
+                best_total = total
+
+        medoids.append(best_index)
+
+    return sorted(medoids)
+
+
+def _compute_cluster_medoids(space, assignments, cluster_count):
+    medoids = []
+    for cluster_index in range(cluster_count):
+        best_index = None
+        best_total = None
+        for candidate_index, assignment in enumerate(assignments):
+            if assignment != cluster_index:
+                continue
+            total = sum(
+                space.distance(candidate_index, other_index)
+                for other_index, other_assignment in enumerate(assignments)
+                if other_assignment == cluster_index
+            )
+            if best_total is None or total < best_total or (total == best_total and candidate_index < best_index):
+                best_index = candidate_index
+                best_total = total
+        if best_index is not None:
+            medoids.append(best_index)
+    return medoids
+
+
+def kmedoids(records, metric, groups, max_iterations=100):
+    """Group records with deterministic k-medoids over exact pairwise distances."""
+    records = list(records)
+    if not records:
+        raise ValueError("cannot cluster an empty record set")
+
+    group_count = _coerce_positive_integer(groups, "groups")
+    max_iterations = _coerce_non_negative_integer(max_iterations, "max_iterations")
+    if group_count > len(records):
+        raise ValueError("groups cannot exceed the number of records")
+
+    space = FiniteMetricSpace(records, metric)
+    medoids = _initialize_medoids(space, group_count)
+    assignments, cluster_sizes = _assign_to_medoids(space, medoids)
+
+    iterations = 0
+    converged = False
+    for iteration in range(max_iterations):
+        updated_medoids = _recompute_medoids(space, assignments, cluster_sizes, medoids)
+        updated_assignments, updated_cluster_sizes = _assign_to_medoids(space, updated_medoids)
+        if updated_medoids == medoids and updated_assignments == assignments:
+            medoids = updated_medoids
+            assignments = updated_assignments
+            cluster_sizes = updated_cluster_sizes
+            iterations = iteration + 1
+            converged = True
+            break
+
+        medoids = updated_medoids
+        assignments = updated_assignments
+        cluster_sizes = updated_cluster_sizes
+        iterations = iteration + 1
+
+    return ClusteringResult(
+        assignments=tuple(assignments),
+        medoids=tuple(medoids),
+        core_records=(),
+        noise_records=(),
+        cluster_sizes=tuple(cluster_sizes),
+        record_count=len(records),
+        cluster_count=group_count,
+        noise_count=0,
+        iterations=iterations,
+        converged=converged,
+        algorithm="kmedoids",
+        representation="metric_space",
+    )
+
+
+def _validate_dbscan_parameters(radius, min_points):
+    if radius < 0:
+        raise ValueError("radius must be non-negative")
+    return _coerce_positive_integer(min_points, "min_points")
+
+
+def _dbscan_region_query(space, record_index, radius):
+    return [
+        candidate_index
+        for candidate_index in range(len(space.records))
+        if space.distance(record_index, candidate_index) <= radius
+    ]
+
+
+def _expand_dbscan_cluster(space, seed_neighbors, radius, min_points, cluster, visited, assigned, assignments, core_flags):
+    queue = list(seed_neighbors)
+    queued = [False] * len(space.records)
+    for neighbor_index in seed_neighbors:
+        queued[neighbor_index] = True
+
+    cursor = 0
+    while cursor < len(queue):
+        candidate_index = queue[cursor]
+        cursor += 1
+
+        if not visited[candidate_index]:
+            visited[candidate_index] = True
+            neighbors = _dbscan_region_query(space, candidate_index, radius)
+            if len(neighbors) >= min_points:
+                core_flags[candidate_index] = True
+                for neighbor_index in neighbors:
+                    if not queued[neighbor_index]:
+                        queue.append(neighbor_index)
+                        queued[neighbor_index] = True
+
+        if not assigned[candidate_index]:
+            assignments[candidate_index] = cluster
+            assigned[candidate_index] = True
+
+
+def dbscan(records, metric, radius, min_points):
+    """Group records with deterministic DBSCAN over exact pairwise distances."""
+    records = list(records)
+    if not records:
+        raise ValueError("cannot cluster an empty record set")
+
+    min_points = _validate_dbscan_parameters(radius, min_points)
+    space = FiniteMetricSpace(records, metric)
+    assignments = [ClusteringResult.noise_label] * len(records)
+    assigned = [False] * len(records)
+    visited = [False] * len(records)
+    core_flags = [False] * len(records)
+
+    cluster_count = 0
+    for record_index in range(len(records)):
+        if visited[record_index]:
+            continue
+
+        visited[record_index] = True
+        neighbors = _dbscan_region_query(space, record_index, radius)
+        if len(neighbors) < min_points:
+            continue
+
+        core_flags[record_index] = True
+        _expand_dbscan_cluster(
+            space,
+            neighbors,
+            radius,
+            min_points,
+            cluster_count,
+            visited,
+            assigned,
+            assignments,
+            core_flags,
+        )
+        cluster_count += 1
+
+    cluster_sizes = [0] * cluster_count
+    noise_records = []
+    noise_count = 0
+    for record_index in range(len(records)):
+        if assigned[record_index]:
+            cluster_sizes[assignments[record_index]] += 1
+        else:
+            assignments[record_index] = ClusteringResult.noise_label
+            noise_records.append(record_index)
+            noise_count += 1
+
+    return ClusteringResult(
+        assignments=tuple(assignments),
+        medoids=tuple(_compute_cluster_medoids(space, assignments, cluster_count)),
+        core_records=tuple(index for index, is_core in enumerate(core_flags) if is_core),
+        noise_records=tuple(noise_records),
+        cluster_sizes=tuple(cluster_sizes),
+        record_count=len(records),
+        cluster_count=cluster_count,
+        noise_count=noise_count,
+        iterations=1,
+        converged=True,
+        algorithm="dbscan",
+        representation="metric_space",
+    )
+
+
+def _coerce_grouping_strategy(strategy):
+    if isinstance(strategy, KMedoids):
+        return strategy
+    if isinstance(strategy, DBSCAN):
+        return strategy
+    if hasattr(strategy, "groups"):
+        return KMedoids(
+            groups=strategy.groups,
+            max_iterations=getattr(strategy, "max_iterations", 100),
+        )
+    if hasattr(strategy, "radius") and hasattr(strategy, "min_points"):
+        return DBSCAN(radius=strategy.radius, min_points=strategy.min_points)
+    try:
+        return KMedoids(groups=operator.index(strategy))
+    except TypeError:
+        raise TypeError("strategy must be a KMedoids, DBSCAN, or integer group count") from None
+
+
+def find_groups(records, metric, strategy):
+    """Group records and return an engine-style result object."""
+    strategy = _coerce_grouping_strategy(strategy)
+    if isinstance(strategy, KMedoids):
+        return kmedoids(records, metric, strategy.groups, strategy.max_iterations)
+    if isinstance(strategy, DBSCAN):
+        return dbscan(records, metric, strategy.radius, strategy.min_points)
+    raise TypeError("unsupported grouping strategy")
+
+
 def representative_indices(records, metric, k, seed_index=0):
     """Select representative record IDs with deterministic farthest-first traversal."""
     selected, _nearest_selected_distances, _records = _farthest_first_selection(records, metric, k, seed_index)
@@ -841,6 +1186,7 @@ def intrinsic_dimension_from_distances(distances):
 
 
 __all__ = [
+    "ClusteringResult",
     "GraphConnectivityDiagnostics",
     "GraphDegreeDiagnostics",
     "GraphStretchDiagnostics",
@@ -848,7 +1194,9 @@ __all__ = [
     "GraphConstructionResult",
     "RepresentativeSet",
     "StructureDescription",
+    "dbscan",
     "describe_structure",
+    "find_groups",
     "find_representatives",
     "graph_connectivity_diagnostics",
     "graph_degree_diagnostics",
@@ -861,6 +1209,7 @@ __all__ = [
     "exact_knn_graph_edges",
     "exact_radius_graph",
     "exact_radius_graph_edges",
+    "kmedoids",
     "medoid",
     "medoid_index",
     "pairwise_distance_matrix",

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -63,6 +63,11 @@ class Space(FiniteMetricSpace):
     def within_radius(self, query, radius):
         return self.rnn(query, radius)
 
+    def groups(self, strategy):
+        from metric.operators import find_groups
+
+        return find_groups(self.records, self.metric, strategy)
+
     def representatives(self, k, strategy=None):
         from metric.operators import find_representatives
 

--- a/python/pkg/metric/strategies.py
+++ b/python/pkg/metric/strategies.py
@@ -10,4 +10,20 @@ class FarthestFirst:
     seed_index: int = 0
 
 
-__all__ = ["FarthestFirst"]
+@dataclass(frozen=True)
+class KMedoids:
+    """Deterministic k-medoids grouping strategy."""
+
+    groups: int
+    max_iterations: int = 100
+
+
+@dataclass(frozen=True)
+class DBSCAN:
+    """Deterministic DBSCAN grouping strategy over a finite metric space."""
+
+    radius: float
+    min_points: int
+
+
+__all__ = ["DBSCAN", "FarthestFirst", "KMedoids"]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -9,6 +9,7 @@ import numpy as np
 from metric.metrics import Edit, available
 from metric import mappings, transforms
 from metric.operators import (
+    ClusteringResult,
     GraphConnectivityDiagnostics,
     GraphDegreeDiagnostics,
     GraphStretchDiagnostics,
@@ -18,16 +19,19 @@ from metric.operators import (
     StructureDescription,
     coverage_representative_indices,
     coverage_representatives,
+    dbscan,
     describe_structure,
     exact_knn_graph,
     exact_knn_graph_edges,
     exact_radius_graph,
     exact_radius_graph_edges,
+    find_groups,
     find_representatives,
     graph_connectivity_diagnostics,
     graph_degree_diagnostics,
     graph_stretch_diagnostics,
     intrinsic_dimension,
+    kmedoids,
     medoid,
     medoid_index,
     nearest_neighbors,
@@ -41,7 +45,7 @@ from metric.operators import (
     symmetrize_graph,
 )
 from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
-from metric.strategies import FarthestFirst
+from metric.strategies import DBSCAN, FarthestFirst, KMedoids
 
 
 class RevivalApiTest(unittest.TestCase):
@@ -78,10 +82,14 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.operators.ClusteringResult, ClusteringResult)
         self.assertIs(metric.operators.RepresentativeSet, RepresentativeSet)
         self.assertIs(metric.operators.StructureDescription, StructureDescription)
+        self.assertIs(metric.operators.find_groups, find_groups)
         self.assertIs(metric.operators.describe_structure, describe_structure)
         self.assertIs(metric.operators.find_representatives, find_representatives)
+        self.assertIs(metric.operators.kmedoids, kmedoids)
+        self.assertIs(metric.operators.dbscan, dbscan)
         self.assertIs(metric.operators.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.operators.exact_knn_graph_edges, exact_knn_graph_edges)
         self.assertIs(metric.operators.exact_radius_graph, exact_radius_graph)
@@ -109,10 +117,16 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.ClusteringResult, ClusteringResult)
         self.assertIs(metric.RepresentativeSet, RepresentativeSet)
         self.assertIs(metric.StructureDescription, StructureDescription)
+        self.assertIs(metric.find_groups, find_groups)
         self.assertIs(metric.describe_structure, describe_structure)
         self.assertIs(metric.find_representatives, find_representatives)
+        self.assertIs(metric.kmedoids, kmedoids)
+        self.assertIs(metric.dbscan, dbscan)
+        self.assertIs(metric.KMedoids, KMedoids)
+        self.assertIs(metric.DBSCAN, DBSCAN)
         self.assertIs(metric.FarthestFirst, FarthestFirst)
         self.assertIs(metric.exact_knn_graph, exact_knn_graph)
         self.assertIs(metric.exact_knn_graph_edges, exact_knn_graph_edges)
@@ -144,10 +158,16 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("GraphStretchDiagnostics", metric.__all__)
         self.assertIn("GraphConstructionMetadata", metric.__all__)
         self.assertIn("GraphConstructionResult", metric.__all__)
+        self.assertIn("ClusteringResult", metric.__all__)
         self.assertIn("RepresentativeSet", metric.__all__)
         self.assertIn("StructureDescription", metric.__all__)
+        self.assertIn("find_groups", metric.__all__)
         self.assertIn("describe_structure", metric.__all__)
         self.assertIn("find_representatives", metric.__all__)
+        self.assertIn("kmedoids", metric.__all__)
+        self.assertIn("dbscan", metric.__all__)
+        self.assertIn("KMedoids", metric.__all__)
+        self.assertIn("DBSCAN", metric.__all__)
         self.assertIn("FarthestFirst", metric.__all__)
         self.assertIn("exact_knn_graph", metric.__all__)
         self.assertIn("exact_knn_graph_edges", metric.__all__)
@@ -212,6 +232,32 @@ class RevivalApiTest(unittest.TestCase):
 
     def test_space_intent_methods_return_named_results(self):
         space = Space([0, 1, 2, 3, 4], metric=lambda lhs, rhs: abs(lhs - rhs))
+        group_space = Space([0, 1, 2, 10, 11], metric=lambda lhs, rhs: abs(lhs - rhs))
+
+        groups = group_space.groups(KMedoids(groups=2))
+        self.assertIsInstance(groups, ClusteringResult)
+        self.assertEqual(groups.assignments, (0, 0, 0, 1, 1))
+        self.assertEqual(groups.medoids, (1, 3))
+        self.assertEqual(groups.cluster_sizes, (3, 2))
+        self.assertEqual(groups.record_count, 5)
+        self.assertEqual(groups.cluster_count, 2)
+        self.assertEqual(groups.noise_count, 0)
+        self.assertEqual(groups.iterations, 2)
+        self.assertTrue(groups.converged)
+        self.assertEqual(groups.algorithm, "kmedoids")
+        self.assertEqual(groups.representation, "metric_space")
+        self.assertEqual(find_groups([0, 1, 2, 10, 11], lambda lhs, rhs: abs(lhs - rhs), 2), groups)
+
+        density_groups = group_space.groups(DBSCAN(radius=1, min_points=2))
+        self.assertIsInstance(density_groups, ClusteringResult)
+        self.assertEqual(density_groups.assignments, (0, 0, 0, 1, 1))
+        self.assertEqual(density_groups.medoids, (1, 3))
+        self.assertEqual(density_groups.core_records, (0, 1, 2, 3, 4))
+        self.assertEqual(density_groups.noise_records, ())
+        self.assertEqual(density_groups.cluster_sizes, (3, 2))
+        self.assertEqual(density_groups.cluster_count, 2)
+        self.assertEqual(density_groups.noise_count, 0)
+        self.assertEqual(density_groups.algorithm, "dbscan")
 
         representatives_result = space.representatives(3)
         self.assertIsInstance(representatives_result, RepresentativeSet)


### PR DESCRIPTION
## Summary
- add Python `KMedoids` and `DBSCAN` strategy objects plus a named `ClusteringResult`
- add `find_groups`, `kmedoids`, `dbscan`, and `Space.groups(...)` over finite metric spaces
- update Python API docs, stability notes, changelog, and core tests for the groups intent facade

## Tests
- `cmake --preset python-cmake`
- `cmake --build --preset python-cmake --parallel 2`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
