### PR TITLE
Document Python reduce compress representation status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -38,6 +38,7 @@ The current local tree implements the first revival slice:
 - Python engine-style Space outlier intent with DBSCAN-noise strategy
 - Python engine-style Space reduce intent with representative and medoid reduction strategies
 - Python engine-style Space compress intent with representative and medoid compression strategies
+- Python reduce and compress facades accept fresh explicit representations and record representation metadata
 - Python engine-style Space map intent for deterministic transforms into derived metric spaces
 - Python map facade accepts `transform=` and reports ambiguous or unavailable mapping forms deterministically
 - Python engine-style Space denoise intent with DBSCAN-noise filtering and mapping-result lineage
@@ -280,6 +281,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ engine embed intent backed by the PCFA strategy with LAPACK-gated core smoke, downstream, and include-smoke coverage, merged as `dc44030e5155608dfeaebbdeb48ab367f595cd0f`
 - Python `Space.describe(..., representation=...)` and `Space.describe_structure(..., representation=...)` freshness checks and representation metadata, merged as `292b054d0fd50a9177ed26934b9d445a2dd42943`
 - Python engine-style Space compress intent backed by representative and medoid compression with named `CompressionResult` objects, merged as `e7029d80c0b2e37bae9078a75408c8b45ae14b91`
+- Python `Space.reduce(..., representation=...)` and `Space.compress(..., representation=...)` freshness checks and representation metadata, merged as `04e4931cd4e995bcc667106285df814dd6acdf9b`
 - C++ engine compress intent backed by deterministic farthest-first representative compression with named `CompressionResult` objects, merged as `d6abef83b61d9e68f5d156884d09c525e8792bf6`
 - Python neighbor facade support for target `count` and `radius` intent arguments, merged as `e9dd23e217b12aeb8e6e85df612c55d78c66da50`
 - Python representation facade support for `Space.to_tree()` and `Space.to_graph(count=...)`, merged as `adb6222c2f311662678694fb3a92ee25052b89bd`


### PR DESCRIPTION
## Summary
- record the merged Python reduce/compress `representation=` support in revival status
- add the post-v0.3.2 master progress entry with the merge SHA

## Verification
- ruby scripts/check_revival_whitespace.rb
- ruby scripts/check_revival_format.rb
- ruby scripts/check_markdown_links.rb
- ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'
- git diff --check