### PR TITLE
Add Python groups representation metadata

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -60,7 +60,7 @@ space.neighbors(query, radius=1)
 space.neighbors(query, count=2, radius=1)
 space.nearest(query)
 space.within_radius(query, radius=1)
-space.groups(count=2)
+space.groups(count=2, representation=space.to_matrix())
 space.groups(radius=1, min_size=2)
 space.groups(strategy=KMedoids(groups=2))
 space.groups(strategy=DBSCAN(radius=1, min_points=2))
@@ -206,7 +206,7 @@ structure = describe_structure(records, Edit())
 
 `Space.neighbors(query, count=...)` returns nearest `(record_id, distance)` tuples. `Space.neighbors(query, radius=...)` returns range-neighbor tuples through the same exact metric path as `Space.within_radius(...)`. The older `k` name remains a compatibility alias for count-based nearest-neighbor calls, but new examples should prefer `count`.
 
-`find_groups` returns a `ClusteringResult` with source-record assignments, medoid record IDs, cluster sizes, optional DBSCAN core/noise records, iteration metadata, algorithm metadata, and representation metadata. `Space.groups(...)` exposes the same result from the `Space` facade. Passing an integer group count selects deterministic `KMedoids`; passing `KMedoids` or `DBSCAN` makes the strategy explicit.
+`find_groups` returns a `ClusteringResult` with source-record assignments, medoid record IDs, cluster sizes, optional DBSCAN core/noise records, iteration metadata, algorithm metadata, and representation metadata. `Space.groups(...)` exposes the same result from the `Space` facade. Passing an integer group count selects deterministic `KMedoids`; passing `KMedoids` or `DBSCAN` makes the strategy explicit. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`.
 
 `find_outliers` returns an `OutlierResult` backed by DBSCAN-noise detection. Each `Outlier` contains the source record ID and a deterministic isolation score based on distance to the nearest non-noise record. `Space.outliers(count=...)` also supports a strategy-free exact default that scores records by distance to the nearest other record; pass a DBSCAN strategy for the density-noise path. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`.
 

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -40,7 +40,7 @@ from metric import DistanceProfileCorrelation, Space
 from metric.strategies import ClassicMDS
 
 space = Space(records, metric)
-groups = space.groups(count=2)
+groups = space.groups(count=2, representation=space.to_matrix())
 representatives = space.representatives(count=2, representation=space.to_matrix())
 outliers = space.outliers(count=2, representation=space.to_matrix())
 denoised = space.denoise(count=2, representation=space.to_matrix())

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -916,7 +916,7 @@ def _compute_cluster_medoids(space, assignments, cluster_count):
     return medoids
 
 
-def kmedoids(records, metric, groups, max_iterations=100):
+def kmedoids(records, metric, groups, max_iterations=100, *, representation="metric_space"):
     """Group records with deterministic k-medoids over exact pairwise distances."""
     records = list(records)
     if not records:
@@ -961,7 +961,7 @@ def kmedoids(records, metric, groups, max_iterations=100):
         iterations=iterations,
         converged=converged,
         algorithm="kmedoids",
-        representation="metric_space",
+        representation=representation,
     )
 
 
@@ -1005,7 +1005,7 @@ def _expand_dbscan_cluster(space, seed_neighbors, radius, min_points, cluster, v
             assigned[candidate_index] = True
 
 
-def dbscan(records, metric, radius, min_points):
+def dbscan(records, metric, radius, min_points, *, representation="metric_space"):
     """Group records with deterministic DBSCAN over exact pairwise distances."""
     records = list(records)
     if not records:
@@ -1065,7 +1065,7 @@ def dbscan(records, metric, radius, min_points):
         iterations=1,
         converged=True,
         algorithm="dbscan",
-        representation="metric_space",
+        representation=representation,
     )
 
 
@@ -1087,13 +1087,19 @@ def _coerce_grouping_strategy(strategy):
         raise TypeError("strategy must be a KMedoids, DBSCAN, or integer group count") from None
 
 
-def find_groups(records, metric, strategy):
+def find_groups(records, metric, strategy, *, representation="metric_space"):
     """Group records and return an engine-style result object."""
     strategy = _coerce_grouping_strategy(strategy)
     if isinstance(strategy, KMedoids):
-        return kmedoids(records, metric, strategy.groups, strategy.max_iterations)
+        return kmedoids(
+            records,
+            metric,
+            strategy.groups,
+            strategy.max_iterations,
+            representation=representation,
+        )
     if isinstance(strategy, DBSCAN):
-        return dbscan(records, metric, strategy.radius, strategy.min_points)
+        return dbscan(records, metric, strategy.radius, strategy.min_points, representation=representation)
     raise TypeError("unsupported grouping strategy")
 
 
