### PR TITLE
Document README engine quickstart status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -25,6 +25,7 @@ The current local tree implements the first revival slice:
 - promoted Python examples under `python/examples/metric_space/`
 - CI-tested C++ and Python engine flagship examples for strings, process curves, histograms, and cross-space dependency
 - engine documentation chapters for metric spaces, representations, intents, strategies, operators, mappings, runtime policies, and migration
+- README engine quickstart for C++ engine intents, strategy selection, representation swaps, and mapping-derived spaces
 - C++ smoke and contract tests under `tests/core_smoke/`
 - Python core API and metric-contract tests under `python/tests/core/`
 - intrinsic-dimension diagnostics in C++ and Python core operator helpers
@@ -235,6 +236,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - engine documentation chapters for metric spaces, representations, intents, strategies, operators, mappings, runtime policies, and migration, merged as `48d19a98315da2132d756ce032cba62eab46f12d`
 - C++ engine outlier intent backed by DBSCAN-noise detection with named `OutlierResult` objects and core smoke coverage, merged as `178c635e331b5acee8f1c868ba48dafe834443a3`
 - Python engine-style Space outlier intent with named `OutlierResult` objects and DBSCAN-noise strategy coverage, merged as `3974b358beb5dbe23b181126fe2915e2f065bcba`
+- README engine quickstart covering the C++ engine path, strategy selection, representation swaps, and mapping-derived spaces, merged as `7f01e1084e3fb177a93b3ebb1fdfa4f38f1be895`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- Record the README engine quickstart update in the revival status local scope.
- Add the post-v0.3.2 master progress entry for the README engine identity PR.

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`