### PR TITLE
Fix Python Tree legacy bindings

### DIFF
--- a/python/src/space/tree.cpp
+++ b/python/src/space/tree.cpp
@@ -67,8 +67,8 @@ void register_wrapper_Tree(py::module& m) {
     tree.def("clustering", clustering3);
     tree.def("insert", insert1);
     tree.def("insert", insert2);
-    tree.def("insert", insert_if1);
-    tree.def("insert", insert_if2);
+    tree.def("insert_if", insert_if1);
+    tree.def("insert_if", insert_if2);
 
     tree.def("erase", &Tree::erase);
     tree.def("__getitem__", &Tree::operator[]);
@@ -76,7 +76,8 @@ void register_wrapper_Tree(py::module& m) {
     tree.def("knn", &Tree::knn);
     tree.def("rnn", &Tree::rnn);
     tree.def("__len__", &Tree::size);
-    tree.def("empty", &Tree::size);
+    tree.def("size", &Tree::size);
+    tree.def("empty", &Tree::empty);
     tree.def("to_vector", &Tree::toVector);
     tree.def("check_covering", &Tree::check_covering);
     tree.def("distance_by_id", &Tree::distance_by_id);

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -354,6 +354,31 @@ class RevivalApiTest(unittest.TestCase):
         for name in ("DoubleVector", "LongVector", "test"):
             self.assertFalse(hasattr(metric, name), name)
 
+    def test_legacy_tree_binding_uses_boolean_empty_and_named_insert_if(self):
+        from metric.space import Tree
+
+        tree = Tree()
+        self.assertIs(tree.empty(), True)
+        self.assertEqual(tree.size(), 0)
+        self.assertEqual(len(tree), 0)
+
+        first_id = tree.insert([1.0, 2.0])
+        self.assertEqual(first_id, 0)
+        self.assertIs(tree.empty(), False)
+        self.assertEqual(tree.size(), 1)
+        self.assertEqual(len(tree), 1)
+
+        second_id, inserted = tree.insert_if([2.0, 3.0], 0.1)
+        self.assertEqual(second_id, 1)
+        self.assertIs(inserted, True)
+
+        duplicate_id, inserted = tree.insert_if([2.0, 3.0], 10.0)
+        self.assertEqual(duplicate_id, 1)
+        self.assertIs(inserted, False)
+
+        with self.assertRaises(TypeError):
+            tree.insert([3.0, 4.0], 0.1)
+
     def test_promoted_metric_space_examples_run(self):
         examples_root = Path(__file__).resolve().parents[2] / "examples"
         examples = sorted((examples_root / "metric_space").glob("*.py"))


### PR DESCRIPTION
## Summary
- bind `Tree.empty()` to the C++ boolean empty check instead of `Tree.size()`
- expose `Tree.size()` explicitly alongside `len(tree)`
- move threshold insert-if overloads from `Tree.insert(...)` to the documented `Tree.insert_if(...)` name
- add core Python regression coverage for the legacy Tree binding surface

## Verification
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m py_compile python/tests/core/test_revival_api.py`
- `cmake --preset python-cmake && cmake --build --preset python-cmake --parallel 2`
- `build/python-venv/bin/python -m pip install --force-reinstall ./python`
- direct Tree binding smoke for `empty`, `size`, `insert`, and `insert_if`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`