### PR TITLE
Add Python representatives count intent alias

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -76,8 +76,8 @@ space.compare(other_space, strategy=DistanceProfileCorrelation())
 space.compare(other_space, align="ids")
 space.compare(other_space, runtime=RuntimePolicy(exact=True))
 space.correlate(other_space, align="ids")
-space.representatives(k=3)
-space.representatives(k=3, strategy=FarthestFirst(seed_index=1))
+space.representatives(count=3)
+space.representatives(count=3, strategy=FarthestFirst(seed_index=1))
 space.reduce(count=3)
 space.reduce(strategy=KMedoids(groups=3))
 space.compress(count=3)
@@ -196,7 +196,7 @@ separated_records = separated_representatives(records, Edit(), minimum_distance=
 covered_ids = coverage_representative_indices(records, Edit(), radius=1)
 covered_records = coverage_representatives(records, Edit(), radius=1)
 dimension = intrinsic_dimension(records, Edit())
-representative_result = find_representatives(records, Edit(), k=2, strategy=FarthestFirst(seed_index=0))
+representative_result = find_representatives(records, Edit(), count=2, strategy=FarthestFirst(seed_index=0))
 reduction = reduce_space(records, Edit(), count=2, strategy=FarthestFirst(seed_index=0))
 compression = compress_space(records, Edit(), count=2, strategy=FarthestFirst(seed_index=0))
 mapped = map_space(records, transform, target_metric)
@@ -217,7 +217,7 @@ structure = describe_structure(records, Edit())
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
-`find_representatives` returns a `RepresentativeSet` with selected source indices, nearest-representative distances for every record, coverage radius, average nearest-representative distance, strategy metadata, and representation metadata. `Space.representatives(...)` exposes the same result from the `Space` facade.
+`find_representatives` returns a `RepresentativeSet` with selected source indices, nearest-representative distances for every record, coverage radius, average nearest-representative distance, strategy metadata, and representation metadata. Use `count=` for the semantic target size; the older `k` name remains accepted for compatibility. `Space.representatives(...)` exposes the same result from the `Space` facade.
 
 `reduce_space` returns a `ReductionResult` with a reduced `Space`, selected source-record IDs, source-to-reduced assignments, nearest-representative distances, strategy metadata, and explicit `inverse_supported=False` metadata. Calling `inverse_transform()` on this result raises `metric.UnsupportedOperationError`. `Space.reduce(count=..., strategy=...)` exposes the same result. The first Python-core strategies are `FarthestFirst` and `KMedoids`, so reduction works for arbitrary records plus a metric rather than only vector records.
 

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -41,6 +41,7 @@ from metric.strategies import ClassicMDS
 
 space = Space(records, metric)
 groups = space.groups(count=2)
+representatives = space.representatives(count=2)
 outliers = space.outliers(count=2)
 denoised = space.denoise(count=2)
 embedding = space.embed(strategy=ClassicMDS(dimensions=2))

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1256,9 +1256,18 @@ def _coerce_farthest_first(strategy):
     raise TypeError("strategy must be a FarthestFirst strategy")
 
 
-def find_representatives(records, metric, k, strategy=None):
+def _coerce_representative_request(k=None, count=None):
+    if k is None and count is None:
+        raise TypeError("count is required")
+    if k is not None and count is not None:
+        raise ValueError("use either k or count, not both")
+    return count if count is not None else k
+
+
+def find_representatives(records, metric, k=None, strategy=None, *, count=None):
     """Select representatives and return an engine-style result object."""
     strategy = _coerce_farthest_first(strategy)
+    k = _coerce_representative_request(k, count)
     selected, nearest_selected_distances, records = _farthest_first_selection(
         records,
         metric,

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -393,11 +393,11 @@ class Space(FiniteMetricSpace):
             inverse_supported=False,
         )
 
-    def representatives(self, k, strategy=None, *, runtime=None):
+    def representatives(self, k=None, strategy=None, *, count=None, runtime=None):
         require_exact_runtime(runtime)
         from metric.operators import find_representatives
 
-        return find_representatives(self.records, self.metric, k, strategy=strategy)
+        return find_representatives(self.records, self.metric, k, strategy=strategy, count=count)
 
     def reduce(self, count=None, strategy=None, *, runtime=None):
         require_exact_runtime(runtime)

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -588,6 +588,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(representatives_result.strategy, "farthest_first")
         self.assertEqual(representatives_result.representation, "metric_space")
 
+        self.assertEqual(space.representatives(count=3), representatives_result)
+        self.assertEqual(
+            find_representatives([0, 1, 2, 3, 4], lambda lhs, rhs: abs(lhs - rhs), count=3),
+            representatives_result,
+        )
         seeded = space.representatives(2, strategy=FarthestFirst(seed_index=2))
         self.assertEqual(seeded.representatives, (2, 0))
 
@@ -767,6 +772,12 @@ class RevivalApiTest(unittest.TestCase):
             space.reduce(0)
         with self.assertRaises(ValueError):
             space.reduce(6)
+        with self.assertRaisesRegex(TypeError, "count is required"):
+            space.representatives()
+        with self.assertRaisesRegex(ValueError, "either k or count"):
+            space.representatives(2, count=2)
+        with self.assertRaisesRegex(ValueError, "either k or count"):
+            find_representatives([0, 1], lambda lhs, rhs: abs(lhs - rhs), 1, count=1)
         with self.assertRaises(TypeError):
             space.reduce(strategy=FarthestFirst())
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- add semantic `count=` support to `find_representatives` and `Space.representatives`
- preserve positional/keyword `k` compatibility while rejecting mixed `k` and `count`
- update Python API and engine intent docs

## Verification
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/pkg/metric/spaces.py python/pkg/metric/operators.py python/tests/core/test_revival_api.py
- build/python-venv/bin/python -m pip install --force-reinstall ./python
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- cmake --preset python-cmake
- cmake --build --preset python-cmake --parallel 2