### PR TITLE
Add native autoencoder mapping trainer

### DIFF
--- a/metric/engine.hpp
+++ b/metric/engine.hpp
@@ -25,6 +25,7 @@
 #include "intent/reduce.hpp"
 #include "mappings/clustered_space.hpp"
 #include "mappings/mapping.hpp"
+#include "mappings/native_autoencoder.hpp"
 #include "mappings/pcfa.hpp"
 #include "operators/clustering.hpp"
 #include "operators/correlation.hpp"

--- a/metric/mappings/native_autoencoder.hpp
+++ b/metric/mappings/native_autoencoder.hpp
@@ -1,0 +1,200 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_MAPPINGS_NATIVE_AUTOENCODER_HPP
+#define _METRIC_MAPPINGS_NATIVE_AUTOENCODER_HPP
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "../core/concepts.hpp"
+#include "../core/metric_space.hpp"
+#include "../core/record_id.hpp"
+#include "../core/result.hpp"
+#include "../distance/k-related/Standards.hpp"
+#include "../utils/dnn.hpp"
+
+namespace metric::mappings {
+
+template <typename Record, typename Scalar = typename Record::value_type> class NativeAutoencoderModel {
+  public:
+	using record_type = Record;
+	using scalar_type = Scalar;
+	using latent_record_type = std::vector<scalar_type>;
+	using latent_metric_type = Euclidean<scalar_type>;
+	using space_type = MetricSpace<latent_record_type, latent_metric_type>;
+	using result_type = MappingResult<space_type>;
+	using codec_type = dnn::VectorRecordCodec<record_type, scalar_type>;
+	using matrix_type = blaze::DynamicMatrix<scalar_type>;
+
+	NativeAutoencoderModel(dnn::AutoencoderModel<scalar_type> model, codec_type codec,
+						   std::size_t source_record_count)
+		: model_(std::move(model))
+		, codec_(std::move(codec))
+		, source_record_count_(source_record_count)
+	{
+	}
+
+	template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+	auto transform(const Space &space) const -> result_type
+	{
+		static_assert(std::is_same<typename Space::record_type, record_type>::value,
+					  "NativeAutoencoderModel can only transform spaces with the fitted record type");
+		if (space.empty()) {
+			throw std::invalid_argument("cannot transform an empty space with a native autoencoder");
+		}
+
+		const auto features = codec_.encode_batch(space.records());
+		const auto latent = model_.encode(features);
+		auto latent_records = matrix_to_records(latent);
+		space_type derived_space(std::move(latent_records), latent_metric_type{});
+		auto lineage = singleton_lineage(space);
+
+		result_type result{std::move(derived_space), lineage.first, lineage.second, space.size(),
+						   codec_.inverse_supported(), "native_autoencoder", model_.backend_name(), "metric_space"};
+		return result;
+	}
+
+	auto inverse_transform(const space_type &latent_space) const -> std::vector<record_type>
+	{
+		return inverse_transform(latent_space.records());
+	}
+
+	auto inverse_transform(const result_type &result) const -> std::vector<record_type>
+	{
+		return inverse_transform(result.space);
+	}
+
+	auto inverse_transform(const std::vector<latent_record_type> &latent_records) const -> std::vector<record_type>
+	{
+		const auto latent = records_to_matrix(latent_records);
+		const auto reconstructed = model_.decode(latent);
+		return codec_.decode_batch(reconstructed);
+	}
+
+	auto training_report() const -> const dnn::TrainingReport<scalar_type> & { return model_.training_report(); }
+	auto source_record_count() const -> std::size_t { return source_record_count_; }
+	auto latent_dimension() const -> std::size_t
+	{
+		return model_.network().layers.at(model_.topology().bottleneck_layer)->getOutputSize();
+	}
+	auto native_model() const -> const dnn::AutoencoderModel<scalar_type> & { return model_; }
+
+  private:
+	template <typename Space>
+	static auto singleton_lineage(const Space &space)
+		-> std::pair<std::vector<std::vector<RecordId>>, std::vector<RecordId>>
+	{
+		std::vector<std::vector<RecordId>> source_records;
+		std::vector<RecordId> representative_records;
+		source_records.reserve(space.size());
+		representative_records.reserve(space.size());
+
+		for (std::size_t index = 0; index < space.size(); ++index) {
+			const auto id = space.id(index);
+			source_records.push_back(std::vector<RecordId>{id});
+			representative_records.push_back(id);
+		}
+
+		return {std::move(source_records), std::move(representative_records)};
+	}
+
+	static auto matrix_to_records(const matrix_type &matrix) -> std::vector<latent_record_type>
+	{
+		std::vector<latent_record_type> records;
+		records.reserve(matrix.rows());
+		for (std::size_t row = 0; row < matrix.rows(); ++row) {
+			latent_record_type record;
+			record.reserve(matrix.columns());
+			for (std::size_t column = 0; column < matrix.columns(); ++column) {
+				record.push_back(matrix(row, column));
+			}
+			records.push_back(std::move(record));
+		}
+		return records;
+	}
+
+	static auto records_to_matrix(const std::vector<latent_record_type> &records) -> matrix_type
+	{
+		if (records.empty()) {
+			return matrix_type(0, 0);
+		}
+
+		const auto columns = records.front().size();
+		matrix_type matrix(records.size(), columns);
+		for (std::size_t row = 0; row < records.size(); ++row) {
+			if (records[row].size() != columns) {
+				throw std::invalid_argument("latent records must have a consistent feature count");
+			}
+			for (std::size_t column = 0; column < columns; ++column) {
+				matrix(row, column) = records[row][column];
+			}
+		}
+		return matrix;
+	}
+
+	mutable dnn::AutoencoderModel<scalar_type> model_;
+	codec_type codec_;
+	std::size_t source_record_count_{};
+};
+
+template <typename Scalar> class NativeAutoencoderMapping {
+  public:
+	using scalar_type = Scalar;
+
+	NativeAutoencoderMapping(dnn::AutoencoderModel<scalar_type> prototype, dnn::CompositeLoss<scalar_type> objective,
+							 dnn::TrainingSpec<scalar_type> spec = {})
+		: prototype_(std::move(prototype))
+		, objective_(std::move(objective))
+		, spec_(std::move(spec))
+	{
+	}
+
+	template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+	auto fit(const Space &space) const -> NativeAutoencoderModel<typename Space::record_type, scalar_type>
+	{
+		if (space.empty()) {
+			throw std::invalid_argument("cannot fit native autoencoder mapping on an empty space");
+		}
+
+		using record_type = typename Space::record_type;
+		using model_type = NativeAutoencoderModel<record_type, scalar_type>;
+		using codec_type = typename model_type::codec_type;
+
+		codec_type codec(space.records().front().size());
+		auto features = codec.encode_batch(space.records());
+		std::vector<RecordId> ids;
+		ids.reserve(space.size());
+		for (std::size_t index = 0; index < space.size(); ++index) {
+			ids.push_back(space.id(index));
+		}
+
+		dnn::EncodedDataset<scalar_type> dataset(std::move(ids), std::move(features), space.version());
+		auto model = prototype_.clone();
+		const dnn::NativeDnnTrainer<scalar_type> trainer;
+		trainer.fit(model, dataset, objective_, spec_);
+
+		return model_type(std::move(model), std::move(codec), space.size());
+	}
+
+  private:
+	dnn::AutoencoderModel<scalar_type> prototype_;
+	dnn::CompositeLoss<scalar_type> objective_;
+	dnn::TrainingSpec<scalar_type> spec_;
+};
+
+template <typename Scalar>
+auto native_autoencoder(dnn::AutoencoderModel<Scalar> model, dnn::CompositeLoss<Scalar> objective,
+						dnn::TrainingSpec<Scalar> spec = {}) -> NativeAutoencoderMapping<Scalar>
+{
+	return NativeAutoencoderMapping<Scalar>(std::move(model), std::move(objective), std::move(spec));
+}
+
+} // namespace metric::mappings
+
+#endif

