### PR TITLE
Add engine representation swap example

### DIFF
--- a/examples/engine/CMakeLists.txt
+++ b/examples/engine/CMakeLists.txt
@@ -10,9 +10,13 @@ target_link_libraries(engine_histogram_transport_space PRIVATE ${METRIC_TARGET_N
 add_executable(engine_cross_space_mgc cross_space_mgc.cpp)
 target_link_libraries(engine_cross_space_mgc PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_representation_swap representation_swap.cpp)
+target_link_libraries(engine_representation_swap PRIVATE ${METRIC_TARGET_NAME})
+
 if (BUILD_TESTING)
     add_test(NAME example_engine_strings_edit_space COMMAND engine_strings_edit_space)
     add_test(NAME example_engine_process_curves_space COMMAND engine_process_curves_space)
     add_test(NAME example_engine_histogram_transport_space COMMAND engine_histogram_transport_space)
     add_test(NAME example_engine_cross_space_mgc COMMAND engine_cross_space_mgc)
+    add_test(NAME example_engine_representation_swap COMMAND engine_representation_swap)
 endif ()

--- a/examples/engine/representation_swap.cpp
+++ b/examples/engine/representation_swap.cpp
@@ -1,0 +1,71 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <metric/distance.hpp>
+#include <metric/engine.hpp>
+
+namespace {
+
+template <typename NeighborSet>
+auto assert_top_neighbor(const NeighborSet &neighbors, metric::RecordId expected, typename NeighborSet::distance_type distance)
+	-> void
+{
+	assert(neighbors.operator_name == "knn");
+	assert(neighbors.size() == 2);
+	assert(neighbors[0].id == expected);
+	assert(neighbors[0].distance == distance);
+}
+
+} // namespace
+
+int main()
+{
+	std::vector<std::string> records = {"metric", "metrics", "matrix", "tree"};
+	auto space = metric::make_space(records, metric::Edit<char>{});
+	const std::string query = "metricks";
+
+	const auto implicit = metric::find_neighbors(space, query, metric::count{2});
+	assert(implicit.representation == "metric_space");
+	assert_top_neighbor(implicit, space.id(1), 1);
+
+	const auto tree = metric::find_neighbors(space, query, metric::count{2}, metric::strategies::cover_tree{});
+	assert(tree.representation == "cover_tree_index");
+	assert_top_neighbor(tree, implicit[0].id, implicit[0].distance);
+
+	const auto graph = metric::find_neighbors(space, query, metric::count{2}, metric::strategies::knn_graph{3});
+	assert(graph.representation == "knn_graph_index");
+	assert_top_neighbor(graph, implicit[0].id, implicit[0].distance);
+
+	const auto query_id = space.id(1);
+	const auto id_neighbors = metric::find_neighbors(space, query_id, metric::count{2});
+	const auto matrix_neighbors =
+		metric::find_neighbors(space, query_id, metric::count{2}, metric::strategies::matrix_cache{});
+	assert(matrix_neighbors.representation == "matrix_cache");
+	assert_top_neighbor(matrix_neighbors, id_neighbors[0].id, id_neighbors[0].distance);
+
+	metric::representations::MatrixCache<decltype(space)> matrix(space);
+	metric::representations::CoverTreeIndex<decltype(space)> tree_index(space);
+	metric::representations::KnnGraphIndex<decltype(space)> graph_index(space, 2);
+	assert(!matrix.is_stale());
+	assert(!tree_index.is_stale());
+	assert(!graph_index.is_stale());
+	assert(matrix.diagnostics().kind == metric::representations::representation_kind::matrix_cache);
+	assert(tree_index.diagnostics().kind == metric::representations::representation_kind::cover_tree_index);
+	assert(graph_index.diagnostics().kind == metric::representations::representation_kind::knn_graph_index);
+
+	(void)space.insert("metrica");
+	assert(matrix.is_stale());
+	assert(tree_index.is_stale());
+	assert(graph_index.is_stale());
+
+	std::cout << "implicit nearest = " << records[implicit[0].id.index()] << " via " << implicit.representation
+			  << "\n";
+	std::cout << "tree nearest = " << records[tree[0].id.index()] << " via " << tree.representation << "\n";
+	std::cout << "graph nearest = " << records[graph[0].id.index()] << " via " << graph.representation << "\n";
+	std::cout << "id query nearest = " << records[matrix_neighbors[0].id.index()] << " via "
+			  << matrix_neighbors.representation << "\n";
+
+	return 0;
+}

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -68,6 +68,9 @@ target_link_libraries(engine_outliers_intent_smoke PRIVATE ${METRIC_TARGET_NAME}
 add_executable(engine_runtime_policy_smoke engine_runtime_policy_smoke.cpp)
 target_link_libraries(engine_runtime_policy_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_representation_swap_smoke engine_representation_swap_smoke.cpp)
+target_link_libraries(engine_representation_swap_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_executable(native_dnn_baseline_smoke native_dnn_baseline_smoke.cpp)
 target_link_libraries(native_dnn_baseline_smoke PRIVATE ${METRIC_TARGET_NAME})
 
@@ -109,6 +112,7 @@ add_test(NAME engine_representatives_intent_smoke COMMAND engine_representatives
 add_test(NAME engine_compress_intent_smoke COMMAND engine_compress_intent_smoke)
 add_test(NAME engine_outliers_intent_smoke COMMAND engine_outliers_intent_smoke)
 add_test(NAME engine_runtime_policy_smoke COMMAND engine_runtime_policy_smoke)
+add_test(NAME engine_representation_swap_smoke COMMAND engine_representation_swap_smoke)
 add_test(NAME native_dnn_baseline_smoke COMMAND native_dnn_baseline_smoke)
 add_test(NAME native_dnn_training_hooks_smoke COMMAND native_dnn_training_hooks_smoke)
 add_test(NAME native_dnn_dataset_codec_smoke COMMAND native_dnn_dataset_codec_smoke)

--- a/tests/core_smoke/engine_representation_swap_smoke.cpp
+++ b/tests/core_smoke/engine_representation_swap_smoke.cpp
@@ -1,0 +1,60 @@
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "metric/distance.hpp"
+#include "metric/engine.hpp"
+
+namespace {
+
+template <typename NeighborSet>
+auto assert_top_neighbor(const NeighborSet &neighbors, metric::RecordId expected, typename NeighborSet::distance_type distance)
+	-> void
+{
+	assert(neighbors.operator_name == "knn");
+	assert(neighbors.size() == 2);
+	assert(neighbors[0].id == expected);
+	assert(neighbors[0].distance == distance);
+}
+
+} // namespace
+
+int main()
+{
+	std::vector<std::string> records = {"metric", "metrics", "matrix", "tree"};
+	auto space = metric::make_space(records, metric::Edit<char>{});
+	const std::string query = "metricks";
+
+	const auto implicit = metric::find_neighbors(space, query, metric::count{2});
+	assert(implicit.representation == "metric_space");
+	assert_top_neighbor(implicit, space.id(1), 1);
+
+	const auto tree = metric::find_neighbors(space, query, metric::count{2}, metric::strategies::cover_tree{});
+	assert(tree.representation == "cover_tree_index");
+	assert_top_neighbor(tree, implicit[0].id, implicit[0].distance);
+
+	const auto graph = metric::find_neighbors(space, query, metric::count{2}, metric::strategies::knn_graph{3});
+	assert(graph.representation == "knn_graph_index");
+	assert_top_neighbor(graph, implicit[0].id, implicit[0].distance);
+
+	const auto query_id = space.id(1);
+	const auto id_neighbors = metric::find_neighbors(space, query_id, metric::count{2});
+	const auto matrix_neighbors =
+		metric::find_neighbors(space, query_id, metric::count{2}, metric::strategies::matrix_cache{});
+	assert(matrix_neighbors.representation == "matrix_cache");
+	assert_top_neighbor(matrix_neighbors, id_neighbors[0].id, id_neighbors[0].distance);
+
+	metric::representations::MatrixCache<decltype(space)> matrix(space);
+	metric::representations::CoverTreeIndex<decltype(space)> tree_index(space);
+	metric::representations::KnnGraphIndex<decltype(space)> graph_index(space, 2);
+	assert(!matrix.is_stale());
+	assert(!tree_index.is_stale());
+	assert(!graph_index.is_stale());
+
+	(void)space.insert("metrica");
+	assert(matrix.is_stale());
+	assert(tree_index.is_stale());
+	assert(graph_index.is_stale());
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add a C++ engine flagship example showing the same string metric space queried through implicit, cover-tree, kNN-graph, and matrix-cache representations
- add a core smoke test for the same representation-swap behavior so the PR triggers and covers Core C++ CI
- register the example as a CTest target

## Verification
- `cmake --preset core`
- `cmake --build --preset core --target engine_representation_swap_smoke engine_representation_swap --parallel 2`
- `./build/core/tests/core_smoke/engine_representation_swap_smoke`
- `./build/core/examples/engine/engine_representation_swap`
- `ctest --preset core --output-on-failure`