### PR TITLE
Hide Python top-level debug exports

### DIFF
--- a/python/src/init.cpp
+++ b/python/src/init.cpp
@@ -10,10 +10,6 @@
 //#include "stl_wrappers.hpp"
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
-
-#include <vector>
-#include <iostream>
 
 namespace py = pybind11;
 
@@ -73,28 +69,10 @@ namespace py = pybind11;
 
 void export_blaze_matrices(py::module& m);
 
-
-std::vector<long> data(const std::vector<long>& ro_a, std::vector<long>& rw_a) {
-    std::vector<long> result = {1, 2, 3};
-    std::cout << &ro_a << " x " << &rw_a << " -> " << &result << std::endl;
-    result.insert(result.end(), ro_a.begin(), ro_a.end());
-    rw_a.front() = 777;
-    return result;
-}
-
-PYBIND11_MAKE_OPAQUE(std::vector<long>);
-
 PYBIND11_MODULE(metric, m) {
-    py::bind_vector<std::vector<long>>(m, "LongVector", py::buffer_protocol())
-        .def("ptr", [](std::vector<long>& self){ return (unsigned long)&self; });
-    py::bind_vector<std::vector<double>>(m, "DoubleVector", py::buffer_protocol());
     //export_converters();
     // exposing C++ return types
     //export_containers();
 
     export_blaze_matrices(m);
-    m.def("test", &data,
-        py::arg("a"),
-        py::arg("b")
-    );
 }

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -350,6 +350,10 @@ class RevivalApiTest(unittest.TestCase):
             if historical is not None:
                 self.assertIs(getattr(distance_module, alias), historical)
 
+    def test_top_level_hides_debug_extension_exports(self):
+        for name in ("DoubleVector", "LongVector", "test"):
+            self.assertFalse(hasattr(metric, name), name)
+
     def test_promoted_metric_space_examples_run(self):
         examples_root = Path(__file__).resolve().parents[2] / "examples"
         examples = sorted((examples_root / "metric_space").glob("*.py"))


### PR DESCRIPTION
## Summary
- remove native debug helper exports `LongVector`, `DoubleVector`, and `test` from the top-level Python extension module
- add a core Python regression test so these debug bindings do not leak into `metric` again

## Verification
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/tests/core/test_revival_api.py`
- `cmake --preset python-cmake && cmake --build --preset python-cmake --parallel 2`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- import smoke checking `metric` has no `DoubleVector`, `LongVector`, or `test`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`