### PR TITLE
Complete representation layer follow-ups

### DIFF
--- a/docs/engine/representations.md
+++ b/docs/engine/representations.md
@@ -18,16 +18,26 @@ Each adapter captures the source `space.version()` when it is built and exposes 
 
 ## Matrix Cache
 
-`MatrixCache` eagerly stores all pairwise distances. Use it when repeated `RecordId` queries or all-pairs operators make the materialization cost explicit and worthwhile.
+`MatrixCache` can eagerly store all pairwise distances or fill entries lazily. Use eager materialization when repeated `RecordId` queries or all-pairs operators make the upfront cost explicit and worthwhile. Use the lazy mode when the workflow needs distance-provider semantics but should only compute requested pairs.
 
 ```cpp
 metric::representations::MatrixCache<decltype(space)> matrix(space);
 auto distance = matrix.distance(space.id(0), space.id(1));
+
+metric::representations::MatrixCache<decltype(space)> lazy_matrix(
+    space, metric::representations::matrix_cache_mode::lazy);
+auto first = lazy_matrix.distance(space.id(0), space.id(2));  // miss
+auto again = lazy_matrix.distance(space.id(0), space.id(2));  // hit
+auto stats = lazy_matrix.stats();
 ```
+
+`stats()` reports cache hits, misses, fill ratio, and whether symmetric storage is used. `diagnostics()` reports whether the matrix cache was eager/materialized or lazy, the number of cached distances, the number of evaluated distances, memory estimates, and stale-version warnings.
 
 ## Neighbor Indexes
 
 `CoverTreeIndex` and `KnnGraphIndex` currently provide exact deterministic neighbor ordering over finite spaces while preserving the intended engine vocabulary. Their internals can later be replaced by specialized index implementations without changing the representation role.
+
+`KnnGraphIndex::sampled_recall(provider, sample_count)` and `KnnGraphIndex::stats_against(provider, sample_count)` compare graph neighbors with an exact distance provider, usually `MatrixCache`, when recall evidence is needed. This validation is explicit so approximate-quality checks do not hide extra all-pairs work.
 
 ## Graph Topology
 
@@ -42,3 +52,5 @@ The stable Python facade exposes:
 - `Space.to_graph(count=...)` and `metric.representations.graph(space, count=...)` for an exact kNN graph index with construction metadata
 
 The first Python `TreeIndex` preserves the representation vocabulary and deterministic neighbor semantics while using exact scans internally. The first Python `GraphIndex` wraps the promoted exact kNN graph construction result so sparse local-structure workflows can share the same edge metadata as `metric.operators.exact_knn_graph(...)`.
+
+The promoted Python representation-swap example lives at `python/examples/engine/representation_swap.py`. It uses one string/edit `Space`, then inspects the implicit path, matrix materialization, exact tree-style neighbor lookup, exact kNN graph adjacency, runtime diagnostics, and stale-representation checks over the same record IDs.

--- a/metric/representations/diagnostics.hpp
+++ b/metric/representations/diagnostics.hpp
@@ -67,6 +67,8 @@ struct knn_graph_stats {
 	std::size_t nodes{};
 	std::size_t edges{};
 	std::size_t neighbors_requested{};
+	bool recall_validated{};
+	double sampled_recall{};
 };
 
 } // namespace metric::representations

--- a/metric/representations/knn_graph_index.hpp
+++ b/metric/representations/knn_graph_index.hpp
@@ -106,6 +106,43 @@ template <typename Space> class KnnGraphIndex {
 		return result;
 	}
 
