### PR TITLE
Add Python representatives representation metadata

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -77,7 +77,7 @@ space.compare(other_space, strategy=DistanceProfileCorrelation())
 space.compare(other_space, align="ids")
 space.compare(other_space, runtime=RuntimePolicy(exact=True))
 space.correlate(other_space, align="ids")
-space.representatives(count=3)
+space.representatives(count=3, representation=space.to_matrix())
 space.representatives(count=3, strategy=FarthestFirst(seed_index=1))
 space.reduce(count=3, representation=space.to_matrix())
 space.reduce(strategy=KMedoids(groups=3))
@@ -218,7 +218,7 @@ structure = describe_structure(records, Edit())
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 
-`find_representatives` returns a `RepresentativeSet` with selected source indices, nearest-representative distances for every record, coverage radius, average nearest-representative distance, strategy metadata, and representation metadata. Use `count=` for the semantic target size; the older `k` name remains accepted for compatibility. `Space.representatives(...)` exposes the same result from the `Space` facade.
+`find_representatives` returns a `RepresentativeSet` with selected source indices, nearest-representative distances for every record, coverage radius, average nearest-representative distance, strategy metadata, and representation metadata. Use `count=` for the semantic target size; the older `k` name remains accepted for compatibility. `Space.representatives(...)` exposes the same result from the `Space` facade. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`.
 
 `reduce_space` returns a `ReductionResult` with a reduced `Space`, selected source-record IDs, source-to-reduced assignments, nearest-representative distances, strategy metadata, and explicit `inverse_supported=False` metadata. Calling `inverse_transform()` on this result raises `metric.UnsupportedOperationError`. `Space.reduce(count=..., strategy=...)` exposes the same result. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`. The first Python-core strategies are `FarthestFirst` and `KMedoids`, so reduction works for arbitrary records plus a metric rather than only vector records.
 

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -41,7 +41,7 @@ from metric.strategies import ClassicMDS
 
 space = Space(records, metric)
 groups = space.groups(count=2)
-representatives = space.representatives(count=2)
+representatives = space.representatives(count=2, representation=space.to_matrix())
 outliers = space.outliers(count=2, representation=space.to_matrix())
 denoised = space.denoise(count=2, representation=space.to_matrix())
 embedding = space.embed(strategy=ClassicMDS(dimensions=2), representation=space.to_matrix())

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1264,7 +1264,7 @@ def _coerce_representative_request(k=None, count=None):
     return count if count is not None else k
 
 
-def find_representatives(records, metric, k=None, strategy=None, *, count=None):
+def find_representatives(records, metric, k=None, strategy=None, *, count=None, representation="metric_space"):
     """Select representatives and return an engine-style result object."""
     strategy = _coerce_farthest_first(strategy)
     k = _coerce_representative_request(k, count)
@@ -1289,7 +1289,7 @@ def find_representatives(records, metric, k=None, strategy=None, *, count=None):
         average_nearest_distance=average_nearest_distance,
         exact=True,
         strategy="farthest_first",
-        representation="metric_space",
+        representation=representation,
     )
 
 
@@ -1372,7 +1372,13 @@ def reduce_space(records, metric, count=None, strategy=None, *, representation="
         raise ValueError("count cannot exceed the number of records")
 
     if isinstance(strategy, FarthestFirst):
-        representatives_result = find_representatives(records, metric, count, strategy=strategy)
+        representatives_result = find_representatives(
+            records,
+            metric,
+            count,
+            strategy=strategy,
+            representation=representation,
+        )
         source_record_ids = representatives_result.representatives
         strategy_name = "farthest_first"
     elif isinstance(strategy, KMedoids):

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -391,11 +391,18 @@ class Space(FiniteMetricSpace):
             inverse_supported=False,
         )
 
-    def representatives(self, k=None, strategy=None, *, count=None, runtime=None):
+    def representatives(self, k=None, strategy=None, *, count=None, representation=None, runtime=None):
         require_exact_runtime(runtime)
         from metric.operators import find_representatives
 
-        return find_representatives(self.records, self.metric, k, strategy=strategy, count=count)
+        return find_representatives(
+            self.records,
+            self.metric,
+            k,
+            strategy=strategy,
+            count=count,
+            representation=self._representation_name(representation),
+        )
 
     def _representation_name(self, representation):
         representation_name = "metric_space"

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -599,6 +599,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertAlmostEqual(representatives_result.average_nearest_distance, 0.4)
         self.assertEqual(representatives_result.strategy, "farthest_first")
         self.assertEqual(representatives_result.representation, "metric_space")
+        matrix_representatives = space.representatives(count=3, representation=space.to_matrix())
+        self.assertEqual(matrix_representatives.representation, "matrix")
+        self.assertEqual(matrix_representatives.representatives, representatives_result.representatives)
 
         self.assertEqual(space.representatives(count=3), representatives_result)
         self.assertEqual(
@@ -838,6 +841,8 @@ class RevivalApiTest(unittest.TestCase):
             space.reduce(count=2, representation=stale_matrix)
         with self.assertRaises(StaleRepresentationError):
             space.compress(count=2, representation=stale_matrix)
+        with self.assertRaises(StaleRepresentationError):
+            space.representatives(count=2, representation=stale_matrix)
         with self.assertRaises(StaleRepresentationError):
             space.outliers(count=1, representation=stale_matrix)
         with self.assertRaises(StaleRepresentationError):


### PR DESCRIPTION
## Summary
- add `representation=` support to `Space.representatives(...)`
- propagate representation metadata through `find_representatives(...)`
- preserve representation metadata in the farthest-first reduction path
- cover fresh matrix representations and stale representation errors in core tests
- update Python API and engine intent docs

## Verification
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/pkg/metric/spaces.py python/pkg/metric/operators.py python/tests/core/test_revival_api.py`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `cmake --preset python-cmake`
- `cmake --build --preset python-cmake --parallel 2`