--- a/metric/utils/dnn/AutoencoderModel.h
+++ b/metric/utils/dnn/AutoencoderModel.h
@@ -1,0 +1,327 @@
+#ifndef AUTOENCODER_MODEL_H_
+#define AUTOENCODER_MODEL_H_
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+#include "Loss.h"
+#include "Network.h"
+
+namespace metric::dnn {
+
+struct AutoencoderTopology {
+	std::size_t input_layer{0};
+	std::size_t bottleneck_layer{0};
+	std::size_t output_layer{0};
+	std::vector<std::size_t> encoder_layers;
+	std::vector<std::size_t> decoder_layers;
+};
+
+inline auto infer_autoencoder_topology(std::size_t layer_count) -> AutoencoderTopology
+{
+	if (layer_count < 2) {
+		throw std::invalid_argument("autoencoder topology requires at least two layers");
+	}
+
+	AutoencoderTopology topology;
+	topology.output_layer = layer_count - 1;
+	topology.bottleneck_layer = layer_count % 2 == 0 ? (layer_count / 2) - 1 : layer_count / 2;
+
+	topology.encoder_layers.reserve(topology.bottleneck_layer + 1);
+	for (std::size_t layer = 0; layer <= topology.bottleneck_layer; ++layer) {
+		topology.encoder_layers.push_back(layer);
+	}
+
+	for (std::size_t layer = topology.bottleneck_layer + 1; layer < layer_count; ++layer) {
+		topology.decoder_layers.push_back(layer);
+	}
+
+	return topology;
+}
+
+template <class Scalar> struct EpochReport {
+	std::size_t epoch{0};
+	Scalar total_loss{0};
+	std::vector<LossTermReport<Scalar>> terms;
+	std::size_t batch_count{0};
+};
+
+template <class Scalar> struct TrainingReport {
+	std::vector<EpochReport<Scalar>> epochs;
+	bool stopped_early{false};
+	std::string stop_reason;
+};
+
+template <class Scalar> struct TrainingSpec {
+	std::size_t epochs{100};
+	std::size_t batch_size{32};
+	std::uint64_t seed{123};
+	bool shuffle{true};
+	Scalar gradient_clip_norm{0};
+	Scalar early_stop_min_delta{0};
+	std::size_t early_stop_patience{0};
+};
+
+template <class Scalar> class AutoencoderModel {
+  public:
+	using matrix_type = blaze::DynamicMatrix<Scalar>;
+	using network_type = Network<Scalar>;
+
+	explicit AutoencoderModel(network_type network)
+		: network_(std::move(network))
+		, topology_(infer_autoencoder_topology(network_.layers.size()))
+	{
+		validate_topology();
+	}
+
+	AutoencoderModel(network_type network, AutoencoderTopology topology)
+		: network_(std::move(network))
+		, topology_(std::move(topology))
+	{
+		validate_topology();
+	}
+
+	AutoencoderModel(const AutoencoderModel &other)
+		: network_(clone_network(other.network_))
+		, topology_(other.topology_)
+		, backend_name_(other.backend_name_)
+		, report_(other.report_)
+	{
+	}
+
+	auto operator=(const AutoencoderModel &other) -> AutoencoderModel &
+	{
+		if (this != &other) {
+			network_ = clone_network(other.network_);
+			topology_ = other.topology_;
+			backend_name_ = other.backend_name_;
+			report_ = other.report_;
+		}
+		return *this;
+	}
+
+	AutoencoderModel(AutoencoderModel &&) noexcept = default;
+	auto operator=(AutoencoderModel &&) noexcept -> AutoencoderModel & = default;
+
+	auto network() -> network_type & { return network_; }
+	auto network() const -> const network_type & { return network_; }
+	auto topology() const -> const AutoencoderTopology & { return topology_; }
+	auto backend_name() const -> const std::string & { return backend_name_; }
+	auto training_report() const -> const TrainingReport<Scalar> & { return report_; }
+	auto set_training_report(TrainingReport<Scalar> report) -> void { report_ = std::move(report); }
+
+	auto clone() const -> AutoencoderModel { return AutoencoderModel(*this); }
+
+	auto encode(const matrix_type &features) -> matrix_type
+	{
+		std::vector<matrix_type> activations;
+		network_.forward_all(features, &activations);
+		return activations.at(topology_.bottleneck_layer);
+	}
+
+	auto decode(const matrix_type &latent) -> matrix_type
+	{
+		matrix_type current(latent);
+		for (const auto layer_index : topology_.decoder_layers) {
+			network_.layers.at(layer_index)->forward(current);
+			current = network_.layers.at(layer_index)->output();
+		}
+		return current;
+	}
+
+  private:
+	static auto clone_network(const network_type &source) -> network_type
+	{
+		std::stringstream stream;
+		source.save(stream);
+
+		network_type copy;
+		copy.load(stream);
+		return copy;
+	}
+
+	auto validate_topology() const -> void
+	{
+		const auto layer_count = network_.layers.size();
+		if (layer_count < 2) {
+			throw std::invalid_argument("AutoencoderModel requires at least two network layers");
+		}
+		if (topology_.bottleneck_layer >= layer_count || topology_.output_layer >= layer_count) {
+			throw std::invalid_argument("AutoencoderModel topology references an unknown layer");
+		}
+		if (topology_.output_layer != layer_count - 1) {
+			throw std::invalid_argument("AutoencoderModel output layer must be the final network layer");
+		}
+		for (const auto layer : topology_.encoder_layers) {
+			if (layer > topology_.bottleneck_layer || layer >= layer_count) {
+				throw std::invalid_argument("AutoencoderModel encoder layer is out of range");
+			}
+		}
+		for (const auto layer : topology_.decoder_layers) {
+			if (layer <= topology_.bottleneck_layer || layer >= layer_count) {
+				throw std::invalid_argument("AutoencoderModel decoder layer is out of range");
+			}
+		}
+	}
+
+	network_type network_;
+	AutoencoderTopology topology_;
+	std::string backend_name_{"native_dnn"};
+	TrainingReport<Scalar> report_;
+};
+
+template <class Scalar> class NativeDnnTrainer {
+  public:
+	using matrix_type = blaze::DynamicMatrix<Scalar>;
+
+	auto fit(AutoencoderModel<Scalar> &model, const EncodedDataset<Scalar> &dataset,
+			 const CompositeLoss<Scalar> &objective, const TrainingSpec<Scalar> &spec) const
+		-> TrainingReport<Scalar>
+	{
+		if (dataset.size() == 0) {
+			throw std::invalid_argument("NativeDnnTrainer requires a non-empty dataset");
+		}
+		if (objective.size() == 0) {
+			throw std::invalid_argument("NativeDnnTrainer requires at least one loss term");
+		}
+
+		model.network().reset_optimizer();
+		std::mt19937 rng(static_cast<std::mt19937::result_type>(spec.seed));
+
+		TrainingReport<Scalar> report;
+		Scalar best_loss = std::numeric_limits<Scalar>::infinity();
+		std::size_t stale_epochs = 0;
+
+		for (std::size_t epoch = 0; epoch < spec.epochs; ++epoch) {
+			auto batches = dataset.batches(spec.batch_size, rng, spec.shuffle);
+			EpochAccumulator accumulator(epoch);
+
+			for (auto &batch : batches) {
+				std::vector<matrix_type> activations;
+				model.network().forward_all(batch.x, &activations);
+
+				auto evaluation = objective.evaluate(batch, activations);
+				clip_gradients(evaluation.gradients_by_layer, spec.gradient_clip_norm);
+				model.network().backprop_from_layer_gradients(batch.x, evaluation.gradients_by_layer);
+				model.network().apply_optimizer();
+
+				accumulator.add(evaluation);
+			}
+
+			report.epochs.push_back(accumulator.finish());
+			const auto current_loss = report.epochs.back().total_loss;
+			if (spec.early_stop_patience > 0) {
+				if (current_loss + spec.early_stop_min_delta < best_loss) {
+					best_loss = current_loss;
+					stale_epochs = 0;
+				} else {
+					++stale_epochs;
+					if (stale_epochs >= spec.early_stop_patience) {
+						report.stopped_early = true;
+						report.stop_reason = "early_stop_patience";
+						break;
+					}
+				}
+			}
+		}
+
+		model.set_training_report(report);
+		return report;
+	}
+
+  private:
+	class EpochAccumulator {
+	  public:
+		explicit EpochAccumulator(std::size_t epoch)
+			: epoch_(epoch)
+		{
+		}
+
+		auto add(const CompositeLossEvaluation<Scalar> &evaluation) -> void
+		{
+			if (batch_count_ == 0) {
+				terms_ = evaluation.terms;
+				for (auto &term : terms_) {
+					term.value = Scalar(0);
+					term.weighted_value = Scalar(0);
+				}
+			}
+			if (evaluation.terms.size() != terms_.size()) {
+				throw std::invalid_argument("Composite loss term layout changed during an epoch");
+			}
+
+			total_loss_ += evaluation.total_value;
+			for (std::size_t index = 0; index < terms_.size(); ++index) {
+				if (terms_[index].name != evaluation.terms[index].name) {
+					throw std::invalid_argument("Composite loss term order changed during an epoch");
+				}
+				terms_[index].value += evaluation.terms[index].value;
+				terms_[index].weighted_value += evaluation.terms[index].weighted_value;
+			}
+			++batch_count_;
+		}
+
+		auto finish() const -> EpochReport<Scalar>
+		{
+			if (batch_count_ == 0) {
+				throw std::invalid_argument("NativeDnnTrainer epoch has no batches");
+			}
+
+			EpochReport<Scalar> report;
+			report.epoch = epoch_;
+			report.total_loss = total_loss_ / static_cast<Scalar>(batch_count_);
+			report.terms = terms_;
+			report.batch_count = batch_count_;
+			for (auto &term : report.terms) {
+				term.value /= static_cast<Scalar>(batch_count_);
+				term.weighted_value /= static_cast<Scalar>(batch_count_);
+			}
+			return report;
+		}
+
+	  private:
+		std::size_t epoch_{0};
+		Scalar total_loss_{0};
+		std::vector<LossTermReport<Scalar>> terms_;
+		std::size_t batch_count_{0};
+	};
+
+	static auto clip_gradients(std::vector<matrix_type> &gradients_by_layer, Scalar clip_norm) -> void
+	{
+		if (clip_norm <= Scalar(0)) {
+			return;
+		}
+
+		Scalar squared_norm{0};
+		for (const auto &gradient : gradients_by_layer) {
+			if (blaze::size(gradient) != 0) {
+				squared_norm += blaze::sqrNorm(gradient);
+			}
+		}
+
+		const auto norm = std::sqrt(squared_norm);
+		if (norm == Scalar(0) || norm <= clip_norm) {
+			return;
+		}
+
+		const auto scale = clip_norm / norm;
+		for (auto &gradient : gradients_by_layer) {
+			if (blaze::size(gradient) != 0) {
+				gradient *= scale;
+			}
+		}
+	}
+};
+
+} // namespace metric::dnn
+
+#endif /* AUTOENCODER_MODEL_H_ */

