### PR TITLE
Document Python map intent keyword status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -36,6 +36,7 @@ The current local tree implements the first revival slice:
 - Python engine-style Space reduce intent with representative and medoid reduction strategies
 - Python engine-style Space compress intent with representative and medoid compression strategies
 - Python engine-style Space map intent for deterministic transforms into derived metric spaces
+- Python map facade accepts `transform=` and reports ambiguous or unavailable mapping forms deterministically
 - Python engine-style Space denoise intent with DBSCAN-noise filtering and mapping-result lineage
 - Python beta compatibility bridge modules under `metric.mappings` and `metric.transforms`
 - promoted C++ examples under `examples/core/`
@@ -263,6 +264,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - API and stability documentation for the promoted C++ and Python outlier intent surface, merged as `ce1beaf44f9b3319cccceb4273d2823b20affce5`
 - Python engine-style Space reduce intent with named `ReductionResult` objects, representative/medoid strategy coverage, and API/stability docs, merged as `c24069575071a228363220a00ff1fb0299307f29`
 - Python engine-style Space map intent with named `MappingResult` objects, deterministic transform coverage, and API/stability docs, merged as `e5d2f796c8eb842a5e784160acdf9b87baef10de`
+- Python `Space.map(transform=...)` keyword intent plus deterministic ambiguity and unavailable-strategy errors, merged as `77bb3665ee9a3b8401440e3cbf0f8b066f1102bc`
 - C++ engine map intent with `MappingResult` lineage metadata, deterministic transform smoke coverage, and API/stability docs, merged as `4cd6144e25761225fd1362dd3f5ae9e501f4859a`
 - C++ engine denoise intent backed by DBSCAN-noise filtering with `MappingResult` lineage metadata and core smoke coverage, merged as `998d1bc1d357f982c30b0eeb9a8ccce196fddb56`
 - Python engine-style Space denoise intent with named `MappingResult` objects, DBSCAN-noise filtering coverage, and API/stability docs, merged as `74054a493909b35af65034f21c944d057a600f91`


### PR DESCRIPTION
## Summary
- record the merged Python `Space.map(transform=...)` keyword intent status
- add the post-v0.3.2 master progress entry with the merge SHA

## Verification
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- git diff --check