### PR TITLE
Add engine documentation chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Add graph representation terminology for exact, approximate, directed, symmetrized, weighted, and normalized graph construction.
 - Add exact graph edge fixture documentation for k-nearest-neighbor and radius edge lists.
 - Add CI-tested C++ and Python engine flagship examples for strings, process curves, histograms, and cross-space dependency.
+- Add engine documentation chapters for metric spaces, representations, intents, strategies, operators, mappings, runtime policies, and migration.
 
 ## [0.3.2] - 2026-06-19
 

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -10,6 +10,17 @@ This model is the public architecture of the engine.
 
 The first implementation slices are documented in [Engine Mental Model](mental-model.md).
 
+## Engine Guides
+
+- [Metric Space](metric-space.md)
+- [Representations](representations.md)
+- [Intent API](intent-api.md)
+- [Strategies](strategies.md)
+- [Operators](operators.md)
+- [Mappings](mappings.md)
+- [Runtime Policies](runtime.md)
+- [Migration](migration.md)
+
 ## Flagship Examples
 
 The first CI-tested engine demos live under `examples/engine/` and `python/examples/engine/`.

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -1,0 +1,41 @@
+# Intent API
+
+Intent APIs are named by what users want to do, not by the algorithm used to do it.
+
+| User intent | C++ surface | Python surface | Current status |
+|---|---|---|---|
+| Find similar records | `find_neighbors` | `Space.neighbors` | Core Revival |
+| Find groups | `find_groups` | `Space.groups` | Core Revival |
+| Find representatives | `find_representatives` | `Space.representatives` | Core Revival |
+| Compare spaces | `compare`, `correlate` | `Space.compare`, `Space.correlate` | Core Revival |
+| Describe a space | `describe_structure` | `Space.describe` | Core Revival |
+| Reduce complexity | `reduce` | roadmap | C++ PCFA-backed path |
+| Map to another space | `metric::mappings::*` | roadmap | C++ initial mapping conventions |
+| Find outliers | roadmap | roadmap | Target Engine API |
+| Denoise a space | roadmap | roadmap | Target Engine API |
+
+The operator layer may still use algorithm names because it is the implementation layer. The intent layer is the recommended user-facing vocabulary.
+
+## C++
+
+```cpp
+auto neighbors = metric::find_neighbors(space, query, 2);
+auto groups = metric::find_groups(space, metric::strategies::k_medoids(2));
+auto representatives = metric::find_representatives(space, 2);
+auto dependency = metric::compare(space_a, space_b, metric::strategies::mgc{});
+auto structure = metric::describe_structure(space);
+```
+
+## Python
+
+```python
+from metric import DistanceProfileCorrelation, Space
+from metric.strategies import KMedoids
+
+space = Space(records, metric)
+groups = space.groups(KMedoids(groups=2))
+dependency = space.compare(other_space, DistanceProfileCorrelation())
+structure = space.describe()
+```
+
+Intent results are named dataclasses or structs. They carry selected records, source IDs, diagnostics, strategy names, and representation metadata.

--- a/docs/engine/mappings.md
+++ b/docs/engine/mappings.md
@@ -1,0 +1,42 @@
+# Engine Mappings
+
+Mappings produce new metric spaces or derived records from an existing metric space.
+
+```text
+MetricSpace -> Mapping -> MappingModel -> MappingResult
+```
+
+The first C++ mapping convention follows:
+
+```text
+fit(space) -> model
+model.transform(space) -> derived MetricSpace
+model.inverse_transform(derived_space) -> reconstructed records, if supported
+```
+
+## Current C++ Surface
+
+The current engine mapping layer includes:
+
+- `metric::MappingResult`
+- `metric::mappings::fit`
+- `metric::mappings::transform`
+- clustered-space mapping from `ClusteringResult`
+- LAPACK-backed PCFA mapping
+- PCFA-backed `metric::reduce`
+
+`MappingResult` stores the derived space plus source-record lineage. Inverse reconstruction is explicit and optional.
+
+## Python Status
+
+Python exposes `metric.mappings` as a beta compatibility bridge for installed legacy names. A Python engine mapping facade should be promoted only when it has named result contracts, examples, and wheel CI coverage.
+
+## Promotion Rule
+
+A mapping becomes part of Core Revival when it:
+
+- starts from a `MetricSpace` / `Space`
+- documents what metric is used in the derived space
+- stores source-to-target lineage
+- has explicit inverse support or explicit unsupported metadata
+- is covered by deterministic tests and examples