@@ -1123,7 +1129,7 @@ def find_outliers(records, metric, strategy, *, representation="metric_space"):
     """Find unusual records and return an engine-style result object."""
     strategy = _coerce_outlier_strategy(strategy)
     records = list(records)
-    groups = dbscan(records, metric, strategy.radius, strategy.min_points)
+    groups = dbscan(records, metric, strategy.radius, strategy.min_points, representation=representation)
     space = FiniteMetricSpace(records, metric)
     references = [
         record_index
@@ -1165,7 +1171,7 @@ def denoise_space(records, metric, strategy, *, representation="metric_space"):
     """Filter DBSCAN noise records and return a derived metric space."""
     strategy = _coerce_denoise_strategy(strategy)
     records = list(records)
-    groups = dbscan(records, metric, strategy.radius, strategy.min_points)
+    groups = dbscan(records, metric, strategy.radius, strategy.min_points, representation=representation)
     kept_record_ids = tuple(
         record_index
         for record_index, assignment in enumerate(groups.assignments)
@@ -1382,7 +1388,7 @@ def reduce_space(records, metric, count=None, strategy=None, *, representation="
         source_record_ids = representatives_result.representatives
         strategy_name = "farthest_first"
     elif isinstance(strategy, KMedoids):
-        groups = find_groups(records, metric, strategy)
+        groups = find_groups(records, metric, strategy, representation=representation)
         source_record_ids = groups.medoids
         strategy_name = "kmedoids"
     else:

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -258,8 +258,7 @@ class Space(FiniteMetricSpace):
 
     def groups(self, strategy=None, *, count="auto", radius=None, min_size=1, representation=None, runtime=None):
         require_exact_runtime(runtime)
-        if representation is not None:
-            representation.ensure_fresh()
+        representation_name = self._representation_name(representation)
         if strategy is not None and (count != "auto" or radius is not None):
             raise ValueError("use either strategy or count/radius, not both")
 
@@ -274,7 +273,7 @@ class Space(FiniteMetricSpace):
                     count = 1 if len(self.records) <= 2 else 2
                 strategy = KMedoids(groups=count)
 
-        return find_groups(self.records, self.metric, strategy)
+        return find_groups(self.records, self.metric, strategy, representation=representation_name)
 
     def _nearest_other_distance(self, source_index):
         candidates = [

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -485,6 +485,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(find_groups([0, 1, 2, 10, 11], lambda lhs, rhs: abs(lhs - rhs), 2), groups)
         self.assertEqual(group_space.groups(count=2), groups)
         self.assertEqual(group_space.groups(), groups)
+        matrix_groups = group_space.groups(count=2, representation=group_space.to_matrix())
+        self.assertEqual(matrix_groups.representation, "matrix")
+        self.assertEqual(matrix_groups.assignments, groups.assignments)
 
         density_groups = group_space.groups(DBSCAN(radius=1, min_points=2))
         self.assertIsInstance(density_groups, ClusteringResult)
@@ -497,6 +500,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(density_groups.noise_count, 0)
         self.assertEqual(density_groups.algorithm, "dbscan")
         self.assertEqual(group_space.groups(radius=1, min_size=2), density_groups)
+        matrix_density_groups = group_space.groups(radius=1, min_size=2, representation=group_space.to_matrix())
+        self.assertEqual(matrix_density_groups.representation, "matrix")
+        self.assertEqual(matrix_density_groups.assignments, density_groups.assignments)
         with self.assertRaises(ValueError):
             group_space.groups(KMedoids(groups=2), count=2)
 
@@ -835,6 +841,8 @@ class RevivalApiTest(unittest.TestCase):
         space.touch()
         with self.assertRaises(StaleRepresentationError):
             space.embed(representation=stale_matrix)
+        with self.assertRaises(StaleRepresentationError):
+            space.groups(count=2, representation=stale_matrix)
         with self.assertRaises(StaleRepresentationError):
             space.describe(representation=stale_matrix)
         with self.assertRaises(StaleRepresentationError):


### PR DESCRIPTION
## Summary
- propagate representation metadata through `Space.groups(...)` and `find_groups(...)`
- preserve representation metadata in KMedoids and DBSCAN clustering results
- pass representation metadata through grouped outlier, denoise, and KMedoids reduction internals
- cover fresh matrix representations and stale representation errors in core tests
- update Python API and engine intent docs

## Verification
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/pkg/metric/spaces.py python/pkg/metric/operators.py python/tests/core/test_revival_api.py`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `cmake --preset python-cmake`
- `cmake --build --preset python-cmake --parallel 2`