### PR TITLE
Update revival status for kmeans keyword fix

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -52,6 +52,7 @@ The current local tree implements the first revival slice:
 - Python distance compatibility aliases expose `Manhattan`, `Minkowski`, and `ThresholdedEuclidean` when optional historical standard bindings are installed
 - Python top-level package hides legacy native debug exports such as `LongVector`, `DoubleVector`, and `test`
 - Python legacy Tree bindings expose boolean `empty()`, explicit `size()`, and named `insert_if(...)` threshold insertion
+- Python legacy kmeans binding uses the corrected `random_seed` keyword
 - Python beta compatibility bridge modules under `metric.mappings` and `metric.transforms`
 - promoted C++ examples under `examples/core/`
 - promoted Python examples under `python/examples/metric_space/`
@@ -317,6 +318,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - Python distance compatibility aliases for optional historical standard bindings, merged as `3b210fec8ffcc49e767065d829f830d74447fa38`
 - Python top-level debug extension exports hidden from the public package API, merged as `66d7c07933c6cfd08b3dea8184741fc3ede41a47`
 - Python legacy Tree binding fixes for boolean `empty()`, explicit `size()`, and named `insert_if(...)`, merged as `b11d339fe9c0867d76aee20ff8ed02762fe67a12`
+- Python legacy kmeans binding keyword corrected from `random_see` to `random_seed`, merged as `e8faf336ffc9a7087eec95213593bf339d2f52e4`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the legacy Python kmeans keyword fix in local revival scope
- add the post-v0.3.2 master progress entry for merge commit `e8faf336ffc9a7087eec95213593bf339d2f52e4`

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`