--- a/docs/engine/metric-space.md
+++ b/docs/engine/metric-space.md
@@ -1,0 +1,52 @@
+# Engine Metric Space
+
+The engine starts with a finite record set and a metric callable:
+
+```text
+RecordSet + Metric -> MetricSpace
+```
+
+`MetricSpace` is the canonical C++ engine object. It owns records by value, assigns stable `RecordId` values, exposes the metric, and carries a `version()` counter for representation staleness checks.
+
+Python exposes the same model through `Space`: a finite record set plus a metric callable with cached pairwise distances and intent-named helpers.
+
+## C++
+
+```cpp
+#include <metric/distance.hpp>
+#include <metric/engine.hpp>
+
+#include <string>
+#include <vector>
+
+std::vector<std::string> records = {"metric", "metrics", "matrix", "tree"};
+auto space = metric::make_space(records, metric::Edit<char>{});
+
+auto lhs = space.id(0);
+auto rhs = space.id(1);
+auto distance = space.distance(lhs, rhs);
+```
+
+The record type is not required to be a vector. A metric can operate on strings, histograms, event sequences, process curves, structured records, or vectors.
+
+## Python
+
+```python
+from metric import Edit, Space
+
+records = ["metric", "metrics", "matrix", "tree"]
+space = Space(records, Edit())
+
+distance = space.distance(0, 1)
+matrix = space.to_matrix()
+```
+
+`to_matrix()` makes materialization explicit in Python. It returns an independent finite matrix-space view with the same records and metric.
+
+## Current Contract
+
+- `RecordId` is opaque in C++ but currently backed by dense internal storage.
+- C++ `MetricSpace` owns records by value in the first engine version.
+- Python `Space` stores records as a list and eagerly caches pairwise distances.
+- Mutating C++ space state should call `touch()` so cached representations can report stale state.
+- Mathematical metric laws are documented and tested by examples, not enforced by the type system.

--- a/docs/engine/migration.md
+++ b/docs/engine/migration.md
@@ -1,0 +1,46 @@
+# Engine Migration
+
+Existing METRIC APIs remain compatibility surfaces. Migration should be gradual and test-backed.
+
+## Recommended New Code
+
+Start new C++ code with:
+
+```cpp
+#include <metric/engine.hpp>
+
+auto space = metric::make_space(records, metric);
+auto neighbors = metric::find_neighbors(space, query, 2);
+```
+
+Start new Python code with:
+
+```python
+from metric import Space
+
+space = Space(records, metric)
+neighbors = space.neighbors(query, 2)
+```
+
+## Compatibility APIs
+
+The following remain valid for existing code:
+
+- `metric::Space::from_records`
+- `metric::MatrixSpace`
+- `metric::GraphSpace`
+- `metric::TreeSpace`
+- historical mapping classes
+- historical transform classes
+- Python compatibility modules under `metric.distance`, `metric.correlation`, `metric.mapping`, `metric.space`, and `metric.transform`
+
+## Migration Steps
+
+1. Keep the existing metric callable.
+2. Wrap the records and metric in `MetricSpace` or `Space`.
+3. Replace direct algorithm calls in examples with intent calls where stable equivalents exist.
+4. Replace tuple handling with named result objects.
+5. Introduce strategies only when the default intent path is not enough.
+6. Introduce runtime policies only when representation or execution cost matters.
+
+Do not migrate broad historical examples into the release gate until they have deterministic fixtures, documented assumptions, and CI coverage.

