### PR TITLE
Add Python compare representation metadata

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -73,7 +73,7 @@ space.outliers(strategy=DBSCAN(radius=1, min_points=2))
 space.denoise()
 space.denoise(count=2, representation=space.to_matrix())
 space.denoise(strategy=DBSCAN(radius=1, min_points=2))
-space.compare(other_space, strategy=DistanceProfileCorrelation())
+space.compare(other_space, strategy=DistanceProfileCorrelation(), representation=space.to_matrix(), other_representation=other_space.to_matrix())
 space.compare(other_space, align="ids")
 space.compare(other_space, runtime=RuntimePolicy(exact=True))
 space.correlate(other_space, align="ids")
@@ -214,7 +214,7 @@ structure = describe_structure(records, Edit())
 
 `embed_space` returns an `EmbeddingResult` backed by deterministic classical MDS over the exact finite distance matrix. The result includes NumPy `coordinates`, an `embedded_space` over coordinate records with a Euclidean metric, the original `source_space`, source-record IDs, exact/operator/representation metadata, a small `EmbeddingModel`, normalized stress, local-neighbor trustworthiness, distance-profile correlation, and finite-coordinate diagnostics. `Space.embed(...)` exposes the same derived coordinate view from the `Space` facade. Pass `representation=space.to_matrix()` or another fresh representation when the result should record the execution representation; stale representations raise `metric.StaleRepresentationError`.
 
