### PR TITLE
Update revival status for Python distance aliases

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -49,6 +49,7 @@ The current local tree implements the first revival slice:
 - Python map facade accepts fresh explicit representations and records representation metadata
 - Python engine-style Space denoise intent with DBSCAN-noise filtering and mapping-result lineage
 - Python describe facade accepts fresh explicit representations and records representation metadata
+- Python distance compatibility aliases expose `Manhattan`, `Minkowski`, and `ThresholdedEuclidean` when optional historical standard bindings are installed
 - Python beta compatibility bridge modules under `metric.mappings` and `metric.transforms`
 - promoted C++ examples under `examples/core/`
 - promoted Python examples under `python/examples/metric_space/`
@@ -311,6 +312,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - Python strategy-free `Space.outliers(count=...)`, `fraction`, and `threshold` facade, merged as `376e45480dcdb3abaaab6aa972d32f4373b0744c`
 - Python strategy-free `Space.denoise(...)`, `count`, `fraction`, `threshold`, and `strength` facade, merged as `8b2fd745d4e2ed343d678ffdb7423cae5c1e3e71`
 - Python `Space.outliers(..., representation=...)` and `Space.denoise(..., representation=...)` freshness checks and representation metadata, merged as `215185307b04ef167fa2723e38b3266a17e71853`
+- Python distance compatibility aliases for optional historical standard bindings, merged as `3b210fec8ffcc49e767065d829f830d74447fa38`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the merged Python distance compatibility alias slice in local revival scope
- add the post-v0.3.2 master progress entry for merge commit `3b210fec8ffcc49e767065d829f830d74447fa38`

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`