### PR TITLE
Add native DNN baseline smoke coverage

### DIFF
--- a/metric/utils/dnn/Layer/FullyConnected.h
+++ b/metric/utils/dnn/Layer/FullyConnected.h
@@ -1,6 +1,7 @@
 #ifndef LAYER_FULLYCONNECTED_H_
 #define LAYER_FULLYCONNECTED_H_
 
+#include <cassert>
 #include <iostream>
 #include <random>
 #include <stdexcept>
@@ -168,7 +169,12 @@ template <typename Scalar, typename Activation> class FullyConnected : public La
 		parameters[0].resize(blaze::size(m_weight));
 		parameters[1].resize(m_bias.size());
 
-		std::copy(m_weight.data(), m_weight.data() + blaze::size(m_weight), parameters[0].begin());
+		size_t offset = 0;
+		for (size_t column = 0; column < m_weight.columns(); ++column) {
+			for (size_t row = 0; row < m_weight.rows(); ++row) {
+				parameters[0][offset++] = m_weight(row, column);
+			}
+		}
 		std::copy(m_bias.data(), m_bias.data() + m_bias.size(), parameters[1].begin());
 
 		return parameters;
@@ -181,7 +187,15 @@ template <typename Scalar, typename Activation> class FullyConnected : public La
 			throw std::invalid_argument("Parameter size does not match");
 		}*/
 
