### PR TITLE
Document native PHATE autoencoder progress

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -64,6 +64,7 @@ The current local tree implements the first revival slice:
 - native C++ DNN `SampleId`, `DnnBatch`, `EncodedDataset`, ID-preserving shuffled batches, and `FlatVectorCodec` with Autoencoder-backed conversion
 - native C++ DNN trainer-level `CompositeLoss` with reconstruction MSE, bottleneck coordinate MSE, anchored gradients, and per-term loss reports
 - native C++ DNN `AutoencoderModel`, `NativeDnnTrainer`, vector-record codec support, and `NativeAutoencoderMapping` into Euclidean latent metric spaces with inverse decode
+- native C++ DNN PHATE-style diffusion-potential geometry targets keyed by `SampleId` and `NativePhateAutoencoderMapping` smoke/example coverage
 - direct Python smoke gates run promoted metric-space and engine examples together
 - engine documentation chapters for metric spaces, representations, intents, strategies, operators, mappings, runtime policies, and migration
 - README engine quickstart for C++ engine intents, strategy selection, representation swaps, and mapping-derived spaces
@@ -299,6 +300,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - native C++ DNN `SampleId`, `DnnBatch`, `EncodedDataset`, ID-preserving shuffled batches, and `FlatVectorCodec` with Autoencoder-backed conversion, merged as `0fcf652c36b9141cc3c80e51e2388d6cd51f5cf3`
 - native C++ DNN trainer-level `CompositeLoss` with reconstruction MSE, bottleneck coordinate MSE, anchored gradients, and per-term loss reports, merged as `2c03b29590e0df0718894ac88d75efcac8fc2f65`
 - native C++ DNN `AutoencoderModel`, `NativeDnnTrainer`, vector-record codec support, and `NativeAutoencoderMapping` into Euclidean latent metric spaces with inverse decode, merged as `dc7c6a4aeba0b4e855a997b0641e50036bd97fb5`
+- native C++ DNN PHATE-style diffusion-potential geometry targets keyed by `SampleId` and `NativePhateAutoencoderMapping` smoke/example coverage, merged as `7880eced81cd34e580e05727f17720dff887f061`
 - direct Python smoke gates now run promoted metric-space and engine examples together, merged as `06f22b20e7d44c7f2058b81d43f513fc157f36b0`
 - Python engine-style Space intent facade methods for representatives and structure diagnostics with named result objects and core test coverage, merged as `1849c29a25122b31605945295c91710cfc6a126f`
 - Python `Space.representatives(count=...)` and `find_representatives(..., count=...)` semantic target aliases, merged as `5e2986bc788a758cccdcd8cbb2e122c77d2796d7`


### PR DESCRIPTION
## Summary
- record the native PHATE-style autoencoder mapping merge in the revival status local scope
- add the merged commit SHA for PR #540 to the post-v0.3.2 progress list

## Tests
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`