### PR TITLE
Add Python Space map intent keyword handling

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -82,6 +82,7 @@ space.reduce(strategy=KMedoids(groups=3))
 space.compress(count=3)
 space.compress(strategy=KMedoids(groups=3))
 space.map(transform=lambda record: record["value"], metric=lambda lhs, rhs: abs(lhs - rhs))
+space.map(lambda record: record["value"], lambda lhs, rhs: abs(lhs - rhs))
 space.describe()
 space.describe_structure()
 space.knn(query, k=10)
@@ -221,7 +222,7 @@ structure = describe_structure(records, Edit())
 
 `compress_space` returns a `CompressionResult` with a compressed representative `Space`, selected source-record IDs, source-to-compressed assignments, nearest-representative distances, `compression="representatives"`, a compressed/source record-count `compression_ratio`, and explicit `lossy=True` / `inverse_supported=False` metadata. Calling `inverse_transform()` raises `metric.UnsupportedOperationError` until a strategy with explicit reconstruction support is promoted. `Space.compress(count=..., strategy=...)` exposes the same result. The first Python-core compression path uses the same deterministic `FarthestFirst` and `KMedoids` representative strategies as `reduce_space`.
 
-`map_space` returns a `MappingResult` with a new `Space`, source-record lineage, target record count, mapping metadata, strategy metadata, and explicit `inverse_supported=False` metadata. Calling `inverse_transform()` raises `metric.UnsupportedOperationError`; denoise results include guidance to use the filtered `result.space`, `space.embed(...)`, or a strategy that declares inverse support. `Space.map(transform, metric=...)` exposes the same deterministic transform path from an existing space. This is the first Python-core mapping intent; broader learned or inverse mappings remain in the beta mapping surface until they have stable result contracts and CI fixtures.
+`map_space` returns a `MappingResult` with a new `Space`, source-record lineage, target record count, mapping metadata, strategy metadata, and explicit `inverse_supported=False` metadata. Calling `inverse_transform()` raises `metric.UnsupportedOperationError`; denoise results include guidance to use the filtered `result.space`, `space.embed(...)`, or a strategy that declares inverse support. `Space.map(transform=..., metric=...)` exposes the same deterministic transform path from an existing space, while the positional compatibility form `Space.map(transform, metric)` remains supported. Calling `Space.map()` with no `transform` or `target` raises `metric.AmbiguousIntentError`; `target=` and `strategy=` mapping forms raise `metric.StrategyUnavailableError` until learned or fitted mapping contracts are promoted with CI fixtures. This is the first Python-core mapping intent; broader learned or inverse mappings remain in the beta mapping surface until they have stable result contracts and CI fixtures.
 
 `medoid_index` and `medoid` select the existing record with the smallest total distance to all records. Equal total-distance ties are resolved by record order.
 

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -47,7 +47,7 @@ embedding = space.embed(strategy=ClassicMDS(dimensions=2))
 dependency = space.compare(other_space, DistanceProfileCorrelation())
 reduction = space.reduce(count=2)
 compression = space.compress(count=2)
