### PR TITLE
Document Python neighbor argument status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -260,6 +260,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ engine embed intent backed by the PCFA strategy with LAPACK-gated core smoke, downstream, and include-smoke coverage, merged as `dc44030e5155608dfeaebbdeb48ab367f595cd0f`
 - Python engine-style Space compress intent backed by representative and medoid compression with named `CompressionResult` objects, merged as `e7029d80c0b2e37bae9078a75408c8b45ae14b91`
 - C++ engine compress intent backed by deterministic farthest-first representative compression with named `CompressionResult` objects, merged as `d6abef83b61d9e68f5d156884d09c525e8792bf6`
+- Python neighbor facade support for target `count` and `radius` intent arguments, merged as `e9dd23e217b12aeb8e6e85df612c55d78c66da50`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- Record the Python neighbor `count`/`radius` argument merge SHA in `docs/revival-status.md`

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`