### PR TITLE
Fix Python kmeans random seed keyword

### DIFF
--- a/python/src/mapping/kmeans.cpp
+++ b/python/src/mapping/kmeans.cpp
@@ -15,7 +15,7 @@ void register_wrapper_kmeans(py::module& m) {
         py::arg("k") = 0.5,
         py::arg("maxiter") = 200,
         py::arg("metric") = "Euclidean",   // TODO: fix typo
-        py::arg("random_see") = -1
+        py::arg("random_seed") = -1
     );
 }
 


### PR DESCRIPTION
## Summary
- rename the legacy Python kmeans binding keyword from typo `random_see` to `random_seed`

## Verification
- `rg -n "\brandom_see\b" python/src python/pkg python/tests || true` returned no matches
- `cmake --preset python-cmake && cmake --build --preset python-cmake --parallel 2`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`

## Note
- I attempted a local full Python mapping configuration with `METRIC_PYTHON_BUILD_FULL=ON`, but CMake stopped before the mapping target because local Boost headers are not installed (`Could NOT find Boost`). The changed file is outside the core Python wheel target, so this PR relies on source-level verification plus the core Python CMake gate.