### PR TITLE
Add stable metric-space IDs and representation diagnostics

### DIFF
--- a/metric/core/concepts.hpp
+++ b/metric/core/concepts.hpp
@@ -53,6 +53,9 @@ struct DistanceProvider<Provider,
 									decltype(std::declval<const Provider &>().distance(std::declval<RecordId>(),
 																					   std::declval<RecordId>())),
 									decltype(std::declval<const Provider &>().record_count()),
+									decltype(std::declval<const Provider &>().id(std::declval<std::size_t>())),
+									decltype(std::declval<const Provider &>().position_of(std::declval<RecordId>())),
+									decltype(std::declval<const Provider &>().contains(std::declval<RecordId>())),
 									decltype(std::declval<const Provider &>().version()),
 									decltype(std::declval<const Provider &>().is_stale())>> : std::true_type {
 };

--- a/metric/core/metric_space.hpp
+++ b/metric/core/metric_space.hpp
@@ -25,6 +25,8 @@ template <typename Record, typename Metric> class MetricSpace {
 	MetricSpace(std::vector<record_type> records, metric_type metric)
 		: records_(std::move(records))
 		, metric_(std::move(metric))
+		, ids_(make_initial_ids(records_.size()))
+		, next_record_id_(records_.size())
 	{
 		static_assert(MetricCallable_v<metric_type, record_type>,
 					  "metric::core::MetricSpace requires a metric callable accepting two records");
@@ -35,13 +37,35 @@ template <typename Record, typename Metric> class MetricSpace {
 	auto version() const -> std::size_t { return version_; }
 	auto touch() -> void { ++version_; }
 
-	auto id(std::size_t index) const -> RecordId
+	auto id(std::size_t position) const -> RecordId { return id_at(position); }
+
+	auto id_at(std::size_t position) const -> RecordId
 	{
-		validate_index(index);
-		return RecordId::from_index(index);
+		validate_position(position);
+		return ids_[position];
 	}
 
-	auto record(RecordId id) const -> const record_type & { return records_.at(id.index()); }
+	auto contains(RecordId id) const -> bool
+	{
+		for (const auto current : ids_) {
+			if (current == id) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	auto position_of(RecordId id) const -> std::size_t
+	{
+		for (std::size_t position = 0; position < ids_.size(); ++position) {
+			if (ids_[position] == id) {
+				return position;
+			}
+		}
+		throw std::out_of_range("record id is not in the metric space");
+	}
+
+	auto record(RecordId id) const -> const record_type & { return records_.at(position_of(id)); }
 	auto operator[](RecordId id) const -> const record_type & { return record(id); }
 
 	auto distance(RecordId lhs, RecordId rhs) const -> distance_type
@@ -54,16 +78,56 @@ template <typename Record, typename Metric> class MetricSpace {
 	auto records() const -> const std::vector<record_type> & { return records_; }
 	auto metric() const -> const metric_type & { return metric_; }
 
-  private:
-	auto validate_index(std::size_t index) const -> void
+	auto insert(record_type record) -> RecordId
 	{
-		if (index >= records_.size()) {
-			throw std::out_of_range("record id is outside the metric space");
+		const auto id = RecordId::from_index(next_record_id_++);
+		records_.push_back(std::move(record));
+		ids_.push_back(id);
+		++version_;
+		return id;
+	}
+
+	auto replace(RecordId id, record_type record) -> void
+	{
+		records_[position_of(id)] = std::move(record);
+		++version_;
+	}
+
+	auto erase(RecordId id) -> bool
+	{
+		for (std::size_t position = 0; position < ids_.size(); ++position) {
+			if (ids_[position] == id) {
+				records_.erase(records_.begin() + static_cast<std::ptrdiff_t>(position));
+				ids_.erase(ids_.begin() + static_cast<std::ptrdiff_t>(position));
+				++version_;
+				return true;
+			}
+		}
+		return false;
+	}
+
+  private:
+	static auto make_initial_ids(std::size_t count) -> std::vector<RecordId>
+	{
+		std::vector<RecordId> ids;
+		ids.reserve(count);
+		for (std::size_t index = 0; index < count; ++index) {
+			ids.push_back(RecordId::from_index(index));
+		}
+		return ids;
+	}
+
+	auto validate_position(std::size_t position) const -> void
+	{
+		if (position >= records_.size()) {
+			throw std::out_of_range("record position is outside the metric space");
 		}
 	}
 
 	std::vector<record_type> records_;
 	metric_type metric_;
+	std::vector<RecordId> ids_;
+	std::size_t next_record_id_{};
 	std::size_t version_{};
 };
 

--- a/metric/engine.hpp
+++ b/metric/engine.hpp
@@ -30,6 +30,7 @@
 #include "operators/correlation.hpp"
 #include "operators/nearest.hpp"
 #include "representations/cover_tree_index.hpp"
+#include "representations/diagnostics.hpp"
 #include "representations/graph_topology.hpp"
 #include "representations/implicit.hpp"
 #include "representations/knn_graph_index.hpp"

--- a/metric/intent/describe.hpp
+++ b/metric/intent/describe.hpp
@@ -64,7 +64,7 @@ auto describe_structure(const Provider &provider) -> StructureDescription<typena
 
 	for (std::size_t row = 0; row < provider.record_count(); ++row) {
 		for (std::size_t column = row + 1; column < provider.record_count(); ++column) {
-			const auto distance = provider.distance(RecordId::from_index(row), RecordId::from_index(column));
+			const auto distance = provider.distance(provider.id(row), provider.id(column));
 			distances[row][column] = distance;
 			distances[column][row] = distance;
 			++result.pair_count;

--- a/metric/intent/outliers.hpp
+++ b/metric/intent/outliers.hpp
@@ -41,7 +41,7 @@ auto nearest_reference_distance(const Provider &provider, RecordId id, const std
 	}
 
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		const auto reference = RecordId::from_index(index);
+		const auto reference = provider.id(index);
 		if (reference == id) {
 			continue;
 		}
@@ -67,7 +67,7 @@ auto outlier_result_from_groups(const Provider &provider,
 	references.reserve(provider.record_count() - groups.noise_count);
 	for (std::size_t index = 0; index < groups.assignments.size(); ++index) {
 		if (groups.assignments[index] != noise_label) {
-			references.push_back(RecordId::from_index(index));
+			references.push_back(provider.id(index));
 		}
 	}
 

--- a/metric/intent/representatives.hpp
+++ b/metric/intent/representatives.hpp
@@ -47,7 +47,7 @@ auto find_representatives(const Provider &provider, std::size_t count, strategie
 		throw std::out_of_range("seed_index is outside the metric space");
 	}
 
-	result.representatives.push_back(RecordId::from_index(strategy.seed_index));
+	result.representatives.push_back(provider.id(strategy.seed_index));
 
 	std::vector<bool> is_selected(provider.record_count(), false);
 	is_selected[strategy.seed_index] = true;
@@ -55,7 +55,7 @@ auto find_representatives(const Provider &provider, std::size_t count, strategie
 	result.nearest_representative_distances.resize(provider.record_count());
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
 		result.nearest_representative_distances[index] =
-			provider.distance(RecordId::from_index(index), result.representatives.front());
+			provider.distance(provider.id(index), result.representatives.front());
 	}
 
 	while (result.representatives.size() < count) {
@@ -78,13 +78,13 @@ auto find_representatives(const Provider &provider, std::size_t count, strategie
 			throw std::logic_error("failed to select the next representative");
 		}
 
-		const auto next_id = RecordId::from_index(next_index);
+		const auto next_id = provider.id(next_index);
 		result.representatives.push_back(next_id);
 		is_selected[next_index] = true;
 		for (std::size_t index = 0; index < result.nearest_representative_distances.size(); ++index) {
 			result.nearest_representative_distances[index] =
 				std::min(result.nearest_representative_distances[index],
-						 provider.distance(RecordId::from_index(index), next_id));
+						 provider.distance(provider.id(index), next_id));
 		}
 	}
 

--- a/metric/mappings/clustered_space.hpp
+++ b/metric/mappings/clustered_space.hpp
@@ -147,7 +147,7 @@ template <typename Distance> class ClusteredSpaceMapping {
 			if (label >= clustering.cluster_count) {
 				throw std::invalid_argument("clustering assignment references an unknown cluster");
 			}
-			source_records[label].push_back(RecordId::from_index(index));
+			source_records[label].push_back(provider.id(index));
 		}
 
 		std::vector<RecordId> representative_records;

--- a/metric/operators/clustering.hpp
+++ b/metric/operators/clustering.hpp
@@ -29,7 +29,7 @@ auto total_distance_to_all(const Provider &provider, RecordId candidate) -> type
 
 	distance_type total{};
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		total += provider.distance(candidate, RecordId::from_index(index));
+		total += provider.distance(candidate, provider.id(index));
 	}
 	return total;
 }
@@ -69,7 +69,7 @@ auto initialize_medoids(const Provider &provider, std::size_t cluster_count) -> 
 	distance_type best_total{};
 	bool has_best = false;
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		const auto candidate = RecordId::from_index(index);
+		const auto candidate = provider.id(index);
 		const auto total = total_distance_to_all(provider, candidate);
 		if (!has_best || total < best_total) {
 			first_medoid = candidate;
@@ -84,7 +84,7 @@ auto initialize_medoids(const Provider &provider, std::size_t cluster_count) -> 
 		distance_type best_distance{};
 		bool has_next = false;
 		for (std::size_t index = 0; index < provider.record_count(); ++index) {
-			const auto candidate = RecordId::from_index(index);
+			const auto candidate = provider.id(index);
 			if (contains_medoid(medoids, candidate)) {
 				continue;
 			}
@@ -116,7 +116,7 @@ auto assign_to_medoids(const Provider &provider, const std::vector<RecordId> &me
 	std::vector<std::size_t> cluster_sizes(medoids.size(), 0);
 
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		const auto id = RecordId::from_index(index);
+		const auto id = provider.id(index);
 		std::size_t best_cluster = 0;
 		distance_type best_distance{};
 		bool has_best = false;
@@ -159,11 +159,11 @@ auto recompute_medoids(const Provider &provider, const std::vector<std::size_t> 
 			if (assignments[candidate_index] != cluster) {
 				continue;
 			}
-			const auto candidate = RecordId::from_index(candidate_index);
+			const auto candidate = provider.id(candidate_index);
 			distance_type total{};
 			for (std::size_t other_index = 0; other_index < assignments.size(); ++other_index) {
 				if (assignments[other_index] == cluster) {
-					total += provider.distance(candidate, RecordId::from_index(other_index));
+					total += provider.distance(candidate, provider.id(other_index));
 				}
 			}
 			if (!has_best || total < best_total ||
@@ -198,11 +198,11 @@ auto compute_cluster_medoids(const Provider &provider, const std::vector<std::si
 			if (assignments[candidate_index] != cluster) {
 				continue;
 			}
-			const auto candidate = RecordId::from_index(candidate_index);
+			const auto candidate = provider.id(candidate_index);
 			distance_type total{};
 			for (std::size_t other_index = 0; other_index < assignments.size(); ++other_index) {
 				if (assignments[other_index] == cluster) {
-					total += provider.distance(candidate, RecordId::from_index(other_index));
+					total += provider.distance(candidate, provider.id(other_index));
 				}
 			}
 			if (!has_best || total < best_total ||
@@ -261,7 +261,7 @@ auto affinity_similarity_matrix(const Provider &provider, typename Provider::dis
 
 	for (std::size_t lhs = 0; lhs < provider.record_count(); ++lhs) {
 		for (std::size_t rhs = lhs; rhs < provider.record_count(); ++rhs) {
-			const auto distance = provider.distance(RecordId::from_index(lhs), RecordId::from_index(rhs));
+			const auto distance = provider.distance(provider.id(lhs), provider.id(rhs));
 			const auto current_similarity = -distance;
 			if (!has_similarity || current_similarity < minimum_similarity) {
 				minimum_similarity = current_similarity;
@@ -289,7 +289,7 @@ auto dbscan_region_query(const Provider &provider, RecordId id, Radius radius) -
 	neighbors.reserve(provider.record_count());
 
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		const auto candidate = RecordId::from_index(index);
+		const auto candidate = provider.id(index);
 		if (provider.distance(id, candidate) <= radius) {
 			neighbors.push_back(candidate);
 		}
@@ -310,12 +310,12 @@ auto expand_dbscan_cluster(const Provider &provider, const std::vector<RecordId>
 
 	for (const auto neighbor : seed_neighbors) {
 		queue.push_back(neighbor);
-		queued[neighbor.index()] = true;
+		queued[provider.position_of(neighbor)] = true;
 	}
 
 	for (std::size_t cursor = 0; cursor < queue.size(); ++cursor) {
 		const auto candidate = queue[cursor];
-		const auto candidate_index = candidate.index();
+		const auto candidate_index = provider.position_of(candidate);
 
 		if (!visited[candidate_index]) {
 			visited[candidate_index] = true;
@@ -323,9 +323,10 @@ auto expand_dbscan_cluster(const Provider &provider, const std::vector<RecordId>
 			if (neighbors.size() >= min_points) {
 				core_records[candidate_index] = true;
 				for (const auto neighbor : neighbors) {
-					if (!queued[neighbor.index()]) {
+					const auto neighbor_position = provider.position_of(neighbor);
+					if (!queued[neighbor_position]) {
 						queue.push_back(neighbor);
-						queued[neighbor.index()] = true;
+						queued[neighbor_position] = true;
 					}
 				}
 			}
@@ -429,7 +430,7 @@ auto dbscan(const Provider &provider, Radius radius, std::size_t min_points)
 			continue;
 		}
 
-		const auto id = RecordId::from_index(index);
+		const auto id = provider.id(index);
 		visited[index] = true;
 		auto neighbors = engine_detail::dbscan_region_query(provider, id, radius);
 		if (neighbors.size() < min_points) {
@@ -451,12 +452,12 @@ auto dbscan(const Provider &provider, Radius radius, std::size_t min_points)
 			++cluster_sizes[assignments[index]];
 		} else {
 			assignments[index] = noise_label;
-			noise_records.push_back(RecordId::from_index(index));
+			noise_records.push_back(provider.id(index));
 			++noise_count;
 		}
 
 		if (core_record_flags[index]) {
-			core_records.push_back(RecordId::from_index(index));
+			core_records.push_back(provider.id(index));
 		}
 	}
 
@@ -534,7 +535,7 @@ auto affinity_propagation(const Provider &provider, double preference = 0.5, int
 	std::vector<RecordId> medoids;
 	medoids.reserve(exemplars.size());
 	for (const auto exemplar : exemplars) {
-		medoids.push_back(RecordId::from_index(exemplar));
+		medoids.push_back(provider.id(exemplar));
 	}
 
 	ClusteringResult<distance_type> result;

--- a/metric/operators/correlation.hpp
+++ b/metric/operators/correlation.hpp
@@ -23,8 +23,7 @@ auto provider_distance_matrix(const Provider &provider) -> DistanceMatrix<double
 	for (std::size_t row = 0; row < matrix.rows(); ++row) {
 		matrix(row, row) = 0.0;
 		for (std::size_t column = row + 1; column < matrix.columns(); ++column) {
-			matrix(row, column) = static_cast<double>(
-				provider.distance(RecordId::from_index(row), RecordId::from_index(column)));
+			matrix(row, column) = static_cast<double>(provider.distance(provider.id(row), provider.id(column)));
 		}
 	}
 	return matrix;

--- a/metric/operators/nearest.hpp
+++ b/metric/operators/nearest.hpp
@@ -85,7 +85,7 @@ auto knn(const Space &space, const typename Space::record_type &query, std::size
 	std::vector<Neighbor<distance_type>> candidates;
 	candidates.reserve(space.size());
 	for (std::size_t index = 0; index < space.size(); ++index) {
-		const auto id = RecordId::from_index(index);
+		const auto id = space.id(index);
 		candidates.push_back(Neighbor<distance_type>{id, space.metric()(query, space.record(id))});
 	}
 
@@ -101,7 +101,7 @@ auto knn(const Space &space, RecordId query_id, std::size_t k) -> NeighborSet<ty
 	std::vector<Neighbor<distance_type>> candidates;
 	candidates.reserve(space.size() > 0 ? space.size() - 1 : 0);
 	for (std::size_t index = 0; index < space.size(); ++index) {
-		const auto id = RecordId::from_index(index);
+		const auto id = space.id(index);
 		if (id == query_id) {
 			continue;
 		}
@@ -116,14 +116,14 @@ auto knn(const Provider &provider, RecordId query_id, std::size_t k) -> Neighbor
 {
 	using distance_type = typename Provider::distance_type;
 
-	if (query_id.index() >= provider.record_count()) {
+	if (!provider.contains(query_id)) {
 		throw std::out_of_range("query record id is outside the distance provider");
 	}
 
 	std::vector<Neighbor<distance_type>> candidates;
 	candidates.reserve(provider.record_count() > 0 ? provider.record_count() - 1 : 0);
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		const auto id = RecordId::from_index(index);
+		const auto id = provider.id(index);
 		if (id == query_id) {
 			continue;
 		}
@@ -159,7 +159,7 @@ auto range(const Space &space, const typename Space::record_type &query, Radius 
 
 	std::vector<Neighbor<distance_type>> candidates;
 	for (std::size_t index = 0; index < space.size(); ++index) {
-		const auto id = RecordId::from_index(index);
+		const auto id = space.id(index);
 		const auto distance = space.metric()(query, space.record(id));
 		if (static_cast<comparison_type>(distance) <= threshold) {
 			candidates.push_back(Neighbor<distance_type>{id, distance});
@@ -176,14 +176,14 @@ auto range(const Provider &provider, RecordId query_id, Radius radius) -> Neighb
 	using comparison_type = typename std::common_type<distance_type, Radius>::type;
 
 	engine_detail::validate_radius(radius);
-	if (query_id.index() >= provider.record_count()) {
+	if (!provider.contains(query_id)) {
 		throw std::out_of_range("query record id is outside the distance provider");
 	}
 	const auto threshold = static_cast<comparison_type>(radius);
 
 	std::vector<Neighbor<distance_type>> candidates;
 	for (std::size_t index = 0; index < provider.record_count(); ++index) {
-		const auto id = RecordId::from_index(index);
+		const auto id = provider.id(index);
 		if (id == query_id) {
 			continue;
 		}

--- a/metric/representations/cover_tree_index.hpp
+++ b/metric/representations/cover_tree_index.hpp
@@ -7,10 +7,12 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <stdexcept>
 #include <vector>
 
 #include "../core/neighbor.hpp"
 #include "../core/record_id.hpp"
+#include "diagnostics.hpp"
 
 namespace metric::representations {
 
@@ -23,18 +25,25 @@ template <typename Space> class CoverTreeIndex {
 
 	explicit CoverTreeIndex(const space_type &space)
 		: space_(&space)
+		, record_count_(space.size())
 		, version_(space.version())
 	{
+		ids_.reserve(record_count_);
+		records_.reserve(record_count_);
+		for (std::size_t index = 0; index < record_count_; ++index) {
+			const auto id = space.id(index);
+			ids_.push_back(id);
+			records_.push_back(space.record(id));
+		}
 	}
 
 	auto knn(const record_type &query, std::size_t k) const -> std::vector<neighbor_type>
 	{
 		std::vector<neighbor_type> candidates;
-		candidates.reserve(space_->size());
+		candidates.reserve(record_count_);
 
-		for (std::size_t index = 0; index < space_->size(); ++index) {
-			const auto id = RecordId::from_index(index);
-			candidates.push_back(neighbor_type{id, space_->metric()(query, space_->record(id))});
+		for (std::size_t index = 0; index < record_count_; ++index) {
+			candidates.push_back(neighbor_type{ids_[index], space_->metric()(query, records_[index])});
 		}
 
 		sort_neighbors(candidates);
@@ -44,9 +53,55 @@ template <typename Space> class CoverTreeIndex {
 		return candidates;
 	}
 
-	auto record_count() const -> std::size_t { return space_->size(); }
+	auto record_count() const -> std::size_t { return record_count_; }
+	auto id(std::size_t position) const -> RecordId
+	{
+		validate_position(position);
+		return ids_[position];
+	}
+	auto position_of(RecordId id) const -> std::size_t
+	{
+		for (std::size_t position = 0; position < ids_.size(); ++position) {
+			if (ids_[position] == id) {
+				return position;
+			}
+		}
+		throw std::out_of_range("record id is outside the cover tree index");
+	}
+	auto contains(RecordId id) const -> bool
+	{
+		for (const auto current : ids_) {
+			if (current == id) {
+				return true;
+			}
+		}
+		return false;
+	}
 	auto version() const -> std::size_t { return version_; }
 	auto is_stale() const -> bool { return space_->version() != version_; }
+	auto stats() const -> cover_tree_stats
+	{
+		cover_tree_stats result;
+		result.nodes = record_count_;
+		return result;
+	}
+
+	auto diagnostics() const -> representation_diagnostics
+	{
+		representation_diagnostics result{representation_kind::cover_tree_index,
+										  exactness::exact,
+										  materialization::materialized,
+										  update_mode::snapshot};
+		result.space_version = space_->version();
+		result.built_for_version = version_;
+		result.stale = is_stale();
+		result.records = record_count_;
+		result.memory_bytes_estimate = ids_.size() * sizeof(RecordId) + records_.size() * sizeof(record_type);
+		if (result.stale) {
+			result.warnings.push_back("cover tree index was built for an older metric-space version");
+		}
+		return result;
+	}
 
   private:
 	static auto sort_neighbors(std::vector<neighbor_type> &neighbors) -> void
@@ -59,8 +114,18 @@ template <typename Space> class CoverTreeIndex {
 		});
 	}
 
+	auto validate_position(std::size_t position) const -> void
+	{
+		if (position >= record_count_) {
+			throw std::out_of_range("record position is outside the cover tree index");
+		}
+	}
+
 	const space_type *space_;
+	std::size_t record_count_;
 	std::size_t version_;
+	std::vector<RecordId> ids_;
+	std::vector<record_type> records_;
 };
 
 } // namespace metric::representations

--- a/metric/representations/diagnostics.hpp
+++ b/metric/representations/diagnostics.hpp
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_REPRESENTATIONS_DIAGNOSTICS_HPP
+#define _METRIC_REPRESENTATIONS_DIAGNOSTICS_HPP
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace metric::representations {
+
+enum class representation_kind {
+	implicit_distance_provider,
+	matrix_cache,
+	cover_tree_index,
+	knn_graph_index,
+	graph_topology,
+};
+
+enum class exactness {
+	exact,
+	approximate,
+};
+
+enum class materialization {
+	lazy,
+	materialized,
+	topology,
+};
+
+enum class update_mode {
+	live,
+	snapshot,
+};
+
+struct representation_diagnostics {
+	representation_kind kind;
+	exactness exact;
+	materialization materialized;
+	update_mode updates;
+	std::size_t space_version{};
+	std::size_t built_for_version{};
+	bool stale{};
+	std::size_t records{};
+	std::size_t distance_evaluations{};
+	std::size_t cached_distances{};
+	std::size_t memory_bytes_estimate{};
+	std::vector<std::string> warnings;
+};
+
+struct matrix_cache_stats {
+	std::size_t hits{};
+	std::size_t misses{};
+	double fill_ratio{};
+	bool symmetric_storage{};
+};
+
+struct cover_tree_stats {
+	std::size_t nodes{};
+	bool covering_validated{};
+	bool covering_valid{};
+};
+
+struct knn_graph_stats {
+	std::size_t nodes{};
+	std::size_t edges{};
+	std::size_t neighbors_requested{};
+};
+
+} // namespace metric::representations
+
+#endif

--- a/metric/representations/graph_topology.hpp
+++ b/metric/representations/graph_topology.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "../core/record_id.hpp"
+#include "diagnostics.hpp"
 
 namespace metric::representations {
 
@@ -30,6 +31,10 @@ template <typename Space> class GraphTopology {
 		, record_count_(space.size())
 		, version_(space.version())
 	{
+		ids_.reserve(record_count_);
+		for (std::size_t index = 0; index < record_count_; ++index) {
+			ids_.push_back(space.id(index));
+		}
 	}
 
 	auto add_edge(RecordId source, RecordId target, distance_type distance) -> void
@@ -42,20 +47,68 @@ template <typename Space> class GraphTopology {
 	auto edges() const -> const std::vector<edge_type> & { return edges_; }
 	auto edge_count() const -> std::size_t { return edges_.size(); }
 	auto record_count() const -> std::size_t { return record_count_; }
+	auto id(std::size_t position) const -> RecordId
+	{
+		validate_position(position);
+		return ids_[position];
+	}
+	auto position_of(RecordId id) const -> std::size_t
+	{
+		for (std::size_t position = 0; position < ids_.size(); ++position) {
+			if (ids_[position] == id) {
+				return position;
+			}
+		}
+		throw std::out_of_range("record id is outside the graph topology");
+	}
+	auto contains(RecordId id) const -> bool
+	{
+		for (const auto current : ids_) {
+			if (current == id) {
+				return true;
+			}
+		}
+		return false;
+	}
 	auto version() const -> std::size_t { return version_; }
 	auto is_stale() const -> bool { return space_->version() != version_; }
+	auto diagnostics() const -> representation_diagnostics
+	{
+		representation_diagnostics result{representation_kind::graph_topology,
+										  exactness::approximate,
+										  materialization::topology,
+										  update_mode::snapshot};
+		result.space_version = space_->version();
+		result.built_for_version = version_;
+		result.stale = is_stale();
+		result.records = record_count_;
+		result.cached_distances = edges_.size();
+		result.memory_bytes_estimate = ids_.size() * sizeof(RecordId) + edges_.size() * sizeof(edge_type);
+		if (result.stale) {
+			result.warnings.push_back("graph topology was built for an older metric-space version");
+		}
+		return result;
+	}
 
   private:
 	auto validate(RecordId id) const -> void
 	{
-		if (id.index() >= record_count_) {
+		if (!contains(id)) {
 			throw std::out_of_range("record id is outside the graph topology");
+		}
+	}
+
+	auto validate_position(std::size_t position) const -> void
+	{
+		if (position >= record_count_) {
+			throw std::out_of_range("record position is outside the graph topology");
 		}
 	}
 
 	const space_type *space_;
 	std::size_t record_count_;
 	std::size_t version_;
+	std::vector<RecordId> ids_;
 	std::vector<edge_type> edges_;
 };
 

--- a/metric/representations/implicit.hpp
+++ b/metric/representations/implicit.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 
 #include "../core/record_id.hpp"
+#include "diagnostics.hpp"
 
 namespace metric::representations {
 
@@ -18,18 +19,31 @@ template <typename Space> class ImplicitDistanceProvider {
 
 	explicit ImplicitDistanceProvider(const space_type &space)
 		: space_(&space)
-		, version_(space.version())
 	{
 	}
 
 	auto distance(RecordId lhs, RecordId rhs) const -> distance_type { return space_->distance(lhs, rhs); }
 	auto record_count() const -> std::size_t { return space_->size(); }
-	auto version() const -> std::size_t { return version_; }
-	auto is_stale() const -> bool { return space_->version() != version_; }
+	auto id(std::size_t position) const -> RecordId { return space_->id(position); }
+	auto position_of(RecordId id) const -> std::size_t { return space_->position_of(id); }
+	auto contains(RecordId id) const -> bool { return space_->contains(id); }
+	auto version() const -> std::size_t { return space_->version(); }
+	auto is_stale() const -> bool { return false; }
+
+	auto diagnostics() const -> representation_diagnostics
+	{
+		representation_diagnostics result{representation_kind::implicit_distance_provider,
+										  exactness::exact,
+										  materialization::lazy,
+										  update_mode::live};
+		result.space_version = space_->version();
+		result.built_for_version = space_->version();
+		result.records = space_->size();
+		return result;
+	}
 
   private:
 	const space_type *space_;
-	std::size_t version_;
 };
 
 } // namespace metric::representations

--- a/metric/representations/knn_graph_index.hpp
+++ b/metric/representations/knn_graph_index.hpp
@@ -12,6 +12,7 @@
 
 #include "../core/neighbor.hpp"
 #include "../core/record_id.hpp"
+#include "diagnostics.hpp"
 
 namespace metric::representations {
 
@@ -28,16 +29,23 @@ template <typename Space> class KnnGraphIndex {
 		, record_count_(space.size())
 		, version_(space.version())
 	{
+		ids_.reserve(record_count_);
+		records_.reserve(record_count_);
+		for (std::size_t index = 0; index < record_count_; ++index) {
+			const auto id = space.id(index);
+			ids_.push_back(id);
+			records_.push_back(space.record(id));
+		}
+
 		adjacency_.reserve(record_count_);
 		for (std::size_t source = 0; source < record_count_; ++source) {
-			adjacency_.push_back(build_neighbors(RecordId::from_index(source)));
+			adjacency_.push_back(build_neighbors(source));
 		}
 	}
 
 	auto neighbors(RecordId source) const -> const std::vector<neighbor_type> &
 	{
-		validate(source);
-		return adjacency_[source.index()];
+		return adjacency_[position_of(source)];
 	}
 
 	auto knn(const record_type &query, std::size_t k) const -> std::vector<neighbor_type>
@@ -45,8 +53,7 @@ template <typename Space> class KnnGraphIndex {
 		std::vector<neighbor_type> candidates;
 		candidates.reserve(record_count_);
 		for (std::size_t index = 0; index < record_count_; ++index) {
-			const auto id = RecordId::from_index(index);
-			candidates.push_back(neighbor_type{id, space_->metric()(query, space_->record(id))});
+			candidates.push_back(neighbor_type{ids_[index], space_->metric()(query, records_[index])});
 		}
 		sort_neighbors(candidates);
 		if (candidates.size() > k) {
@@ -57,21 +64,82 @@ template <typename Space> class KnnGraphIndex {
 
 	auto k() const -> std::size_t { return k_; }
 	auto record_count() const -> std::size_t { return record_count_; }
+	auto id(std::size_t position) const -> RecordId
+	{
+		validate_position(position);
+		return ids_[position];
+	}
+	auto position_of(RecordId id) const -> std::size_t
+	{
+		for (std::size_t position = 0; position < ids_.size(); ++position) {
+			if (ids_[position] == id) {
+				return position;
+			}
+		}
+		throw std::out_of_range("record id is outside the kNN graph index");
+	}
+	auto contains(RecordId id) const -> bool
+	{
+		for (const auto current : ids_) {
+			if (current == id) {
+				return true;
+			}
+		}
+		return false;
+	}
 	auto version() const -> std::size_t { return version_; }
 	auto is_stale() const -> bool { return space_->version() != version_; }
+	auto edge_count() const -> std::size_t
+	{
+		std::size_t count = 0;
+		for (const auto &neighbors : adjacency_) {
+			count += neighbors.size();
+		}
+		return count;
+	}
+	auto stats() const -> knn_graph_stats
+	{
+		knn_graph_stats result;
+		result.nodes = record_count_;
+		result.edges = edge_count();
+		result.neighbors_requested = k_;
+		return result;
+	}
+
+	auto diagnostics() const -> representation_diagnostics
+	{
+		representation_diagnostics result{representation_kind::knn_graph_index,
+										  exactness::approximate,
+										  materialization::materialized,
+										  update_mode::snapshot};
+		result.space_version = space_->version();
+		result.built_for_version = version_;
+		result.stale = is_stale();
+		result.records = record_count_;
+		result.distance_evaluations = record_count_ * (record_count_ > 0 ? record_count_ - 1 : 0);
+		result.cached_distances = edge_count();
+		result.memory_bytes_estimate = ids_.size() * sizeof(RecordId) + records_.size() * sizeof(record_type);
+		for (const auto &neighbors : adjacency_) {
+			result.memory_bytes_estimate += neighbors.size() * sizeof(neighbor_type);
+		}
+		if (result.stale) {
+			result.warnings.push_back("kNN graph index was built for an older metric-space version");
+		}
+		return result;
+	}
 
   private:
-	auto build_neighbors(RecordId source) const -> std::vector<neighbor_type>
+	auto build_neighbors(std::size_t source_position) const -> std::vector<neighbor_type>
 	{
 		std::vector<neighbor_type> candidates;
 		candidates.reserve(record_count_ > 0 ? record_count_ - 1 : 0);
 
 		for (std::size_t target = 0; target < record_count_; ++target) {
-			const auto target_id = RecordId::from_index(target);
-			if (target_id == source) {
+			if (target == source_position) {
 				continue;
 			}
-			candidates.push_back(neighbor_type{target_id, space_->distance(source, target_id)});
+			candidates.push_back(neighbor_type{ids_[target],
+											   space_->metric()(records_[source_position], records_[target])});
 		}
 
 		sort_neighbors(candidates);
@@ -91,10 +159,10 @@ template <typename Space> class KnnGraphIndex {
 		});
 	}
 
-	auto validate(RecordId id) const -> void
+	auto validate_position(std::size_t position) const -> void
 	{
-		if (id.index() >= record_count_) {
-			throw std::out_of_range("record id is outside the kNN graph index");
+		if (position >= record_count_) {
+			throw std::out_of_range("record position is outside the kNN graph index");
 		}
 	}
 
@@ -102,6 +170,8 @@ template <typename Space> class KnnGraphIndex {
 	std::size_t k_;
 	std::size_t record_count_;
 	std::size_t version_;
+	std::vector<RecordId> ids_;
+	std::vector<record_type> records_;
 	std::vector<std::vector<neighbor_type>> adjacency_;
 };
 

--- a/metric/representations/matrix_cache.hpp
+++ b/metric/representations/matrix_cache.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "../core/record_id.hpp"
+#include "diagnostics.hpp"
 
 namespace metric::representations {
 
@@ -23,36 +24,93 @@ template <typename Space> class MatrixCache {
 		, record_count_(space.size())
 		, version_(space.version())
 	{
+		ids_.reserve(record_count_);
+		for (std::size_t index = 0; index < record_count_; ++index) {
+			ids_.push_back(space.id(index));
+		}
+
 		matrix_.reserve(record_count_ * record_count_);
 		for (std::size_t lhs = 0; lhs < record_count_; ++lhs) {
 			for (std::size_t rhs = 0; rhs < record_count_; ++rhs) {
-				matrix_.push_back(space.distance(RecordId::from_index(lhs), RecordId::from_index(rhs)));
+				matrix_.push_back(space.distance(ids_[lhs], ids_[rhs]));
 			}
 		}
 	}
 
 	auto distance(RecordId lhs, RecordId rhs) const -> distance_type
 	{
-		validate(lhs);
-		validate(rhs);
-		return matrix_[lhs.index() * record_count_ + rhs.index()];
+		const auto lhs_position = position_of(lhs);
+		const auto rhs_position = position_of(rhs);
+		return matrix_[lhs_position * record_count_ + rhs_position];
 	}
 
 	auto record_count() const -> std::size_t { return record_count_; }
+	auto id(std::size_t position) const -> RecordId
+	{
+		validate_position(position);
+		return ids_[position];
+	}
+	auto position_of(RecordId id) const -> std::size_t
+	{
+		for (std::size_t position = 0; position < ids_.size(); ++position) {
+			if (ids_[position] == id) {
+				return position;
+			}
+		}
+		throw std::out_of_range("record id is outside the matrix cache");
+	}
+	auto contains(RecordId id) const -> bool
+	{
+		for (const auto current : ids_) {
+			if (current == id) {
+				return true;
+			}
+		}
+		return false;
+	}
 	auto version() const -> std::size_t { return version_; }
 	auto is_stale() const -> bool { return space_->version() != version_; }
+	auto cached_distances() const -> std::size_t { return matrix_.size(); }
+
+	auto stats() const -> matrix_cache_stats
+	{
+		matrix_cache_stats result;
+		result.fill_ratio = 1.0;
+		result.symmetric_storage = false;
+		return result;
+	}
+
+	auto diagnostics() const -> representation_diagnostics
+	{
+		representation_diagnostics result{representation_kind::matrix_cache,
+										  exactness::exact,
+										  materialization::materialized,
+										  update_mode::snapshot};
+		result.space_version = space_->version();
+		result.built_for_version = version_;
+		result.stale = is_stale();
+		result.records = record_count_;
+		result.distance_evaluations = matrix_.size();
+		result.cached_distances = matrix_.size();
+		result.memory_bytes_estimate = matrix_.size() * sizeof(distance_type) + ids_.size() * sizeof(RecordId);
+		if (result.stale) {
+			result.warnings.push_back("matrix cache was built for an older metric-space version");
+		}
+		return result;
+	}
 
   private:
-	auto validate(RecordId id) const -> void
+	auto validate_position(std::size_t position) const -> void
 	{
-		if (id.index() >= record_count_) {
-			throw std::out_of_range("record id is outside the matrix cache");
+		if (position >= record_count_) {
+			throw std::out_of_range("record position is outside the matrix cache");
 		}
 	}
 
 	const space_type *space_;
 	std::size_t record_count_;
 	std::size_t version_;
+	std::vector<RecordId> ids_;
 	std::vector<distance_type> matrix_;
 };
 

--- a/tests/core_smoke/engine_core_smoke.cpp
+++ b/tests/core_smoke/engine_core_smoke.cpp
@@ -30,9 +30,37 @@ int main()
 	assert(typed_space.size() == records.size());
 	assert(!typed_space.empty());
 	assert(typed_space.version() == 0);
+	assert(typed_space.id_at(0) == metric_id);
+	assert(typed_space.contains(metric_id));
+	assert(typed_space.position_of(metrics_id) == 1);
 	assert(typed_space[metric_id] == "metric");
 	assert(typed_space.distance(metric_id, metrics_id) == 1);
 	assert(typed_space(metric_id, metrics_id) == 1);
+
+	const auto inserted_id = typed_space.insert("metrician");
+	assert(typed_space.version() == 1);
+	assert(typed_space.size() == records.size() + 1);
+	assert(typed_space.contains(inserted_id));
+	assert(typed_space.position_of(inserted_id) == records.size());
+	assert(typed_space.record(inserted_id) == "metrician");
+
+	typed_space.replace(inserted_id, "forest");
+	assert(typed_space.version() == 2);
+	assert(typed_space.record(inserted_id) == "forest");
+
+	assert(typed_space.erase(metrics_id));
+	assert(typed_space.version() == 3);
+	assert(!typed_space.contains(metrics_id));
+	assert(typed_space.position_of(inserted_id) == records.size() - 1);
+	assert(typed_space.id_at(0) == metric_id);
+	bool rejected_erased_id = false;
+	try {
+		(void)typed_space.position_of(metrics_id);
+	} catch (const std::out_of_range &) {
+		rejected_erased_id = true;
+	}
+	assert(rejected_erased_id);
+	assert(!typed_space.erase(metrics_id));
 
 	const auto made_space = metric::make_space(records, metric::Edit<char>{});
 	static_assert(metric::MetricSpaceLike_v<decltype(made_space)>);

--- a/tests/core_smoke/engine_representations_smoke.cpp
+++ b/tests/core_smoke/engine_representations_smoke.cpp
@@ -20,39 +20,74 @@ int main()
 	metric::representations::ImplicitDistanceProvider<decltype(space)> implicit(space);
 	static_assert(metric::DistanceProvider_v<decltype(implicit)>);
 	assert(implicit.record_count() == space.size());
+	assert(implicit.id(0) == id0);
+	assert(implicit.contains(id2));
+	assert(implicit.position_of(id2) == 2);
 	assert(implicit.distance(id0, id2) == space.distance(id0, id2));
+	const auto implicit_diagnostics = implicit.diagnostics();
+	assert(implicit_diagnostics.kind == metric::representations::representation_kind::implicit_distance_provider);
+	assert(implicit_diagnostics.exact == metric::representations::exactness::exact);
+	assert(implicit_diagnostics.materialized == metric::representations::materialization::lazy);
+	assert(implicit_diagnostics.updates == metric::representations::update_mode::live);
+	assert(!implicit_diagnostics.stale);
 
 	metric::representations::MatrixCache<decltype(space)> matrix(space);
 	static_assert(metric::DistanceProvider_v<decltype(matrix)>);
 	assert(matrix.record_count() == space.size());
+	assert(matrix.id(2) == id2);
+	assert(matrix.contains(id1));
 	assert(matrix.distance(id0, id2) == 5);
 	assert(matrix.distance(id1, id3) == space.distance(id1, id3));
+	const auto matrix_diagnostics = matrix.diagnostics();
+	assert(matrix_diagnostics.kind == metric::representations::representation_kind::matrix_cache);
+	assert(matrix_diagnostics.cached_distances == space.size() * space.size());
+	assert(matrix_diagnostics.distance_evaluations == space.size() * space.size());
+	assert(matrix_diagnostics.built_for_version == space.version());
+	assert(!matrix_diagnostics.stale);
+	assert(matrix.stats().fill_ratio == 1.0);
 
 	metric::representations::CoverTreeIndex<decltype(space)> tree(space);
 	static_assert(metric::NeighborSearchIndex_v<decltype(tree)>);
+	assert(tree.id(3) == id3);
+	assert(tree.contains(id0));
 	const auto tree_neighbors = tree.knn(4, 2);
 	assert(tree_neighbors.size() == 2);
 	assert(tree_neighbors[0].id == id2);
 	assert(tree_neighbors[0].distance == 1);
 	assert(tree_neighbors[1].id == id1);
 	assert(tree_neighbors[1].distance == 2);
+	const auto tree_diagnostics = tree.diagnostics();
+	assert(tree_diagnostics.kind == metric::representations::representation_kind::cover_tree_index);
+	assert(tree_diagnostics.records == space.size());
+	assert(tree.stats().nodes == space.size());
 
 	metric::representations::KnnGraphIndex<decltype(space)> graph(space, 1);
 	static_assert(metric::NeighborSearchIndex_v<decltype(graph)>);
 	assert(graph.k() == 1);
+	assert(graph.id(0) == id0);
+	assert(graph.contains(id3));
 	assert(graph.neighbors(id0).size() == 1);
 	assert(graph.neighbors(id0)[0].id == id1);
 	assert(graph.neighbors(id3).size() == 1);
 	assert(graph.neighbors(id3)[0].id == id2);
+	const auto graph_diagnostics = graph.diagnostics();
+	assert(graph_diagnostics.kind == metric::representations::representation_kind::knn_graph_index);
+	assert(graph_diagnostics.exact == metric::representations::exactness::approximate);
+	assert(graph.stats().edges == space.size());
 
 	metric::representations::GraphTopology<decltype(space)> topology(space);
 	static_assert(metric::GraphTopology_v<decltype(topology)>);
+	assert(topology.id(1) == id1);
+	assert(topology.contains(id2));
 	topology.add_edge(id0, id1, matrix.distance(id0, id1));
 	assert(topology.record_count() == space.size());
 	assert(topology.edge_count() == 1);
 	assert(topology.edges()[0].source == id0);
 	assert(topology.edges()[0].target == id1);
 	assert(topology.edges()[0].distance == 2);
+	const auto topology_diagnostics = topology.diagnostics();
+	assert(topology_diagnostics.kind == metric::representations::representation_kind::graph_topology);
+	assert(topology_diagnostics.materialized == metric::representations::materialization::topology);
 
 	assert(!implicit.is_stale());
 	assert(!matrix.is_stale());
@@ -60,12 +95,31 @@ int main()
 	assert(!graph.is_stale());
 	assert(!topology.is_stale());
 
-	space.touch();
-	assert(implicit.is_stale());
+	const auto inserted_id = space.insert(12);
+	assert(!implicit.is_stale());
+	assert(implicit.contains(inserted_id));
+	assert(implicit.position_of(inserted_id) == 4);
 	assert(matrix.is_stale());
 	assert(tree.is_stale());
 	assert(graph.is_stale());
 	assert(topology.is_stale());
+	assert(matrix.diagnostics().stale);
+	assert(!matrix.diagnostics().warnings.empty());
+
+	assert(matrix.distance(id1, id3) == 7);
+	assert(space.erase(id1));
+	assert(!space.contains(id1));
+	assert(space.position_of(id2) == 1);
+	assert(matrix.contains(id1));
+	assert(matrix.position_of(id3) == 3);
+	assert(matrix.distance(id1, id3) == 7);
+
+	metric::representations::MatrixCache<decltype(space)> refreshed_matrix(space);
+	assert(refreshed_matrix.record_count() == space.size());
+	assert(!refreshed_matrix.contains(id1));
+	assert(refreshed_matrix.id(1) == id2);
+	assert(refreshed_matrix.contains(inserted_id));
+	assert(refreshed_matrix.distance(id0, id2) == space.distance(id0, id2));
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
- add stable `MetricSpace` IDs with `id_at`, `contains`, `position_of`, `insert`, `replace`, and `erase`
- make distance-provider operators enumerate records through provider IDs instead of assuming IDs are row positions
- add common representation diagnostics and snapshot metadata for implicit, matrix, tree, graph-index, and topology representations
- extend core smoke coverage for mutation/version behavior, diagnostics, stale snapshots, and refreshed matrix caches

## Verification
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`