-		std::copy(parameters[0].begin(), parameters[0].begin() + blaze::size(m_weight), m_weight.data());
+		assert(parameters[0].size() == blaze::size(m_weight));
+		assert(parameters[1].size() == blaze::size(m_bias));
+
+		size_t offset = 0;
+		for (size_t column = 0; column < m_weight.columns(); ++column) {
+			for (size_t row = 0; row < m_weight.rows(); ++row) {
+				m_weight(row, column) = parameters[0][offset++];
+			}
+		}
 		std::copy(parameters[1].begin(), parameters[1].begin() + blaze::size(m_bias), m_bias.data());
 	}
 

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -68,6 +68,9 @@ target_link_libraries(engine_outliers_intent_smoke PRIVATE ${METRIC_TARGET_NAME}
 add_executable(engine_runtime_policy_smoke engine_runtime_policy_smoke.cpp)
 target_link_libraries(engine_runtime_policy_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(native_dnn_baseline_smoke native_dnn_baseline_smoke.cpp)
+target_link_libraries(native_dnn_baseline_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_test(NAME metric_core_smoke COMMAND metric_core_smoke)
 add_test(NAME metric_mgc_smoke COMMAND metric_mgc_smoke)
 if (METRIC_BUILD_CORE_ENTROPY)
@@ -94,3 +97,4 @@ add_test(NAME engine_representatives_intent_smoke COMMAND engine_representatives
 add_test(NAME engine_compress_intent_smoke COMMAND engine_compress_intent_smoke)
 add_test(NAME engine_outliers_intent_smoke COMMAND engine_outliers_intent_smoke)
 add_test(NAME engine_runtime_policy_smoke COMMAND engine_runtime_policy_smoke)
+add_test(NAME native_dnn_baseline_smoke COMMAND native_dnn_baseline_smoke)

--- a/tests/core_smoke/native_dnn_baseline_smoke.cpp
+++ b/tests/core_smoke/native_dnn_baseline_smoke.cpp
@@ -132,7 +132,7 @@ int main()
 		loaded.load(archive);
 		const auto loaded_prediction = loaded.predict(sample);
 		assert(loaded_prediction.size() == prediction.size());
-		const auto roundtrip_tolerance = 1.0e-6;
+		const auto roundtrip_tolerance = 1.0e-9;
 		for (std::size_t index = 0; index < prediction.size(); ++index) {
 			assert(std::isfinite(loaded_prediction[index]));
 			assert(close(loaded_prediction[index], prediction[index], roundtrip_tolerance));

--- a/tests/core_smoke/native_dnn_baseline_smoke.cpp
+++ b/tests/core_smoke/native_dnn_baseline_smoke.cpp
@@ -132,8 +132,10 @@ int main()
 		loaded.load(archive);
 		const auto loaded_prediction = loaded.predict(sample);
 		assert(loaded_prediction.size() == prediction.size());
+		const auto roundtrip_tolerance = 1.0e-6;
 		for (std::size_t index = 0; index < prediction.size(); ++index) {
-			assert(close(loaded_prediction[index], prediction[index], 1.0e-9));
+			assert(std::isfinite(loaded_prediction[index]));
+			assert(close(loaded_prediction[index], prediction[index], roundtrip_tolerance));
 		}
 	}
 

--- a/tests/core_smoke/native_dnn_baseline_smoke.cpp
+++ b/tests/core_smoke/native_dnn_baseline_smoke.cpp
@@ -1,0 +1,141 @@
+#include <cassert>
+#include <cmath>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <blaze/Math.h>
+
+#include "metric/mapping/autoencoder.hpp"
+#include "metric/utils/dnn.hpp"
+
+namespace {
+
+using Matrix = blaze::DynamicMatrix<double>;
+using RowVector = blaze::DynamicVector<double, blaze::rowVector>;
+
+auto close(double lhs, double rhs, double tolerance = 1.0e-9) -> bool
+{
+	return std::abs(lhs - rhs) <= tolerance;
+}
+
+auto small_autoencoder_json() -> std::string
+{
+	return R"({
+		"0": {
+			"type": "FullyConnected",
+			"inputSize": 2,
+			"outputSize": 1,
+			"activation": "Identity"
+		},
+		"1": {
+			"type": "FullyConnected",
+			"inputSize": 1,
+			"outputSize": 2,
+			"activation": "Identity"
+		},
+		"train": {
+			"loss": "RegressionMSE",
+			"optimizer": {
+				"type": "RMSProp",
+				"learningRate": 0.001,
+				"eps": 1e-8,
+				"decay": 0.99
+			}
+		}
+	})";
+}
+
+auto assert_same_shape(const Matrix &matrix, std::size_t rows, std::size_t columns) -> void
+{
+	assert(matrix.rows() == rows);
+	assert(matrix.columns() == columns);
+}
+
+} // namespace
+
+int main()
+{
+	static_assert(std::is_base_of<metric::dnn::Optimizer<double>, metric::dnn::RMSProp<double>>::value);
+
+	{
+		metric::dnn::RegressionMSE<double> mse;
+		const Matrix predicted{{1.0, 2.0}, {3.0, 4.0}};
+		const Matrix target{{1.0, 1.0}, {5.0, 4.0}};
+
+		mse.evaluate(predicted, target);
+		assert_same_shape(mse.backprop_data(), 2, 2);
+		assert(close(mse.backprop_data()(0, 0), 0.0));
+		assert(close(mse.backprop_data()(0, 1), 2.0));
+		assert(close(mse.backprop_data()(1, 0), -4.0));
+		assert(close(mse.backprop_data()(1, 1), 0.0));
+		assert(close(mse.loss(), 2.5));
+	}
+
+	{
+		metric::dnn::RMSProp<double> optimizer(0.0001, 1.0e-8, 0.99);
+		RowVector weights{-0.021, 1.03, -0.05, -0.749, 0.009};
+		const RowVector gradients{1.0, -3.24, -0.60, 2.79, 1.82};
+
+		optimizer.update(gradients, weights);
+		assert(close(weights[0], -0.0220, 1.0e-4));
+		assert(close(weights[1], 1.0310, 1.0e-4));
+		assert(close(weights[2], -0.0490, 1.0e-4));
+		assert(close(weights[3], -0.7500, 1.0e-4));
+		assert(close(weights[4], 0.0080, 1.0e-4));
+
+		optimizer.update(gradients, weights);
+		assert(close(weights[0], -0.0227, 1.0e-4));
+		assert(close(weights[1], 1.0317, 1.0e-4));
+		assert(close(weights[2], -0.0483, 1.0e-4));
+		assert(close(weights[3], -0.7507, 1.0e-4));
+		assert(close(weights[4], 0.0073, 1.0e-4));
+	}
+
+	{
+		metric::dnn::Network<double> network;
+		network.addLayer(metric::dnn::FullyConnected<double, metric::dnn::Identity<double>>(2, 2));
+		network.setOutput(metric::dnn::RegressionMSE<double>());
+		network.setOptimizer(metric::dnn::RMSProp<double>(0.001, 1.0e-8, 0.99));
+		network.init(0.0, 0.01, 7);
+
+		const Matrix samples{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
+		const auto before = network.predict(samples);
+		assert_same_shape(before, 3, 2);
+
+		const auto fit_result = network.fit(samples, samples, 2, 2, 11);
+		assert(fit_result);
+		const auto after = network.predict(samples);
+		assert_same_shape(after, 3, 2);
+	}
+
+	{
+		metric::Autoencoder<double, double> autoencoder(small_autoencoder_json());
+		autoencoder.setNormValue(0);
+		const std::vector<double> samples{0.0, 1.0, 1.0, 0.0};
+		autoencoder.train(samples, 1, 1);
+
+		const std::vector<double> sample{0.25, 0.75};
+		const auto prediction = autoencoder.predict(sample);
+		const auto latent = autoencoder.encode(sample);
+		const auto decoded = autoencoder.decode(latent);
+		assert(prediction.size() == sample.size());
+		assert(latent.size() == 1);
+		assert(decoded.size() == sample.size());
+
+		std::stringstream archive;
+		autoencoder.save(archive);
+
+		metric::Autoencoder<double, double> loaded;
+		loaded.setNormValue(0);
+		loaded.load(archive);
+		const auto loaded_prediction = loaded.predict(sample);
+		assert(loaded_prediction.size() == prediction.size());
+		for (std::size_t index = 0; index < prediction.size(); ++index) {
+			assert(close(loaded_prediction[index], prediction[index], 1.0e-9));
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add an active core smoke test for current native DNN baseline behavior
- cover `RegressionMSE`, `RMSProp`, row-as-observation `Network::fit/predict`, and a tiny dense `Autoencoder` train/encode/decode/save/load round trip
- register the smoke test in the core preset/CTest gate

## Verification
- `cmake --preset core`
- `cmake --build --preset core --target native_dnn_baseline_smoke --parallel 2`
- `./build/core/tests/core_smoke/native_dnn_baseline_smoke`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`