### PR TITLE
Document Python strategy roadmap exports

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -47,6 +47,7 @@ The current local tree implements the first revival slice:
 - Python engine-style Space map intent for deterministic transforms into derived metric spaces
 - Python map facade accepts `transform=` and reports ambiguous or unavailable mapping forms deterministically
 - Python map facade accepts fresh explicit representations and records representation metadata
+- Python strategy facade exports `MDS`, `DiffusionEmbedding`, `PCFA`, `SOM`, and `PhateAE`, with `MDS` executing the promoted classical-MDS path and roadmap strategies raising explicit unavailable errors
 - Python engine-style Space denoise intent with DBSCAN-noise filtering and mapping-result lineage
 - Python describe facade accepts fresh explicit representations and records representation metadata
 - Python distance compatibility aliases expose `Manhattan`, `Minkowski`, and `ThresholdedEuclidean` when optional historical standard bindings are installed
@@ -338,6 +339,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - C++ engine compress intent backed by deterministic farthest-first representative compression with named `CompressionResult` objects, merged as `d6abef83b61d9e68f5d156884d09c525e8792bf6`
 - Python neighbor facade support for target `count` and `radius` intent arguments, merged as `e9dd23e217b12aeb8e6e85df612c55d78c66da50`
 - Python representation facade support for `Space.to_tree()` and `Space.to_graph(count=...)`, merged as `adb6222c2f311662678694fb3a92ee25052b89bd`
+- Python strategy facade exports for `MDS`, `DiffusionEmbedding`, `PCFA`, `SOM`, and `PhateAE`, with promoted-vs-roadmap strategy errors covered by wheel CI, merged as `6961fe0dc97185a03a5e48b35b5b32ddaa8423f6`
 - Python public exception facade with `UnsupportedOperationError` for unsupported inverse reconstruction, merged as `ec94ef66017733624e52465fb96bccbed13ae9c2`
 - C++ semantic `metric::count{...}` target argument support for `find_neighbors`, merged as `806eb4628770e89811a9c27205161d371a325c99`
 - Python representation freshness checks with deterministic stale representation errors, merged as `da591dcbd98d04a5541925170726429e17f836d0`


### PR DESCRIPTION
## Summary
- record the Python strategy roadmap exports merged in #546 in `docs/revival-status.md`
- add local-scope status for promoted `MDS` and explicit unavailable errors for roadmap strategy names

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`