### PR TITLE
Add native autoencoder artifact metadata

### DIFF
--- a/metric/utils/dnn/AutoencoderArtifact.h
+++ b/metric/utils/dnn/AutoencoderArtifact.h
@@ -1,0 +1,95 @@
+#ifndef AUTOENCODER_ARTIFACT_H_
+#define AUTOENCODER_ARTIFACT_H_
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "AutoencoderModel.h"
+#include "Loss.h"
+#include "Network.h"
+
+namespace metric::dnn {
+
+template <class Scalar> struct NativeAutoencoderArtifact {
+	nlohmann::json manifest;
+	std::string network_cereal;
+	nlohmann::json diagnostics;
+};
+
+template <class Scalar> auto scalar_type_name() -> std::string
+{
+	if constexpr (std::is_same<Scalar, float>::value) {
+		return "float";
+	} else if constexpr (std::is_same<Scalar, double>::value) {
+		return "double";
+	} else if constexpr (std::is_same<Scalar, long double>::value) {
+		return "long_double";
+	} else {
+		return "custom";
+	}
+}
+
+template <class Scalar, class Codec>
+auto make_native_autoencoder_artifact(const AutoencoderModel<Scalar> &model, const Codec &codec,
+									  const CompositeLoss<Scalar> &objective,
+									  const TrainingSpec<Scalar> &training_spec,
+									  std::size_t source_record_count,
+									  std::uint64_t source_space_version = 0)
+	-> NativeAutoencoderArtifact<Scalar>
+{
+	std::stringstream network_stream;
+	model.network().save(network_stream);
+
+	NativeAutoencoderArtifact<Scalar> artifact;
+	artifact.network_cereal = network_stream.str();
+	artifact.diagnostics = training_report_to_json(model.training_report());
+	artifact.manifest = {
+		{"format", "metric.native_autoencoder_artifact"},
+		{"format_version", 1},
+		{"backend", model.backend_name()},
+		{"scalar_type", scalar_type_name<Scalar>()},
+		{"network", {{"serialization", "cereal_binary"}, {"byte_count", artifact.network_cereal.size()}}},
+		{"network_json", model.network().toJson()},
+		{"autoencoder_topology", autoencoder_topology_to_json(model.topology())},
+		{"codec", codec.to_json()},
+		{"loss", objective.to_json()},
+		{"training_spec", training_spec_to_json(training_spec)},
+		{"diagnostics", {{"serialization", "json"}, {"epoch_count", model.training_report().epochs.size()}}},
+		{"source",
+		 {{"record_count", source_record_count},
+		  {"feature_count", codec.feature_count()},
+		  {"space_version", source_space_version}}}};
+	return artifact;
+}
+
+template <class Scalar>
+auto load_native_autoencoder_model(const NativeAutoencoderArtifact<Scalar> &artifact) -> AutoencoderModel<Scalar>
+{
+	if (artifact.manifest.at("format").template get<std::string>() != "metric.native_autoencoder_artifact") {
+		throw std::invalid_argument("unexpected native autoencoder artifact format");
+	}
+	if (artifact.manifest.at("format_version").template get<int>() != 1) {
+		throw std::invalid_argument("unsupported native autoencoder artifact version");
+	}
+	if (artifact.manifest.at("backend").template get<std::string>() != "native_dnn") {
+		throw std::invalid_argument("unsupported native autoencoder artifact backend");
+	}
+	if (artifact.network_cereal.empty()) {
+		throw std::invalid_argument("native autoencoder artifact is missing network bytes");
+	}
+
+	std::stringstream network_stream(artifact.network_cereal);
+	Network<Scalar> network;
+	network.load(network_stream);
+	return AutoencoderModel<Scalar>(std::move(network),
+									autoencoder_topology_from_json(artifact.manifest.at("autoencoder_topology")));
+}
+
+} // namespace metric::dnn
+
+#endif /* AUTOENCODER_ARTIFACT_H_ */

--- a/metric/utils/dnn/AutoencoderModel.h
+++ b/metric/utils/dnn/AutoencoderModel.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <blaze/Math.h>
+#include <nlohmann/json.hpp>
 
 #include "Loss.h"
 #include "Network.h"
@@ -48,6 +49,26 @@ inline auto infer_autoencoder_topology(std::size_t layer_count) -> AutoencoderTo
 	return topology;
 }
 