--- a/docs/engine/operators.md
+++ b/docs/engine/operators.md
@@ -1,0 +1,44 @@
+# Engine Operators
+
+Operators are implementation-level functions that compute on spaces or representations.
+
+The operator layer is allowed to use algorithmic names because it is not the first user-facing vocabulary. Intent APIs call into operators after strategies and runtime policies select an execution path.
+
+## C++ Operators
+
+The current C++ engine operators include:
+
+- `metric::operators::knn`
+- `metric::operators::range`
+- `metric::operators::kmedoids`
+- `metric::operators::dbscan`
+- `metric::operators::entropy`
+- `metric::operators::mgc`
+
+They return named result objects:
+
+- `NeighborSet`
+- `ClusteringResult`
+- `EntropyResult`
+- `CorrelationResult`
+
+## Python Operators
+
+The current Python operator layer includes:
+
+- nearest and range helpers
+- exact kNN and radius graph construction
+- graph degree, connectivity, and stretch diagnostics
+- graph symmetrization and out-degree pruning
+- grouping helpers
+- representative selection helpers
+- medoid and separated-representative helpers
+- intrinsic-dimension diagnostics
+- structure diagnostics
+- cross-space comparison helpers
+
+Python operators return dataclasses such as `ClusteringResult`, `GraphConstructionResult`, `RepresentativeSet`, `StructureDescription`, and `CorrelationResult`.
+
+## Compatibility
+
+Older tuple-returning and class-specific APIs remain compatibility surfaces. New promoted examples should prefer named result objects so outputs can carry metadata and compose with other engine layers.

--- a/docs/engine/representations.md
+++ b/docs/engine/representations.md
@@ -1,0 +1,38 @@
+# Engine Representations
+
+Representations are execution structures over one metric space. They do not redefine the record set.
+
+```text
+MetricSpace -> Representation -> Operator
+```
+
+The current C++ engine representation adapters live under `metric::representations`:
+
+- `ImplicitDistanceProvider<Space>`
+- `MatrixCache<Space>`
+- `CoverTreeIndex<Space>`
+- `KnnGraphIndex<Space>`
+- `GraphTopology<Space>`
+
+Each adapter captures the source `space.version()` when it is built and exposes `is_stale()`.
+
+## Matrix Cache
+
+`MatrixCache` eagerly stores all pairwise distances. Use it when repeated `RecordId` queries or all-pairs operators make the materialization cost explicit and worthwhile.
+
+```cpp
+metric::representations::MatrixCache<decltype(space)> matrix(space);
+auto distance = matrix.distance(space.id(0), space.id(1));
+```
+
+## Neighbor Indexes
+
+`CoverTreeIndex` and `KnnGraphIndex` currently provide exact deterministic neighbor ordering over finite spaces while preserving the intended engine vocabulary. Their internals can later be replaced by specialized index implementations without changing the representation role.
+
+## Graph Topology
+
+`GraphTopology` stores explicit weighted edges using `RecordId` endpoints. It is the bridge between metric-space distances and sparse graph workflows.
+
+## Python
+
+The stable Python facade currently exposes `Space.to_matrix()` for explicit materialization. Graph helpers in `metric.operators` return named graph-construction result objects rather than persistent graph representation classes.

--- a/docs/engine/runtime.md
+++ b/docs/engine/runtime.md
@@ -1,0 +1,40 @@
+# Runtime Policies
+
+Runtime policies make execution cost and approximation explicit.
+
+The first C++ runtime policy surface lives under `metric::runtime`:
+
+- `exact`
+- `approximate`
+- `lazy`
+- `materialized`
+- `serial`
+- `parallel`
+- `cache`
+
+## Neighbor Execution
+
+`runtime::exact()` uses the lazy metric-space path for neighbor lookup.
+
+`runtime::materialized(runtime::exact())` uses a `MatrixCache` for `RecordId` neighbor lookup and reports `representation == "matrix_cache"` in the returned `NeighborSet`.
+
+`runtime::approximate()` is reserved. It currently throws for neighbor lookup instead of silently selecting an approximate algorithm.
+
+## Cache Staleness
+
+Representations capture `space.version()` at construction. `runtime::cache(...)` wraps a representation and delegates `is_stale()` to that version check.
+
+```cpp
+auto matrix = metric::runtime::cache(metric::representations::MatrixCache<decltype(space)>(space));
+auto before = matrix.is_stale();
+space.touch();
+auto after = matrix.is_stale();
+```
+
+## Current Limits
+
+- Approximate policies are explicit placeholders until backed by real approximate execution paths.
+- Parallel policy metadata is exposed before broad parallel execution is implemented.
+- Python does not yet expose runtime policies as first-class objects.
+
+This conservative behavior is intentional: no hidden all-pairs materialization or approximate search should happen without an explicit policy or documented default.

