### PR TITLE
Add native DNN composite losses

### DIFF
--- a/metric/utils/dnn/Loss.h
+++ b/metric/utils/dnn/Loss.h
@@ -1,0 +1,230 @@
+#ifndef LOSS_H_
+#define LOSS_H_
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <nlohmann/json.hpp>
+
+#include "Dataset.h"
+
+namespace metric::dnn {
+
+enum class LossAnchorKind { final_output, layer_output };
+
+struct LossAnchor {
+	LossAnchorKind kind{LossAnchorKind::final_output};
+	std::size_t layer_index{0};
+};
+
+inline auto loss_anchor_kind_name(LossAnchorKind kind) -> std::string
+{
+	return kind == LossAnchorKind::final_output ? "final_output" : "layer_output";
+}
+
+template <class Scalar> struct LossEvaluation {
+	Scalar value{0};
+	blaze::DynamicMatrix<Scalar> gradient;
+};
+
+template <class Scalar> class LossTerm {
+  public:
+	using matrix_type = blaze::DynamicMatrix<Scalar>;
+
+	virtual ~LossTerm() = default;
+	virtual auto name() const -> std::string = 0;
+	virtual auto anchor() const -> LossAnchor = 0;
+	virtual auto evaluate(const DnnBatch<Scalar> &batch, const std::vector<matrix_type> &activations) const
+		-> LossEvaluation<Scalar> = 0;
+	virtual auto to_json() const -> nlohmann::json = 0;
+};
+
+template <class Scalar> struct LossTermReport {
+	std::string name;
+	Scalar weight{1};
+	Scalar value{0};
+	Scalar weighted_value{0};
+	LossAnchor anchor;
+};
+
+template <class Scalar> struct CompositeLossEvaluation {
+	Scalar total_value{0};
+	std::vector<blaze::DynamicMatrix<Scalar>> gradients_by_layer;
+	std::vector<LossTermReport<Scalar>> terms;
+};
+
+template <class Scalar> class CompositeLoss {
+  public:
+	using matrix_type = blaze::DynamicMatrix<Scalar>;
+
+	auto add(std::shared_ptr<const LossTerm<Scalar>> term, Scalar weight = Scalar(1)) -> CompositeLoss &
+	{
+		if (!term) {
+			throw std::invalid_argument("CompositeLoss term must not be null");
+		}
+		terms_.push_back({std::move(term), weight});
+		return *this;
+	}
+
+	auto size() const -> std::size_t { return terms_.size(); }
+
+	auto evaluate(const DnnBatch<Scalar> &batch, const std::vector<matrix_type> &activations) const
+		-> CompositeLossEvaluation<Scalar>
+	{
+		if (activations.empty()) {
+			throw std::invalid_argument("CompositeLoss requires layer activations");
+		}
+
+		CompositeLossEvaluation<Scalar> result;
+		result.gradients_by_layer.resize(activations.size());
+		result.terms.reserve(terms_.size());
+
+		for (const auto &weighted_term : terms_) {
+			const auto term_evaluation = weighted_term.term->evaluate(batch, activations);
+			const auto anchor = weighted_term.term->anchor();
+			const auto layer_index = resolve_anchor(anchor, activations.size());
+			validate_gradient_shape(term_evaluation.gradient, activations[layer_index]);
+
+			if (blaze::size(result.gradients_by_layer[layer_index]) == 0) {
+				result.gradients_by_layer[layer_index].resize(activations[layer_index].rows(),
+															 activations[layer_index].columns());
+				result.gradients_by_layer[layer_index] = Scalar(0);
+			}
+			result.gradients_by_layer[layer_index] += weighted_term.weight * term_evaluation.gradient;
+
+			const auto weighted_value = weighted_term.weight * term_evaluation.value;
+			result.total_value += weighted_value;
+			result.terms.push_back({weighted_term.term->name(), weighted_term.weight, term_evaluation.value,
+									weighted_value, anchor});
+		}
+
+		return result;
+	}
+
+  private:
+	struct WeightedTerm {
+		std::shared_ptr<const LossTerm<Scalar>> term;
+		Scalar weight{1};
+	};
+
+	static auto resolve_anchor(LossAnchor anchor, std::size_t layer_count) -> std::size_t
+	{
+		if (anchor.kind == LossAnchorKind::final_output) {
+			return layer_count - 1;
+		}
+		if (anchor.layer_index >= layer_count) {
+			throw std::invalid_argument("Loss anchor layer index is out of range");
+		}
+		return anchor.layer_index;
+	}
+
+	static auto validate_gradient_shape(const matrix_type &gradient, const matrix_type &activation) -> void
+	{
+		if (gradient.rows() != activation.rows() || gradient.columns() != activation.columns()) {
+			throw std::invalid_argument("Loss gradient shape does not match anchored activation");
+		}
+	}
+
+	std::vector<WeightedTerm> terms_;
+};
+
+template <class Scalar> class ReconstructionMSELoss final : public LossTerm<Scalar> {
+  public:
+	using matrix_type = typename LossTerm<Scalar>::matrix_type;
+
+	auto name() const -> std::string override { return "reconstruction_mse"; }
+	auto anchor() const -> LossAnchor override { return {LossAnchorKind::final_output, 0}; }
+
+	auto evaluate(const DnnBatch<Scalar> &batch, const std::vector<matrix_type> &activations) const
+		-> LossEvaluation<Scalar> override
+	{
+		if (activations.empty()) {
+			throw std::invalid_argument("ReconstructionMSELoss requires final activation");
+		}
+		const auto &prediction = activations.back();
+		if (prediction.rows() == 0 || prediction.rows() != batch.x.rows() || prediction.columns() != batch.x.columns()) {
+			throw std::invalid_argument("ReconstructionMSELoss target shape does not match final activation");
+		}
+
+		LossEvaluation<Scalar> result;
+		result.gradient = Scalar(2) * (prediction - batch.x);
+		result.value = blaze::sqrNorm(prediction - batch.x) / prediction.rows();
+		return result;
+	}
+
+	auto to_json() const -> nlohmann::json override
+	{
+		return {{"type", "ReconstructionMSELoss"}, {"anchor", loss_anchor_kind_name(anchor().kind)}};
+	}
+};
+
+template <class Scalar> class BottleneckCoordinateMSELoss final : public LossTerm<Scalar> {
+  public:
+	using matrix_type = typename LossTerm<Scalar>::matrix_type;
+	using target_table_type = std::map<SampleId, std::vector<Scalar>>;
+
+	BottleneckCoordinateMSELoss(std::size_t layer_index, target_table_type coordinates)
+		: anchor_{LossAnchorKind::layer_output, layer_index}
+		, coordinates_(std::move(coordinates))
+	{
+	}
+
+	auto name() const -> std::string override { return "bottleneck_coordinate_mse"; }
+	auto anchor() const -> LossAnchor override { return anchor_; }
+
+	auto evaluate(const DnnBatch<Scalar> &batch, const std::vector<matrix_type> &activations) const
+		-> LossEvaluation<Scalar> override
+	{
+		if (anchor_.layer_index >= activations.size()) {
+			throw std::invalid_argument("BottleneckCoordinateMSELoss anchor is out of range");
+		}
+		const auto &bottleneck = activations[anchor_.layer_index];
+		if (bottleneck.rows() == 0 || bottleneck.rows() != batch.ids.size()) {
+			throw std::invalid_argument("BottleneckCoordinateMSELoss batch IDs do not match activation rows");
+		}
+
+		LossEvaluation<Scalar> result;
+		result.gradient.resize(bottleneck.rows(), bottleneck.columns());
+		result.gradient = Scalar(0);
+
+		Scalar squared_error{0};
+		for (std::size_t row = 0; row < batch.ids.size(); ++row) {
+			const auto found = coordinates_.find(batch.ids[row]);
+			if (found == coordinates_.end()) {
+				throw std::invalid_argument("BottleneckCoordinateMSELoss target is missing a sample ID");
+			}
+			if (found->second.size() != bottleneck.columns()) {
+				throw std::invalid_argument("BottleneckCoordinateMSELoss target dimension does not match bottleneck");
+			}
+			for (std::size_t column = 0; column < bottleneck.columns(); ++column) {
+				const auto delta = bottleneck(row, column) - found->second[column];
+				squared_error += delta * delta;
+				result.gradient(row, column) = Scalar(2) * delta;
+			}
+		}
+
+		result.value = squared_error / bottleneck.rows();
+		return result;
+	}
+
+	auto to_json() const -> nlohmann::json override
+	{
+		return {{"type", "BottleneckCoordinateMSELoss"},
+				{"anchor", loss_anchor_kind_name(anchor_.kind)},
+				{"layer_index", anchor_.layer_index},
+				{"target_count", coordinates_.size()}};
+	}
+
+  private:
+	LossAnchor anchor_;
+	target_table_type coordinates_;
+};
+
+} // namespace metric::dnn
+
+#endif /* LOSS_H_ */