-`compare_spaces` returns a `CorrelationResult` for two aligned finite metric spaces with the same record count. The first Python-core strategy is `DistanceProfileCorrelation`, which computes the Pearson correlation of upper-triangular pairwise distance profiles. `Space.compare(...)` and `Space.correlate(...)` expose the same result with metric-space representation metadata. The facade defaults to `align="position"` for compatibility. Pass `align="ids"` to compare spaces with the same stable IDs even when the right-hand space is in a different order; mismatched ID sets raise `metric.IncompatibleSpaceError`.
+`compare_spaces` returns a `CorrelationResult` for two aligned finite metric spaces with the same record count. The first Python-core strategy is `DistanceProfileCorrelation`, which computes the Pearson correlation of upper-triangular pairwise distance profiles. `Space.compare(...)` and `Space.correlate(...)` expose the same result with metric-space representation metadata. The facade defaults to `align="position"` for compatibility. Pass fresh `representation=` and `other_representation=` values to record left/right representation metadata; stale representations raise `metric.StaleRepresentationError`. Pass `align="ids"` to compare spaces with the same stable IDs even when the right-hand space is in a different order; mismatched ID sets raise `metric.IncompatibleSpaceError`.
 
 `representative_indices` and `representatives` use deterministic farthest-first traversal over the finite metric space. They select existing records rather than vector centroids, start from `seed_index=0` by default, and resolve equal-distance ties by record order.
 

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -45,7 +45,13 @@ representatives = space.representatives(count=2, representation=space.to_matrix(
 outliers = space.outliers(count=2, representation=space.to_matrix())
 denoised = space.denoise(count=2, representation=space.to_matrix())
 embedding = space.embed(strategy=ClassicMDS(dimensions=2), representation=space.to_matrix())
-dependency = space.compare(other_space, DistanceProfileCorrelation(), align="ids")
+dependency = space.compare(
+    other_space,
+    DistanceProfileCorrelation(),
+    align="ids",
+    representation=space.to_matrix(),
+    other_representation=other_space.to_matrix(),
+)
 reduction = space.reduce(count=2, representation=space.to_matrix())
 compression = space.compress(count=2, representation=space.to_matrix())
 mapped = space.map(transform=transform, metric=target_metric, representation=space.to_matrix())

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -1787,9 +1787,26 @@ def compare_spaces(
     )
 
 
-def correlate_spaces(left_records, left_metric, right_records, right_metric, strategy=None):
+def correlate_spaces(
+    left_records,
+    left_metric,
+    right_records,
+    right_metric,
+    strategy=None,
+    *,
+    left_representation="records",
+    right_representation="records",
+):
     """Alias for compare_spaces for correlation-oriented workflows."""
-    return compare_spaces(left_records, left_metric, right_records, right_metric, strategy)
+    return compare_spaces(
+        left_records,
+        left_metric,
+        right_records,
+        right_metric,
+        strategy,
+        left_representation=left_representation,
+        right_representation=right_representation,
+    )
 
 
 def intrinsic_dimension(records, metric):

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -494,7 +494,16 @@ class Space(FiniteMetricSpace):
             raise IncompatibleSpaceError("align='ids' requires both spaces to have the same ids")
         return self.records, [other.record(record_id) for record_id in self.ids]
 
-    def compare(self, other, strategy=None, *, align="position", runtime=None):
+    def compare(
+        self,
+        other,
+        strategy=None,
+        *,
+        align="position",
+        representation=None,
+        other_representation=None,
+        runtime=None,
+    ):
         require_exact_runtime(runtime)
         from metric.operators import compare_spaces
 
@@ -505,12 +514,28 @@ class Space(FiniteMetricSpace):
             right_records,
             other.metric,
             strategy,
-            left_representation="metric_space",
-            right_representation="metric_space",
+            left_representation=self._representation_name(representation),
+            right_representation=self._representation_name(other_representation),
         )
 
-    def correlate(self, other, strategy=None, *, align="position", runtime=None):
-        return self.compare(other, strategy=strategy, align=align, runtime=runtime)
+    def correlate(
+        self,
+        other,
+        strategy=None,
+        *,
+        align="position",
+        representation=None,
+        other_representation=None,
+        runtime=None,
+    ):
+        return self.compare(
+            other,
+            strategy=strategy,
+            align=align,
+            representation=representation,
+            other_representation=other_representation,
+            runtime=runtime,
+        )
 
 
 MatrixSpace = FiniteMetricSpace

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -781,9 +781,43 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(dependency.left_representation, "metric_space")
         self.assertEqual(dependency.right_representation, "metric_space")
         self.assertEqual(process_space.correlate(quality_space), dependency)
+        matrix_dependency = process_space.compare(
+            quality_space,
+            representation=process_space.to_matrix(),
+            other_representation=quality_space.to_matrix(),
+        )
+        self.assertAlmostEqual(matrix_dependency.value, dependency.value)
+        self.assertEqual(matrix_dependency.left_representation, "matrix")
+        self.assertEqual(matrix_dependency.right_representation, "matrix")
+        self.assertEqual(
+            process_space.correlate(
+                quality_space,
+                representation=process_space.to_matrix(),
+                other_representation=quality_space.to_matrix(),
+            ),
+            matrix_dependency,
+        )
         self.assertEqual(
             compare_spaces(process_space.records, process_space.metric, quality_space.records, quality_space.metric),
             correlate_spaces(process_space.records, process_space.metric, quality_space.records, quality_space.metric),
+        )
+        self.assertEqual(
+            compare_spaces(
+                process_space.records,
+                process_space.metric,
+                quality_space.records,
+                quality_space.metric,
+                left_representation="matrix",
+                right_representation="matrix",
+            ),
+            correlate_spaces(
+                process_space.records,
+                process_space.metric,
+                quality_space.records,
+                quality_space.metric,
+                left_representation="matrix",
+                right_representation="matrix",
+            ),
         )
         shuffled_quality_space = Space(
             [25, 0, 16, 1, 9, 4],
@@ -864,6 +898,8 @@ class RevivalApiTest(unittest.TestCase):
             space.denoise(count=1, representation=stale_matrix)
         with self.assertRaises(StaleRepresentationError):
             space.map(transform=lambda record: record, representation=stale_matrix)
+        with self.assertRaises(StaleRepresentationError):
+            space.compare(space, representation=stale_matrix)
 
     def test_intrinsic_dimension_estimates_distance_growth(self):
         records = [0, 1, 2, 3, 4]


### PR DESCRIPTION
## Summary
- add left/right representation metadata support to `Space.compare(...)` and `Space.correlate(...)`
- propagate representation metadata through `correlate_spaces(...)`
- cover fresh matrix representations and stale representation errors in core tests
- update Python API and engine intent docs

## Verification
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/pkg/metric/spaces.py python/pkg/metric/operators.py python/tests/core/test_revival_api.py`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `cmake --preset python-cmake`
- `cmake --build --preset python-cmake --parallel 2`