+	template <typename Provider> auto stats_against(const Provider &provider, std::size_t sample_count = 0) const
+		-> knn_graph_stats
+	{
+		auto result = stats();
+		result.recall_validated = true;
+		result.sampled_recall = sampled_recall(provider, sample_count);
+		return result;
+	}
+
+	template <typename Provider> auto sampled_recall(const Provider &provider, std::size_t sample_count = 0) const -> double
+	{
+		if (k_ == 0 || record_count_ <= 1) {
+			return 1.0;
+		}
+
+		const auto samples = sample_count == 0 || sample_count > record_count_ ? record_count_ : sample_count;
+		double total_recall = 0.0;
+		for (std::size_t source = 0; source < samples; ++source) {
+			const auto source_id = ids_[source];
+			auto exact_neighbors = exact_provider_neighbors(provider, source_id);
+			const auto &graph_neighbors = adjacency_[source];
+			std::size_t hits = 0;
+			for (const auto &graph_neighbor : graph_neighbors) {
+				const auto found =
+					std::find_if(exact_neighbors.begin(), exact_neighbors.end(), [&](const neighbor_type &exact) {
+						return exact.id == graph_neighbor.id;
+					});
+				if (found != exact_neighbors.end()) {
+					++hits;
+				}
+			}
+			const auto denominator = exact_neighbors.empty() ? 1.0 : static_cast<double>(exact_neighbors.size());
+			total_recall += static_cast<double>(hits) / denominator;
+		}
+		return total_recall / static_cast<double>(samples);
+	}
+
 	auto diagnostics() const -> representation_diagnostics
 	{
 		representation_diagnostics result{representation_kind::knn_graph_index,
@@ -129,6 +166,25 @@ template <typename Space> class KnnGraphIndex {
 	}
 
   private:
+	template <typename Provider>
+	auto exact_provider_neighbors(const Provider &provider, RecordId source_id) const -> std::vector<neighbor_type>
+	{
+		std::vector<neighbor_type> candidates;
+		candidates.reserve(record_count_ > 0 ? record_count_ - 1 : 0);
+		for (std::size_t target = 0; target < provider.record_count(); ++target) {
+			const auto target_id = provider.id(target);
+			if (target_id == source_id) {
+				continue;
+			}
+			candidates.push_back(neighbor_type{target_id, provider.distance(source_id, target_id)});
+		}
+		sort_neighbors(candidates);
+		if (candidates.size() > k_) {
+			candidates.resize(k_);
+		}
+		return candidates;
+	}
+
 	auto build_neighbors(std::size_t source_position) const -> std::vector<neighbor_type>
 	{
 		std::vector<neighbor_type> candidates;

--- a/metric/representations/matrix_cache.hpp
+++ b/metric/representations/matrix_cache.hpp
@@ -6,6 +6,7 @@
 #define _METRIC_REPRESENTATIONS_MATRIX_CACHE_HPP
 
 #include <cstddef>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -14,25 +15,34 @@
 
 namespace metric::representations {
 
+enum class matrix_cache_mode {
+	eager,
+	lazy,
+};
+
 template <typename Space> class MatrixCache {
   public:
 	using space_type = Space;
 	using distance_type = typename space_type::distance_type;
 
-	explicit MatrixCache(const space_type &space)
+	explicit MatrixCache(const space_type &space, matrix_cache_mode mode = matrix_cache_mode::eager)
 		: space_(&space)
 		, record_count_(space.size())
 		, version_(space.version())
+		, mode_(mode)
 	{
 		ids_.reserve(record_count_);
 		for (std::size_t index = 0; index < record_count_; ++index) {
 			ids_.push_back(space.id(index));
 		}
 
-		matrix_.reserve(record_count_ * record_count_);
-		for (std::size_t lhs = 0; lhs < record_count_; ++lhs) {
-			for (std::size_t rhs = 0; rhs < record_count_; ++rhs) {
-				matrix_.push_back(space.distance(ids_[lhs], ids_[rhs]));
+		matrix_.resize(record_count_ * record_count_);
+		if (mode_ == matrix_cache_mode::eager) {
+			for (std::size_t lhs = 0; lhs < record_count_; ++lhs) {
+				for (std::size_t rhs = 0; rhs < record_count_; ++rhs) {
+					matrix_[offset(lhs, rhs)] = space.distance(ids_[lhs], ids_[rhs]);
+					++cached_count_;
+				}
 			}
 		}
 	}
@@ -41,7 +51,15 @@ template <typename Space> class MatrixCache {
 	{
 		const auto lhs_position = position_of(lhs);
 		const auto rhs_position = position_of(rhs);
-		return matrix_[lhs_position * record_count_ + rhs_position];
+		auto &cached = matrix_[offset(lhs_position, rhs_position)];
+		if (cached.has_value()) {
+			++hits_;
+			return *cached;
+		}
+		++misses_;
+		cached = space_->distance(lhs, rhs);
+		++cached_count_;
+		return *cached;
 	}
 
 	auto record_count() const -> std::size_t { return record_count_; }
@@ -70,12 +88,14 @@ template <typename Space> class MatrixCache {
 	}
 	auto version() const -> std::size_t { return version_; }
 	auto is_stale() const -> bool { return space_->version() != version_; }
-	auto cached_distances() const -> std::size_t { return matrix_.size(); }
+	auto cached_distances() const -> std::size_t { return cached_count_; }
 
 	auto stats() const -> matrix_cache_stats
 	{
 		matrix_cache_stats result;
-		result.fill_ratio = 1.0;
+		result.hits = hits_;
+		result.misses = misses_;
+		result.fill_ratio = matrix_.empty() ? 1.0 : static_cast<double>(cached_count_) / static_cast<double>(matrix_.size());
 		result.symmetric_storage = false;
 		return result;
 	}
@@ -84,15 +104,17 @@ template <typename Space> class MatrixCache {
 	{
 		representation_diagnostics result{representation_kind::matrix_cache,
 										  exactness::exact,
-										  materialization::materialized,
+										  mode_ == matrix_cache_mode::eager ? materialization::materialized
+																			: materialization::lazy,
 										  update_mode::snapshot};
 		result.space_version = space_->version();
 		result.built_for_version = version_;
 		result.stale = is_stale();
 		result.records = record_count_;
-		result.distance_evaluations = matrix_.size();
-		result.cached_distances = matrix_.size();
-		result.memory_bytes_estimate = matrix_.size() * sizeof(distance_type) + ids_.size() * sizeof(RecordId);
+		result.distance_evaluations = cached_count_;
+		result.cached_distances = cached_count_;
+		result.memory_bytes_estimate = matrix_.size() * sizeof(std::optional<distance_type>) +
+									   ids_.size() * sizeof(RecordId);
 		if (result.stale) {
 			result.warnings.push_back("matrix cache was built for an older metric-space version");
 		}
@@ -100,6 +122,11 @@ template <typename Space> class MatrixCache {
 	}
 
   private:
+	auto offset(std::size_t lhs_position, std::size_t rhs_position) const -> std::size_t
+	{
+		return lhs_position * record_count_ + rhs_position;
+	}
+
 	auto validate_position(std::size_t position) const -> void
 	{
 		if (position >= record_count_) {
@@ -110,8 +137,12 @@ template <typename Space> class MatrixCache {
 	const space_type *space_;
 	std::size_t record_count_;
 	std::size_t version_;
+	matrix_cache_mode mode_;
 	std::vector<RecordId> ids_;
-	std::vector<distance_type> matrix_;
+	mutable std::vector<std::optional<distance_type>> matrix_;
+	mutable std::size_t cached_count_{};
+	mutable std::size_t hits_{};
+	mutable std::size_t misses_{};
 };
 
 } // namespace metric::representations

--- a/python/examples/engine/representation_swap.py
+++ b/python/examples/engine/representation_swap.py
@@ -1,0 +1,50 @@
+from metric import Edit, RuntimePolicy, Space
+
+
+def main():
+    records = ["metric", "metrics", "matrix", "tree"]
+    space = Space(records, metric=Edit(), name="string_edit_representation_swap")
+
+    query = "metricks"
+    implicit_neighbors = space.neighbors(query, count=2)
+    assert implicit_neighbors[0] == (1, 1)
+
+    matrix = space.to_matrix()
+    assert matrix.representation == "matrix"
+    assert matrix.distance(0, 1) == 1
+    assert matrix.distance(0, 2) == 2
+
+    tree = space.to_tree()
+    tree_neighbors = tree.neighbors(query, count=2)
+    assert tree_neighbors == implicit_neighbors
+
+    graph = space.to_graph(count=2)
+    graph_neighbors = graph.neighbors(0)
+    assert graph_neighbors[0] == (1, 1)
+    assert len(graph_neighbors) == 2
+
+    materialized_groups = space.groups(count=2, representation=matrix)
+    assert materialized_groups.representation == "matrix"
+    assert materialized_groups.cluster_count == 2
+
+    diagnostics = space.runtime_diagnostics(
+        representation=matrix,
+        runtime=RuntimePolicy(exact=True, cache="materialized"),
+        intent="representation_swap",
+    )
+    assert diagnostics.representation == "matrix"
+    assert diagnostics.policy_name == "exact_materialized_serial"
+
+    space.touch()
+    assert matrix.is_stale()
+    assert tree.is_stale()
+    assert graph.is_stale()
+
+    print("implicit nearest =", records[implicit_neighbors[0][0]], implicit_neighbors[0][1])
+    print("tree nearest =", records[tree_neighbors[0][0]], tree_neighbors[0][1])
+    print("graph neighbors from metric =", [records[index] for index, _distance in graph_neighbors])
+    print("runtime representation =", diagnostics.representation)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/core_smoke/engine_representations_smoke.cpp
+++ b/tests/core_smoke/engine_representations_smoke.cpp
@@ -45,6 +45,25 @@ int main()
 	assert(matrix_diagnostics.built_for_version == space.version());
 	assert(!matrix_diagnostics.stale);
 	assert(matrix.stats().fill_ratio == 1.0);
+	assert(matrix.stats().hits == 2);
+
+	metric::representations::MatrixCache<decltype(space)> lazy_matrix(
+		space, metric::representations::matrix_cache_mode::lazy);
+	assert(lazy_matrix.cached_distances() == 0);
+	const auto lazy_initial_diagnostics = lazy_matrix.diagnostics();
+	assert(lazy_initial_diagnostics.materialized == metric::representations::materialization::lazy);
+	assert(lazy_initial_diagnostics.cached_distances == 0);
+	assert(lazy_matrix.distance(id0, id2) == 5);
+	assert(lazy_matrix.cached_distances() == 1);
+	assert(lazy_matrix.distance(id0, id2) == 5);
+	assert(lazy_matrix.distance(id1, id3) == space.distance(id1, id3));
+	const auto lazy_stats = lazy_matrix.stats();
+	assert(lazy_stats.hits == 1);
+	assert(lazy_stats.misses == 2);
+	assert(lazy_stats.fill_ratio == 2.0 / static_cast<double>(space.size() * space.size()));
+	const auto lazy_diagnostics = lazy_matrix.diagnostics();
+	assert(lazy_diagnostics.cached_distances == 2);
+	assert(lazy_diagnostics.distance_evaluations == 2);
 
 	metric::representations::CoverTreeIndex<decltype(space)> tree(space);
 	static_assert(metric::NeighborSearchIndex_v<decltype(tree)>);
@@ -74,6 +93,10 @@ int main()
 	assert(graph_diagnostics.kind == metric::representations::representation_kind::knn_graph_index);
 	assert(graph_diagnostics.exact == metric::representations::exactness::approximate);
 	assert(graph.stats().edges == space.size());
+	const auto graph_recall_stats = graph.stats_against(matrix);
+	assert(graph_recall_stats.recall_validated);
+	assert(graph_recall_stats.sampled_recall == 1.0);
+	assert(graph.sampled_recall(matrix, 2) == 1.0);
 
 	metric::representations::GraphTopology<decltype(space)> topology(space);
 	static_assert(metric::GraphTopology_v<decltype(topology)>);
@@ -91,6 +114,7 @@ int main()
 
 	assert(!implicit.is_stale());
 	assert(!matrix.is_stale());
+	assert(!lazy_matrix.is_stale());
 	assert(!tree.is_stale());
 	assert(!graph.is_stale());
 	assert(!topology.is_stale());
@@ -100,11 +124,14 @@ int main()
 	assert(implicit.contains(inserted_id));
 	assert(implicit.position_of(inserted_id) == 4);
 	assert(matrix.is_stale());
+	assert(lazy_matrix.is_stale());
 	assert(tree.is_stale());
 	assert(graph.is_stale());
 	assert(topology.is_stale());
 	assert(matrix.diagnostics().stale);
+	assert(lazy_matrix.diagnostics().stale);
 	assert(!matrix.diagnostics().warnings.empty());
+	assert(!lazy_matrix.diagnostics().warnings.empty());
 
 	assert(matrix.distance(id1, id3) == 7);
 	assert(space.erase(id1));


### PR DESCRIPTION
## Summary
- add lazy `MatrixCache` mode with hit/miss/fill diagnostics while keeping eager mode as the default
- add explicit kNN graph sampled-recall validation against an exact distance provider
- add the missing promoted Python engine representation-swap example and document the representation diagnostics surface

## Verification
- `cmake --build --preset core --parallel 2`
- `./build/core/tests/core_smoke/engine_representations_smoke`
- `ctest --preset core --output-on-failure`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest discover -s python/tests/core`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`