--- a/metric/utils/dnn/dnn-includes.h
+++ b/metric/utils/dnn/dnn-includes.h
@@ -4,6 +4,7 @@
 #include <blaze/Blaze.h>
 
 #include "Dataset.h"
+#include "Loss.h"
 
 #include "Layer.h"
 #include "Layer/Conv2d-transpose.h"

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -77,6 +77,9 @@ target_link_libraries(native_dnn_training_hooks_smoke PRIVATE ${METRIC_TARGET_NA
 add_executable(native_dnn_dataset_codec_smoke native_dnn_dataset_codec_smoke.cpp)
 target_link_libraries(native_dnn_dataset_codec_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(native_dnn_composite_loss_smoke native_dnn_composite_loss_smoke.cpp)
+target_link_libraries(native_dnn_composite_loss_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_test(NAME metric_core_smoke COMMAND metric_core_smoke)
 add_test(NAME metric_mgc_smoke COMMAND metric_mgc_smoke)
 if (METRIC_BUILD_CORE_ENTROPY)
@@ -106,3 +109,4 @@ add_test(NAME engine_runtime_policy_smoke COMMAND engine_runtime_policy_smoke)
 add_test(NAME native_dnn_baseline_smoke COMMAND native_dnn_baseline_smoke)
 add_test(NAME native_dnn_training_hooks_smoke COMMAND native_dnn_training_hooks_smoke)
 add_test(NAME native_dnn_dataset_codec_smoke COMMAND native_dnn_dataset_codec_smoke)
+add_test(NAME native_dnn_composite_loss_smoke COMMAND native_dnn_composite_loss_smoke)

--- a/tests/core_smoke/native_dnn_composite_loss_smoke.cpp
+++ b/tests/core_smoke/native_dnn_composite_loss_smoke.cpp
@@ -1,0 +1,169 @@
+#include <cassert>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <blaze/Math.h>
+
+#include "metric/utils/dnn.hpp"
+
+namespace {
+
+using Matrix = blaze::DynamicMatrix<double>;
+using Parameters = std::vector<std::vector<double>>;
+
+auto close(double lhs, double rhs, double tolerance = 1.0e-8) -> bool
+{
+	return std::abs(lhs - rhs) <= tolerance;
+}
+
+auto add_identity_dense_layer(metric::dnn::Network<double> &network, std::size_t input_size, std::size_t output_size)
+	-> void
+{
+	metric::dnn::FullyConnected<double, metric::dnn::Identity<double>> layer(input_size, output_size);
+	layer.initConstant(0.0, 0.0);
+	network.addLayer(layer);
+}
+
+auto make_autoencoder_network(double learning_rate = 0.01) -> metric::dnn::Network<double>
+{
+	metric::dnn::Network<double> network;
+	add_identity_dense_layer(network, 2, 1);
+	add_identity_dense_layer(network, 1, 2);
+	network.setOutput(metric::dnn::RegressionMSE<double>());
+	network.setOptimizer(metric::dnn::RMSProp<double>(learning_rate, 1.0e-8, 0.0));
+	network.layers[0]->setParameters({{0.25, -0.15}, {0.05}});
+	network.layers[1]->setParameters({{0.30, -0.40}, {0.02, -0.03}});
+	return network;
+}
+
+auto make_batch(const Matrix &features) -> metric::dnn::DnnBatch<double>
+{
+	metric::dnn::DnnBatch<double> batch;
+	batch.x = features;
+	batch.ids.reserve(features.rows());
+	for (std::size_t index = 0; index < features.rows(); ++index) {
+		batch.ids.push_back(metric::dnn::SampleId::from_index(index));
+	}
+	return batch;
+}
+
+auto evaluate(metric::dnn::Network<double> &network, const metric::dnn::CompositeLoss<double> &objective,
+			  const metric::dnn::DnnBatch<double> &batch) -> metric::dnn::CompositeLossEvaluation<double>
+{
+	std::vector<Matrix> activations;
+	network.forward_all(batch.x, &activations);
+	return objective.evaluate(batch, activations);
+}
+
+auto train_step(metric::dnn::Network<double> &network, const metric::dnn::CompositeLoss<double> &objective,
+				const metric::dnn::DnnBatch<double> &batch) -> metric::dnn::CompositeLossEvaluation<double>
+{
+	auto evaluation = evaluate(network, objective, batch);
+	network.backprop_from_layer_gradients(batch.x, evaluation.gradients_by_layer);
+	network.apply_optimizer();
+	return evaluation;
+}
+
+auto assert_parameters_close(const Parameters &lhs, const Parameters &rhs, double tolerance = 1.0e-8) -> void
+{
+	assert(lhs.size() == rhs.size());
+	for (std::size_t group = 0; group < lhs.size(); ++group) {
+		assert(lhs[group].size() == rhs[group].size());
+		for (std::size_t index = 0; index < lhs[group].size(); ++index) {
+			assert(close(lhs[group][index], rhs[group][index], tolerance));
+		}
+	}
+}
+
+auto assert_networks_close(const metric::dnn::Network<double> &lhs, const metric::dnn::Network<double> &rhs) -> void
+{
+	assert(lhs.layers.size() == rhs.layers.size());
+	for (std::size_t layer = 0; layer < lhs.layers.size(); ++layer) {
+		assert_parameters_close(lhs.layers[layer]->getParameters(), rhs.layers[layer]->getParameters());
+	}
+}
+
+auto find_term_value(const metric::dnn::CompositeLossEvaluation<double> &evaluation, const std::string &name) -> double
+{
+	for (const auto &term : evaluation.terms) {
+		if (term.name == name) {
+			return term.value;
+		}
+	}
+	assert(false);
+	return 0.0;
+}
+
+} // namespace
+
+int main()
+{
+	const Matrix samples{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}};
+	const auto batch = make_batch(samples);
+
+	{
+		metric::dnn::RegressionMSE<double> mse;
+		const Matrix prediction{{0.0, 0.5}, {1.0, 2.0}};
+		const Matrix target{{0.0, 0.0}, {2.0, 2.0}};
+		mse.evaluate(prediction, target);
+
+		metric::dnn::DnnBatch<double> mse_batch;
+		mse_batch.x = target;
+		mse_batch.ids = {metric::dnn::SampleId::from_index(0), metric::dnn::SampleId::from_index(1)};
+		const std::vector<Matrix> activations{prediction};
+		const metric::dnn::ReconstructionMSELoss<double> loss;
+		const auto evaluation = loss.evaluate(mse_batch, activations);
+		assert(close(evaluation.value, mse.loss()));
+		assert(close(evaluation.gradient(0, 0), mse.backprop_data()(0, 0)));
+		assert(close(evaluation.gradient(0, 1), mse.backprop_data()(0, 1)));
+		assert(close(evaluation.gradient(1, 0), mse.backprop_data()(1, 0)));
+		assert(close(evaluation.gradient(1, 1), mse.backprop_data()(1, 1)));
+	}
+
+	{
+		auto legacy = make_autoencoder_network();
+		auto composite = make_autoencoder_network();
+
+		metric::dnn::CompositeLoss<double> objective;
+		objective.add(std::make_shared<metric::dnn::ReconstructionMSELoss<double>>());
+
+		const auto before = evaluate(composite, objective, batch);
+		assert(before.terms.size() == 1);
+		assert(before.terms[0].name == "reconstruction_mse");
+		assert(close(before.total_value, before.terms[0].weighted_value));
+
+		legacy.fit(samples, samples, 3, 1, 123);
+		(void)train_step(composite, objective, batch);
+		assert_networks_close(legacy, composite);
+	}
+
+	{
+		auto supervised = make_autoencoder_network(0.002);
+		std::map<metric::dnn::SampleId, std::vector<double>> bottleneck_targets;
+		bottleneck_targets.emplace(metric::dnn::SampleId::from_index(0), std::vector<double>{0.0});
+		bottleneck_targets.emplace(metric::dnn::SampleId::from_index(1), std::vector<double>{1.0});
+		bottleneck_targets.emplace(metric::dnn::SampleId::from_index(2), std::vector<double>{2.0});
+
+		metric::dnn::CompositeLoss<double> objective;
+		objective.add(std::make_shared<metric::dnn::ReconstructionMSELoss<double>>(), 0.01);
+		objective.add(std::make_shared<metric::dnn::BottleneckCoordinateMSELoss<double>>(0, bottleneck_targets), 1.0);
+
+		const auto initial = evaluate(supervised, objective, batch);
+		assert(initial.terms.size() == 2);
+		assert(initial.total_value > 0.0);
+		const auto initial_bottleneck = find_term_value(initial, "bottleneck_coordinate_mse");
+
+		for (std::size_t step = 0; step < 120; ++step) {
+			(void)train_step(supervised, objective, batch);
+		}
+
+		const auto final = evaluate(supervised, objective, batch);
+		const auto final_bottleneck = find_term_value(final, "bottleneck_coordinate_mse");
+		assert(final_bottleneck < initial_bottleneck);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add trainer-level `LossTerm`, `CompositeLoss`, loss anchors, and per-term loss reports for native DNN training
- add reconstruction MSE and bottleneck coordinate MSE loss terms
- add smoke coverage that matches a reconstruction-only composite update against legacy `Network::fit(...)`
- add smoke coverage that trains a dense autoencoder with an added bottleneck coordinate target and verifies the bottleneck loss decreases

## Local checks
- `cmake --preset core`
- `cmake --build --preset core --target native_dnn_composite_loss_smoke --parallel 2`
- `./build/core/tests/core_smoke/native_dnn_composite_loss_smoke`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`