--- a/metric/utils/dnn/Dataset.h
+++ b/metric/utils/dnn/Dataset.h
@@ -161,6 +161,58 @@ template <class InputDataType, class Scalar> class FlatVectorCodec {
 	InputDataType norm_value_{};
 };
 
+template <class Record, class Scalar> class VectorRecordCodec {
+  public:
+	using matrix_type = blaze::DynamicMatrix<Scalar>;
+
+	explicit VectorRecordCodec(std::size_t feature_count)
+		: feature_count_(feature_count)
+	{
+		if (feature_count_ == 0) {
+			throw std::invalid_argument("VectorRecordCodec feature count must be positive");
+		}
+	}
+
+	auto feature_count() const -> std::size_t { return feature_count_; }
+	auto inverse_supported() const -> bool { return true; }
+
+	auto encode_batch(const std::vector<Record> &records) const -> matrix_type
+	{
+		matrix_type encoded(records.size(), feature_count_);
+		for (std::size_t row = 0; row < records.size(); ++row) {
+			if (records[row].size() != feature_count_) {
+				throw std::invalid_argument("VectorRecordCodec record feature count does not match codec");
+			}
+			for (std::size_t column = 0; column < feature_count_; ++column) {
+				encoded(row, column) = static_cast<Scalar>(records[row][column]);
+			}
+		}
+		return encoded;
+	}
+
+	auto decode_batch(const matrix_type &matrix) const -> std::vector<Record>
+	{
+		if (matrix.columns() != feature_count_) {
+			throw std::invalid_argument("VectorRecordCodec decoded feature count does not match codec");
+		}
+
+		std::vector<Record> records;
+		records.reserve(matrix.rows());
+		for (std::size_t row = 0; row < matrix.rows(); ++row) {
+			Record record;
+			record.reserve(feature_count_);
+			for (std::size_t column = 0; column < feature_count_; ++column) {
+				record.push_back(static_cast<typename Record::value_type>(matrix(row, column)));
+			}
+			records.push_back(std::move(record));
+		}
+		return records;
+	}
+
+  private:
+	std::size_t feature_count_{0};
+};
+
 } // namespace metric::dnn
 
 #endif /* DATASET_H_ */