--- a/docs/engine/strategies.md
+++ b/docs/engine/strategies.md
@@ -1,0 +1,44 @@
+# Engine Strategies
+
+Strategies select how an intent is executed.
+
+```text
+Intent + Strategy -> Operator + Representation
+```
+
+Algorithm names belong at this layer. A user asks to find groups; `k_medoids` or `DBSCAN` is the strategy.
+
+## C++ Strategies
+
+The current C++ strategy objects include:
+
+- `metric::strategies::brute_force`
+- `metric::strategies::matrix_cache`
+- `metric::strategies::cover_tree`
+- `metric::strategies::knn_graph`
+- `metric::strategies::k_medoids`
+- `metric::strategies::dbscan`
+- `metric::strategies::farthest_first`
+- `metric::strategies::mgc`
+- `metric::strategies::pcfa`
+
+## Python Strategies
+
+The current Python strategy objects include:
+
+- `KMedoids`
+- `DBSCAN`
+- `FarthestFirst`
+- `DistanceProfileCorrelation`
+
+## Promotion Rule
+
+A strategy should be promoted only when it has:
+
+- deterministic fixtures or documented stochastic controls
+- named result objects
+- examples that use the intent API
+- CI coverage
+- documented assumptions and failure modes
+
+This keeps the public engine from becoming a flat algorithm catalog.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ This docs tree is the canonical home for concepts, API references, engine archit
 ## Start Here
 
 - [Engine Overview](engine/index.md)
+- [Engine Metric Space](engine/metric-space.md)
+- [Engine Intent API](engine/intent-api.md)
+- [Engine Runtime Policies](engine/runtime.md)
 - [Metric-Space Numerics Manifesto](manifesto.md)
 - [API Surface](stability.md)
 - [Testing and CI Scope](testing-and-ci.md)
@@ -22,18 +25,27 @@ This docs tree is the canonical home for concepts, API references, engine archit
 1. Read the root [README.md](../README.md) for the product framing.
 2. Read [Metric-Space Numerics Manifesto](manifesto.md) for the technical distinction from vector-search and embedding-only workflows.
 3. Read [Engine Overview](engine/index.md) to understand the engine model.
-4. Read [Metric Spaces](concepts/metric-space.md) and [Finite Metric Spaces](concepts/finite-metric-space.md).
-5. Read [Explicit Representations](concepts/explicit-representations.md) to understand matrix, graph, and tree execution forms.
-6. Read [Graph Representation Terminology](concepts/graph-representations.md) before promoting sparse graph construction.
-7. Use the [Python API](api/python.md) or [C++ API](api/cpp.md) for implementation.
-8. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
-9. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
-10. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
-11. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
+4. Read [Engine Metric Space](engine/metric-space.md), [Representations](engine/representations.md), and [Intent API](engine/intent-api.md) for the engine-specific model.
+5. Read [Metric Spaces](concepts/metric-space.md) and [Finite Metric Spaces](concepts/finite-metric-space.md).
+6. Read [Explicit Representations](concepts/explicit-representations.md) to understand matrix, graph, and tree execution forms.
+7. Read [Graph Representation Terminology](concepts/graph-representations.md) before promoting sparse graph construction.
+8. Use the [Python API](api/python.md) or [C++ API](api/cpp.md) for implementation.
+9. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
+10. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
+11. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
+12. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
 
 ## Concepts
 
 - [Metric-Space Numerics Manifesto](manifesto.md)
+- [Engine Metric Space](engine/metric-space.md)
+- [Engine Representations](engine/representations.md)
+- [Engine Intent API](engine/intent-api.md)
+- [Engine Strategies](engine/strategies.md)
+- [Engine Operators](engine/operators.md)
+- [Engine Mappings](engine/mappings.md)
+- [Engine Runtime Policies](engine/runtime.md)
+- [Engine Migration](engine/migration.md)
 - [Metric Spaces](concepts/metric-space.md)
 - [Finite Metric Spaces](concepts/finite-metric-space.md)
 - [Metrics as Recoding Costs](concepts/metrics-as-recoding-costs.md)


### PR DESCRIPTION
## Summary
- Add engine documentation chapters for metric spaces, representations, intents, strategies, operators, mappings, runtime policies, and migration.
- Link the new guides from the documentation index and engine overview.
- Add a changelog note for the documentation expansion.

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`