### PR TITLE
Add Python Space describe representation metadata

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -85,8 +85,8 @@ space.compress(count=3)
 space.compress(strategy=KMedoids(groups=3))
 space.map(transform=lambda record: record["value"], metric=lambda lhs, rhs: abs(lhs - rhs))
 space.map(lambda record: record["value"], lambda lhs, rhs: abs(lhs - rhs))
-space.describe()
-space.describe_structure()
+space.describe(representation=space.to_matrix())
+space.describe_structure(representation=space.to_matrix())
 space.knn(query, k=10)
 space.nn(query)
 space.rnn(query, radius=1)
@@ -246,7 +246,7 @@ structure = describe_structure(records, Edit())
 
 `intrinsic_dimension` returns an expansion-dimension estimate based on finite-space neighborhood growth. Treat it as a diagnostic that depends on the metric, sample density, duplicates, and available radii.
 
-`describe_structure` returns a `StructureDescription` with record count, evaluated pair count, zero-distance pair count, minimum nonzero distance, maximum distance, average distance, and intrinsic-dimension estimate. `Space.describe()` and `Space.describe_structure()` expose the same diagnostics from the `Space` facade.
+`describe_structure` returns a `StructureDescription` with record count, evaluated pair count, zero-distance pair count, minimum nonzero distance, maximum distance, average distance, and intrinsic-dimension estimate. `Space.describe()` and `Space.describe_structure()` expose the same diagnostics from the `Space` facade. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`.
 
 ## Custom Metrics
 

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -49,7 +49,7 @@ dependency = space.compare(other_space, DistanceProfileCorrelation(), align="ids
 reduction = space.reduce(count=2)
 compression = space.compress(count=2)
 mapped = space.map(transform=transform, metric=target_metric)
-structure = space.describe()
+structure = space.describe(representation=space.to_matrix())
 ```
 
 Intent results are named dataclasses or structs. They carry selected records, source IDs, diagnostics, strategy names, and representation metadata.

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1785,7 +1785,7 @@ def intrinsic_dimension(records, metric):
     return intrinsic_dimension_from_distances(pairwise_distance_matrix(records, metric))
 
 
-def describe_structure(records, metric):
+def describe_structure(records, metric, *, representation="metric_space"):
     """Describe exact finite-space structure with all-pairs diagnostics."""
     records = list(records)
     distances = pairwise_distance_matrix(records, metric)
@@ -1820,7 +1820,7 @@ def describe_structure(records, metric):
         has_nonzero_distances=has_nonzero_distances,
         exact=True,
         strategy="exact_all_pairs",
-        representation="metric_space",
+        representation=representation,
     )
 
 

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -449,14 +449,19 @@ class Space(FiniteMetricSpace):
             representation=representation_name,
         )
 
-    def describe(self, *, runtime=None):
+    def describe(self, *, representation=None, runtime=None):
         require_exact_runtime(runtime)
+        representation_name = "metric_space"
+        if representation is not None:
+            representation.ensure_fresh()
+            representation_name = getattr(representation, "representation", representation_name)
+
         from metric.operators import describe_structure
 
-        return describe_structure(self.records, self.metric)
+        return describe_structure(self.records, self.metric, representation=representation_name)
 
-    def describe_structure(self, *, runtime=None):
-        return self.describe(runtime=runtime)
+    def describe_structure(self, *, representation=None, runtime=None):
+        return self.describe(representation=representation, runtime=runtime)
 
     def _compare_records(self, other, align):
         if align == "position":

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -728,6 +728,10 @@ class RevivalApiTest(unittest.TestCase):
         self.assertAlmostEqual(description.average_distance, 2.0)
         self.assertAlmostEqual(description.intrinsic_dimension, np.log2(5.0 / 3.0))
         self.assertEqual(space.describe_structure(), description)
+        matrix_description = space.describe(representation=space.to_matrix())
+        self.assertEqual(matrix_description.representation, "matrix")
+        self.assertEqual(matrix_description.record_count, description.record_count)
+        self.assertEqual(space.describe_structure(representation=space.to_matrix()).representation, "matrix")
 
         process_space = Space([0, 1, 2, 3, 4, 5], metric=lambda lhs, rhs: abs(lhs - rhs))
         quality_space = Space([0, 1, 4, 9, 16, 25], metric=lambda lhs, rhs: abs(lhs - rhs))
@@ -810,6 +814,8 @@ class RevivalApiTest(unittest.TestCase):
         space.touch()
         with self.assertRaises(StaleRepresentationError):
             space.embed(representation=stale_matrix)
+        with self.assertRaises(StaleRepresentationError):
+            space.describe(representation=stale_matrix)
 
     def test_intrinsic_dimension_estimates_distance_growth(self):
         records = [0, 1, 2, 3, 4]


### PR DESCRIPTION
## Summary
- add `representation=` support to `Space.describe` and `Space.describe_structure`
- validate representation freshness and propagate representation metadata into `StructureDescription`
- document describe representation usage

## Verification
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/pkg/metric/spaces.py python/pkg/metric/operators.py python/tests/core/test_revival_api.py
- build/python-venv/bin/python -m pip install --force-reinstall ./python
- PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v
- git diff --check
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- cmake --preset python-cmake
- cmake --build --preset python-cmake --parallel 2