+inline auto autoencoder_topology_to_json(const AutoencoderTopology &topology) -> nlohmann::json
+{
+	return {{"input_layer", topology.input_layer},
+			{"bottleneck_layer", topology.bottleneck_layer},
+			{"output_layer", topology.output_layer},
+			{"encoder_layers", topology.encoder_layers},
+			{"decoder_layers", topology.decoder_layers}};
+}
+
+inline auto autoencoder_topology_from_json(const nlohmann::json &json) -> AutoencoderTopology
+{
+	AutoencoderTopology topology;
+	topology.input_layer = json.at("input_layer").get<std::size_t>();
+	topology.bottleneck_layer = json.at("bottleneck_layer").get<std::size_t>();
+	topology.output_layer = json.at("output_layer").get<std::size_t>();
+	topology.encoder_layers = json.at("encoder_layers").get<std::vector<std::size_t>>();
+	topology.decoder_layers = json.at("decoder_layers").get<std::vector<std::size_t>>();
+	return topology;
+}
+
 template <class Scalar> struct EpochReport {
 	std::size_t epoch{0};
 	Scalar total_loss{0};
@@ -70,6 +91,50 @@ template <class Scalar> struct TrainingSpec {
 	Scalar early_stop_min_delta{0};
 	std::size_t early_stop_patience{0};
 };
+
+template <class Scalar> auto training_spec_to_json(const TrainingSpec<Scalar> &spec) -> nlohmann::json
+{
+	return {{"epochs", spec.epochs},
+			{"batch_size", spec.batch_size},
+			{"seed", spec.seed},
+			{"shuffle", spec.shuffle},
+			{"gradient_clip_norm", spec.gradient_clip_norm},
+			{"early_stop_min_delta", spec.early_stop_min_delta},
+			{"early_stop_patience", spec.early_stop_patience}};
+}
+
+template <class Scalar> auto loss_term_report_to_json(const LossTermReport<Scalar> &term) -> nlohmann::json
+{
+	return {{"name", term.name},
+			{"weight", term.weight},
+			{"value", term.value},
+			{"weighted_value", term.weighted_value},
+			{"anchor", loss_anchor_to_json(term.anchor)}};
+}
+
+template <class Scalar> auto epoch_report_to_json(const EpochReport<Scalar> &epoch) -> nlohmann::json
+{
+	nlohmann::json terms = nlohmann::json::array();
+	for (const auto &term : epoch.terms) {
+		terms.push_back(loss_term_report_to_json(term));
+	}
+	return {{"epoch", epoch.epoch},
+			{"total_loss", epoch.total_loss},
+			{"batch_count", epoch.batch_count},
+			{"terms", std::move(terms)}};
+}
+
+template <class Scalar> auto training_report_to_json(const TrainingReport<Scalar> &report) -> nlohmann::json
+{
+	nlohmann::json epochs = nlohmann::json::array();
+	for (const auto &epoch : report.epochs) {
+		epochs.push_back(epoch_report_to_json(epoch));
+	}
+	return {{"epochs", std::move(epochs)},
+			{"epoch_count", report.epochs.size()},
+			{"stopped_early", report.stopped_early},
+			{"stop_reason", report.stop_reason}};
+}
 
 template <class Scalar> class AutoencoderModel {
   public:

--- a/metric/utils/dnn/Dataset.h
+++ b/metric/utils/dnn/Dataset.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <blaze/Math.h>
+#include <nlohmann/json.hpp>
 
 #include "metric/core/record_id.hpp"
 
@@ -113,6 +114,10 @@ template <class InputDataType, class Scalar> class FlatVectorCodec {
 
 	auto feature_count() const -> std::size_t { return feature_count_; }
 	auto norm_value() const -> InputDataType { return norm_value_; }
+	auto to_json() const -> nlohmann::json
+	{
+		return {{"type", "FlatVectorCodec"}, {"feature_count", feature_count_}, {"norm_value", norm_value_}};
+	}
 
 	auto encode_flat(const std::vector<InputDataType> &input) const -> matrix_type
 	{
@@ -175,6 +180,10 @@ template <class Record, class Scalar> class VectorRecordCodec {
 
 	auto feature_count() const -> std::size_t { return feature_count_; }
 	auto inverse_supported() const -> bool { return true; }
+	auto to_json() const -> nlohmann::json
+	{
+		return {{"type", "VectorRecordCodec"}, {"feature_count", feature_count_}, {"inverse_supported", true}};
+	}
 
 	auto encode_batch(const std::vector<Record> &records) const -> matrix_type
 	{

--- a/metric/utils/dnn/Loss.h
+++ b/metric/utils/dnn/Loss.h
@@ -27,6 +27,11 @@ inline auto loss_anchor_kind_name(LossAnchorKind kind) -> std::string
 	return kind == LossAnchorKind::final_output ? "final_output" : "layer_output";
 }
 
+inline auto loss_anchor_to_json(LossAnchor anchor) -> nlohmann::json
+{
+	return {{"kind", loss_anchor_kind_name(anchor.kind)}, {"layer_index", anchor.layer_index}};
+}
+
 template <class Scalar> struct LossEvaluation {
 	Scalar value{0};
 	blaze::DynamicMatrix<Scalar> gradient;
@@ -72,6 +77,14 @@ template <class Scalar> class CompositeLoss {
 	}
 
 	auto size() const -> std::size_t { return terms_.size(); }
+	auto to_json() const -> nlohmann::json
+	{
+		nlohmann::json terms = nlohmann::json::array();
+		for (const auto &weighted_term : terms_) {
+			terms.push_back({{"weight", weighted_term.weight}, {"term", weighted_term.term->to_json()}});
+		}
+		return {{"type", "CompositeLoss"}, {"terms", std::move(terms)}};
+	}
 
 	auto evaluate(const DnnBatch<Scalar> &batch, const std::vector<matrix_type> &activations) const
 		-> CompositeLossEvaluation<Scalar>

--- a/metric/utils/dnn/dnn-includes.h
+++ b/metric/utils/dnn/dnn-includes.h
@@ -32,5 +32,6 @@
 
 #include "Network.h"
 #include "AutoencoderModel.h"
+#include "AutoencoderArtifact.h"
 
 #endif /* dnn_H_ */

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -89,6 +89,9 @@ target_link_libraries(native_dnn_autoencoder_mapping_smoke PRIVATE ${METRIC_TARG
 add_executable(native_dnn_phate_autoencoder_smoke native_dnn_phate_autoencoder_smoke.cpp)
 target_link_libraries(native_dnn_phate_autoencoder_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(native_dnn_autoencoder_artifact_smoke native_dnn_autoencoder_artifact_smoke.cpp)
+target_link_libraries(native_dnn_autoencoder_artifact_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_test(NAME metric_core_smoke COMMAND metric_core_smoke)
 add_test(NAME metric_mgc_smoke COMMAND metric_mgc_smoke)
 if (METRIC_BUILD_CORE_ENTROPY)
@@ -122,3 +125,4 @@ add_test(NAME native_dnn_dataset_codec_smoke COMMAND native_dnn_dataset_codec_sm
 add_test(NAME native_dnn_composite_loss_smoke COMMAND native_dnn_composite_loss_smoke)
 add_test(NAME native_dnn_autoencoder_mapping_smoke COMMAND native_dnn_autoencoder_mapping_smoke)
 add_test(NAME native_dnn_phate_autoencoder_smoke COMMAND native_dnn_phate_autoencoder_smoke)
+add_test(NAME native_dnn_autoencoder_artifact_smoke COMMAND native_dnn_autoencoder_artifact_smoke)

--- a/tests/core_smoke/native_dnn_autoencoder_artifact_smoke.cpp
+++ b/tests/core_smoke/native_dnn_autoencoder_artifact_smoke.cpp
@@ -1,0 +1,118 @@
+#include <cassert>
+#include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+#include "metric/utils/dnn.hpp"
+
+namespace {
+
+using Matrix = blaze::DynamicMatrix<double>;
+using record_type = std::vector<double>;
+
+auto close(double lhs, double rhs, double tolerance = 1.0e-9) -> bool
+{
+	return std::abs(lhs - rhs) <= tolerance;
+}
+
+auto add_identity_dense_layer(metric::dnn::Network<double> &network, std::size_t input_size, std::size_t output_size)
+	-> void
+{
+	metric::dnn::FullyConnected<double, metric::dnn::Identity<double>> layer(input_size, output_size);
+	layer.initConstant(0.0, 0.0);
+	network.addLayer(layer);
+}
+
+auto make_autoencoder_network() -> metric::dnn::Network<double>
+{
+	metric::dnn::Network<double> network;
+	add_identity_dense_layer(network, 2, 1);
+	add_identity_dense_layer(network, 1, 2);
+	network.setOutput(metric::dnn::RegressionMSE<double>());
+	network.setOptimizer(metric::dnn::RMSProp<double>(0.001, 1.0e-8, 0.0));
+	network.layers[0]->setParameters({{0.20, 0.10}, {0.00}});
+	network.layers[1]->setParameters({{0.15, -0.10}, {0.00, 0.00}});
+	return network;
+}
+
+auto artifact_objective() -> metric::dnn::CompositeLoss<double>
+{
+	metric::dnn::BottleneckCoordinateMSELoss<double>::target_table_type targets;
+	targets.emplace(metric::dnn::SampleId::from_index(0), std::vector<double>{-0.75});
+	targets.emplace(metric::dnn::SampleId::from_index(1), std::vector<double>{-0.25});
+	targets.emplace(metric::dnn::SampleId::from_index(2), std::vector<double>{0.25});
+	targets.emplace(metric::dnn::SampleId::from_index(3), std::vector<double>{0.75});
+
+	metric::dnn::CompositeLoss<double> objective;
+	objective.add(std::make_shared<metric::dnn::ReconstructionMSELoss<double>>(), 0.25);
+	objective.add(std::make_shared<metric::dnn::BottleneckCoordinateMSELoss<double>>(0, std::move(targets)), 1.5);
+	return objective;
+}
+
+auto assert_same_matrix(const Matrix &lhs, const Matrix &rhs) -> void
+{
+	assert(lhs.rows() == rhs.rows());
+	assert(lhs.columns() == rhs.columns());
+	for (std::size_t row = 0; row < lhs.rows(); ++row) {
+		for (std::size_t column = 0; column < lhs.columns(); ++column) {
+			assert(close(lhs(row, column), rhs(row, column)));
+		}
+	}
+}
+
+} // namespace
+
+int main()
+{
+	const std::vector<record_type> records{{0.0, 0.0}, {1.0, 1.0}, {2.0, 2.0}, {3.0, 3.0}};
+	metric::dnn::VectorRecordCodec<record_type, double> codec(2);
+	const auto features = codec.encode_batch(records);
+	auto dataset = metric::dnn::EncodedDataset<double>::from_features(features, 42);
+
+	auto objective = artifact_objective();
+	metric::dnn::TrainingSpec<double> spec;
+	spec.epochs = 5;
+	spec.batch_size = 2;
+	spec.seed = 19;
+	spec.shuffle = true;
+	spec.gradient_clip_norm = 5.0;
+
+	metric::dnn::AutoencoderModel<double> model(make_autoencoder_network());
+	const metric::dnn::NativeDnnTrainer<double> trainer;
+	trainer.fit(model, dataset, objective, spec);
+
+	const auto artifact =
+		metric::dnn::make_native_autoencoder_artifact(model, codec, objective, spec, records.size(),
+													  dataset.source_space_version());
+	assert(artifact.manifest.at("format") == "metric.native_autoencoder_artifact");
+	assert(artifact.manifest.at("format_version") == 1);
+	assert(artifact.manifest.at("backend") == "native_dnn");
+	assert(artifact.manifest.at("scalar_type") == "double");
+	assert(artifact.manifest.at("network").at("serialization") == "cereal_binary");
+	assert(artifact.manifest.at("network").at("byte_count").get<std::size_t>() == artifact.network_cereal.size());
+	assert(artifact.manifest.at("network_json").at("train").at("optimizer").at("type") == "RMSProp");
+	assert(artifact.manifest.at("autoencoder_topology").at("bottleneck_layer") == model.topology().bottleneck_layer);
+	assert(artifact.manifest.at("codec").at("type") == "VectorRecordCodec");
+	assert(artifact.manifest.at("codec").at("feature_count") == codec.feature_count());
+	assert(artifact.manifest.at("loss").at("terms").size() == 2);
+	assert(artifact.manifest.at("loss").at("terms").at(0).at("weight") == 0.25);
+	assert(artifact.manifest.at("loss").at("terms").at(1).at("term").at("target_count") == records.size());
+	assert(artifact.manifest.at("training_spec").at("epochs") == spec.epochs);
+	assert(artifact.manifest.at("source").at("record_count") == records.size());
+	assert(artifact.manifest.at("source").at("feature_count") == codec.feature_count());
+	assert(artifact.manifest.at("source").at("space_version") == dataset.source_space_version());
+	assert(artifact.diagnostics.at("epoch_count") == spec.epochs);
+	assert(artifact.diagnostics.at("epochs").size() == spec.epochs);
+
+	auto loaded = metric::dnn::load_native_autoencoder_model(artifact);
+	assert(loaded.backend_name() == model.backend_name());
+	assert(loaded.latent_dimension() == model.latent_dimension());
+	assert(loaded.topology().bottleneck_layer == model.topology().bottleneck_layer);
+	assert_same_matrix(model.encode(features), loaded.encode(features));
+	assert_same_matrix(model.decode(model.encode(features)), loaded.decode(loaded.encode(features)));
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add JSON specs for native autoencoder topology, training spec/report, composite losses, and vector codecs
- add a `NativeAutoencoderArtifact` container carrying manifest JSON, network cereal bytes, and diagnostics JSON
- add a smoke test that serializes composite-loss autoencoder metadata and reloads the native model from the artifact network bytes

## Tests
- `cmake --preset core`
- `cmake --build --preset core --target native_dnn_autoencoder_artifact_smoke --parallel 2`
- `./build/core/tests/core_smoke/native_dnn_autoencoder_artifact_smoke`
- `ctest --preset core --output-on-failure`