-mapped = space.map(transform, metric=target_metric)
+mapped = space.map(transform=transform, metric=target_metric)
 structure = space.describe()
 ```
 

--- a/docs/engine/mappings.md
+++ b/docs/engine/mappings.md
@@ -34,7 +34,7 @@ The current engine mapping layer includes:
 
 ## Python Status
 
-Python exposes `Space.map` and `metric.operators.map_space` for deterministic transforms into derived `Space` objects. It also exposes `Space.denoise` and `metric.operators.denoise_space` for DBSCAN-noise filtering into derived `Space` objects. Python also exposes `metric.mappings` as a beta compatibility bridge for installed legacy names; learned or inverse mapping facades should be promoted only when they have named result contracts, examples, and wheel CI coverage.
+Python exposes `Space.map(transform=..., metric=...)` and `metric.operators.map_space` for deterministic transforms into derived `Space` objects. The positional compatibility form `Space.map(transform, metric)` remains valid, but no-argument map calls raise `metric.AmbiguousIntentError` and target/strategy mapping forms raise `metric.StrategyUnavailableError` until learned or fitted mapping contracts are promoted. Python also exposes `Space.denoise` and `metric.operators.denoise_space` for DBSCAN-noise filtering into derived `Space` objects. Python also exposes `metric.mappings` as a beta compatibility bridge for installed legacy names; learned or inverse mapping facades should be promoted only when they have named result contracts, examples, and wheel CI coverage.
 
 ## Promotion Rule
 

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -4,7 +4,12 @@ from collections.abc import Mapping
 import math
 import operator
 
-from metric.exceptions import MissingMetricError, StaleRepresentationError
+from metric.exceptions import (
+    AmbiguousIntentError,
+    MissingMetricError,
+    StaleRepresentationError,
+    StrategyUnavailableError,
+)
 from metric.runtime import require_exact_runtime
 
 
@@ -405,8 +410,23 @@ class Space(FiniteMetricSpace):
 
         return compress_space(self.records, self.metric, count, strategy=strategy)
 
-    def map(self, transform, metric=None, *, runtime=None):
+    def map(self, transform=None, metric=None, *, target=None, strategy=None, runtime=None):
         require_exact_runtime(runtime)
+        if transform is None and target is None:
+            raise AmbiguousIntentError("Space.map requires transform=... or target=...")
+        if transform is not None and target is not None:
+            raise AmbiguousIntentError("Space.map uses either transform or target, not both")
+        if strategy is not None:
+            raise StrategyUnavailableError(
+                "Space.map strategy mappings are not promoted yet. "
+                "Use transform=... with metric=... for deterministic maps."
+            )
+        if target is not None:
+            raise StrategyUnavailableError(
+                "Space.map target mappings are not promoted yet. "
+                "Use transform=... with metric=... for deterministic maps."
+            )
+
         from metric.operators import map_space
 
         return map_space(self.records, transform, self.metric if metric is None else metric)

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -8,6 +8,7 @@ import metric
 import numpy as np
 from metric import exceptions, intent, mappings, representations, runtime, transforms
 from metric.exceptions import (
+    AmbiguousIntentError,
     MetricError,
     MissingMetricError,
     StaleRepresentationError,
@@ -667,6 +668,10 @@ class RevivalApiTest(unittest.TestCase):
             map_space([0, 1, 2], lambda record: record * record, lambda lhs, rhs: abs(lhs - rhs)).space.records,
             [0, 1, 4],
         )
+        keyword_mapped = space.map(transform=lambda record: record * record)
+        self.assertEqual(keyword_mapped.space.records, [0, 1, 4, 9, 16])
+        self.assertEqual(keyword_mapped.source_record_ids, (0, 1, 2, 3, 4))
+        self.assertEqual(keyword_mapped.strategy, "deterministic_transform")
 
         embedding = space.embed(dimensions=1)
         self.assertIsInstance(embedding, EmbeddingResult)
@@ -748,6 +753,14 @@ class RevivalApiTest(unittest.TestCase):
             space.reduce(3, strategy=KMedoids(groups=2))
         with self.assertRaises(TypeError):
             space.map(3)
+        with self.assertRaisesRegex(AmbiguousIntentError, "requires transform=... or target=..."):
+            space.map()
+        with self.assertRaisesRegex(AmbiguousIntentError, "either transform or target"):
+            space.map(transform=lambda record: record, target=space)
+        with self.assertRaisesRegex(StrategyUnavailableError, "strategy mappings are not promoted"):
+            space.map(transform=lambda record: record, strategy=KMedoids(groups=2))
+        with self.assertRaisesRegex(StrategyUnavailableError, "target mappings are not promoted"):
+            space.map(target=space)
         with self.assertRaises(TypeError):
             map_space([0, 1], lambda record: record, metric=3)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Summary
- extend `Space.map` with the documented `transform=` keyword path while preserving positional transform compatibility
- raise `AmbiguousIntentError` for no-argument or mixed transform/target map calls
- raise `StrategyUnavailableError` for target/strategy mapping forms that are not promoted yet
- update Python API and engine mapping docs

## Verification
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/pkg/metric/spaces.py python/tests/core/test_revival_api.py
- build/python-venv/bin/python -m pip install --force-reinstall ./python
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- cmake --preset python-cmake
- cmake --build --preset python-cmake --parallel 2