--- a/metric/utils/dnn/Network.h
+++ b/metric/utils/dnn/Network.h
@@ -222,6 +222,14 @@ template <typename Scalar> class Network {
 		update();
 	}
 
+	void reset_optimizer()
+	{
+		if (!opt) {
+			throw std::invalid_argument("Optimizer is not set");
+		}
+		opt->reset();
+	}
+
 	void constructFromJsonString(const std::string &jsonString)
 	{
 		/* Parse json */

--- a/metric/utils/dnn/Optimizer/RMSProp.h
+++ b/metric/utils/dnn/Optimizer/RMSProp.h
@@ -46,7 +46,12 @@ template <typename Scalar> class RMSProp : public Optimizer<Scalar> {
 		return json;
 	}
 
-	void reset() { m_history.clear(); }
+	void reset()
+	{
+		m_history.clear();
+		historyVectors.clear();
+		historyMatrices.clear();
+	}
 
 	void update(ConstAlignedMapVec &dvec, AlignedMapVec &vec)
 	{

--- a/metric/utils/dnn/dnn-includes.h
+++ b/metric/utils/dnn/dnn-includes.h
@@ -31,5 +31,6 @@
 #include "Callback/VerboseCallback.h"
 
 #include "Network.h"
+#include "AutoencoderModel.h"
 
 #endif /* dnn_H_ */

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -80,6 +80,9 @@ target_link_libraries(native_dnn_dataset_codec_smoke PRIVATE ${METRIC_TARGET_NAM
 add_executable(native_dnn_composite_loss_smoke native_dnn_composite_loss_smoke.cpp)
 target_link_libraries(native_dnn_composite_loss_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(native_dnn_autoencoder_mapping_smoke native_dnn_autoencoder_mapping_smoke.cpp)
+target_link_libraries(native_dnn_autoencoder_mapping_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_test(NAME metric_core_smoke COMMAND metric_core_smoke)
 add_test(NAME metric_mgc_smoke COMMAND metric_mgc_smoke)
 if (METRIC_BUILD_CORE_ENTROPY)
@@ -110,3 +113,4 @@ add_test(NAME native_dnn_baseline_smoke COMMAND native_dnn_baseline_smoke)
 add_test(NAME native_dnn_training_hooks_smoke COMMAND native_dnn_training_hooks_smoke)
 add_test(NAME native_dnn_dataset_codec_smoke COMMAND native_dnn_dataset_codec_smoke)
 add_test(NAME native_dnn_composite_loss_smoke COMMAND native_dnn_composite_loss_smoke)
+add_test(NAME native_dnn_autoencoder_mapping_smoke COMMAND native_dnn_autoencoder_mapping_smoke)

--- a/tests/core_smoke/native_dnn_autoencoder_mapping_smoke.cpp
+++ b/tests/core_smoke/native_dnn_autoencoder_mapping_smoke.cpp
@@ -1,0 +1,137 @@
+#include <cassert>
+#include <cmath>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include <blaze/Math.h>
+
+#include "metric/distance.hpp"
+#include "metric/engine.hpp"
+#include "metric/utils/dnn.hpp"
+
+namespace {
+
+using Matrix = blaze::DynamicMatrix<double>;
+
+auto is_finite(double value) -> bool
+{
+	return std::isfinite(value);
+}
+
+auto add_identity_dense_layer(metric::dnn::Network<double> &network, std::size_t input_size, std::size_t output_size)
+	-> void
+{
+	metric::dnn::FullyConnected<double, metric::dnn::Identity<double>> layer(input_size, output_size);
+	layer.initConstant(0.0, 0.0);
+	network.addLayer(layer);
+}
+
+auto make_autoencoder_network(double learning_rate = 0.002) -> metric::dnn::Network<double>
+{
+	metric::dnn::Network<double> network;
+	add_identity_dense_layer(network, 2, 1);
+	add_identity_dense_layer(network, 1, 2);
+	network.setOutput(metric::dnn::RegressionMSE<double>());
+	network.setOptimizer(metric::dnn::RMSProp<double>(learning_rate, 1.0e-8, 0.0));
+	network.layers[0]->setParameters({{0.20, 0.10}, {0.00}});
+	network.layers[1]->setParameters({{0.15, -0.10}, {0.00, 0.00}});
+	return network;
+}
+
+auto reconstruction_objective() -> metric::dnn::CompositeLoss<double>
+{
+	metric::dnn::CompositeLoss<double> objective;
+	objective.add(std::make_shared<metric::dnn::ReconstructionMSELoss<double>>());
+	return objective;
+}
+
+} // namespace
+
+int main()
+{
+	const Matrix features{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}};
+
+	{
+		metric::dnn::EncodedDataset<double> dataset = metric::dnn::EncodedDataset<double>::from_features(features, 7);
+		auto objective = reconstruction_objective();
+		metric::dnn::TrainingSpec<double> spec;
+		spec.epochs = 8;
+		spec.batch_size = 2;
+		spec.seed = 13;
+		spec.shuffle = true;
+		spec.gradient_clip_norm = 10.0;
+
+		metric::dnn::AutoencoderModel<double> model(make_autoencoder_network());
+		assert(model.backend_name() == "native_dnn");
+		assert(model.topology().bottleneck_layer == 0);
+		assert(model.topology().decoder_layers.size() == 1);
+
+		const metric::dnn::NativeDnnTrainer<double> trainer;
+		const auto report = trainer.fit(model, dataset, objective, spec);
+		assert(report.epochs.size() == spec.epochs);
+		assert(!report.stopped_early);
+		assert(report.epochs.front().batch_count == 2);
+		assert(report.epochs.back().terms.size() == 1);
+		assert(report.epochs.back().terms[0].name == "reconstruction_mse");
+		assert(is_finite(report.epochs.back().total_loss));
+		assert(model.training_report().epochs.size() == spec.epochs);
+
+		const auto latent = model.encode(features);
+		assert(latent.rows() == features.rows());
+		assert(latent.columns() == 1);
+
+		const auto reconstructed = model.decode(latent);
+		assert(reconstructed.rows() == features.rows());
+		assert(reconstructed.columns() == features.columns());
+	}
+
+	{
+		using record_type = std::vector<double>;
+
+		auto source =
+			metric::make_space(std::vector<record_type>{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}},
+							   metric::Euclidean<double>{});
+
+		metric::dnn::TrainingSpec<double> spec;
+		spec.epochs = 6;
+		spec.batch_size = 2;
+		spec.seed = 17;
+		spec.shuffle = false;
+
+		auto mapping = metric::mappings::native_autoencoder(metric::dnn::AutoencoderModel<double>(make_autoencoder_network()),
+															reconstruction_objective(), spec);
+		static_assert(metric::Mapping_v<decltype(mapping), decltype(source)>);
+
+		auto model = metric::mappings::fit(mapping, source);
+		static_assert(metric::MappingModel_v<decltype(model), decltype(source)>);
+		assert(model.source_record_count() == source.size());
+		assert(model.latent_dimension() == 1);
+		assert(model.training_report().epochs.size() == spec.epochs);
+
+		const auto reduced = metric::mappings::transform(model, source);
+		using reduced_type = typename std::decay<decltype(reduced)>::type;
+		static_assert(std::is_same<typename reduced_type::space_type::record_type, std::vector<double>>::value);
+		assert(reduced.mapping == "native_autoencoder");
+		assert(reduced.strategy == "native_dnn");
+		assert(reduced.representation == "metric_space");
+		assert(reduced.inverse_supported);
+		assert(reduced.source_record_count == source.size());
+		assert(reduced.source_records.size() == source.size());
+		assert(reduced.representative_records[0] == source.id(0));
+		assert(reduced.space.size() == source.size());
+		assert(reduced.space.record(reduced.space.id(0)).size() == 1);
+		assert(is_finite(reduced.space.distance(reduced.space.id(0), reduced.space.id(1))));
+
+		const auto restored = model.inverse_transform(reduced);
+		assert(restored.size() == source.size());
+		for (const auto &record : restored) {
+			assert(record.size() == 2);
+			for (const auto value : record) {
+				assert(is_finite(value));
+			}
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add native DNN autoencoder topology/model metadata and a structured trainer report
- expose vector-record codec support plus a native autoencoder mapping that returns a Euclidean latent MetricSpace and supports inverse decode
- add a core smoke test covering trainer diagnostics, latent transform, and inverse transform
- reset all RMSProp history stores when resetting the optimizer

## Verification
- `cmake --preset core`
- `cmake --build --preset core --target native_dnn_autoencoder_mapping_smoke --parallel 2`
- `./build/core/tests/core_smoke/native_dnn_autoencoder_mapping_smoke`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`