### PR TITLE
Add Python notebook smoke path

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -60,6 +60,7 @@ python -m pip install --force-reinstall wheelhouse/*.whl
 for example in python/examples/metric_space/*.py python/examples/engine/*.py; do
   python "$example"
 done
+python python/notebooks/smoke_notebooks.py
 PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s python/tests/core -v
 ```
 

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -48,6 +48,7 @@ The Python core wheel path covers:
 - deterministic representative-selection, medoid, separated-representative, and radius-coverage regression values for histogram transport, time-series alignment, and structured mixed-record callables
 - promoted Python examples for strings, structured records, time-series alignment, histogram transport, representative selection, and engine flagship workflows
 - subprocess execution of every `python/examples/metric_space/*.py` and `python/examples/engine/*.py` example from the core Python API tests, so PyPI cibuildwheel tests cover the same promoted examples even when the workflow invokes only the core test suite directly
+- promoted Python notebooks under `python/notebooks/`, executed by `python/notebooks/smoke_notebooks.py` from the core Python API tests without requiring Jupyter in CI
 
 ## Extended and Historical Tests
 

--- a/python/README.md
+++ b/python/README.md
@@ -107,6 +107,10 @@ print("nearest:", space.neighbors("cut", 2))
 
 The core-wheel example is also available at `examples/metric_space/string_edit_space.py`. Full correlation, mapping, and standard-distance examples remain part of the broader restoration path until their bindings are promoted into the default wheel.
 
+Small tutorial notebooks live under `notebooks/`. They are paired with
+`notebooks/smoke_notebooks.py`, which executes their code cells in CI after the
+wheel is installed.
+
 `metric.mappings` and `metric.transforms` are importable beta namespaces. They expose `available()` and `legacy_module()` so callers can inspect whether a wheel includes the broader legacy bindings without making those bindings part of the core-wheel contract.
 
 ## NumPy records

--- a/python/notebooks/00_strings_as_metric_space.ipynb
+++ b/python/notebooks/00_strings_as_metric_space.ipynb
@@ -1,0 +1,149 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Strings As Metric Space\n",
+        "\n",
+        "Audience:\n",
+        "- Python users who want to model records directly as a finite metric space.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Basic Python lists and functions.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Build a `Space` over strings.\n",
+        "- Query nearest neighbors without creating vectors.\n",
+        "- Inspect the pairwise distance matrix."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the public facade.\n",
+        "2. Build a string metric space.\n",
+        "3. Ask a nearest-neighbor question.\n",
+        "4. Inspect pairwise distances.\n",
+        "5. Try a small exercise."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric import Space\n",
+        "from metric import metrics\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Build the space\n",
+        "\n",
+        "The records stay as strings. Edit distance supplies the geometry."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "records = [\"metric\", \"metrics\", \"matrix\", \"tree\"]\n",
+        "space = Space(records, metrics.Edit())\n",
+        "\n",
+        "assert space.distance(0, 1) == 1\n",
+        "space.ids\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - Query neighbors\n",
+        "\n",
+        "The query is another string; no embedding or tokenization step is required."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "neighbors = space.neighbors(\"metricks\", count=2)\n",
+        "nearest_name = records[neighbors[0][0]]\n",
+        "\n",
+        "assert nearest_name == \"metrics\"\n",
+        "assert neighbors[0][1] == 1\n",
+        "(nearest_name, neighbors)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Inspect distances\n",
+        "\n",
+        "`pairwise()` gives the finite metric-space matrix for small spaces."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "matrix = space.pairwise()\n",
+        "\n",
+        "assert matrix[0][0] == 0\n",
+        "assert matrix[0][1] == matrix[1][0]\n",
+        "matrix\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Change the query to `metrix` and predict whether `metric` or `metrics` is closer.\n",
+        "\n",
+        "Common pitfall: comparing record positions instead of record IDs. Use the returned ID to index `records` only when IDs are the default integer IDs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "exercise_neighbors = space.neighbors(\"metrix\", count=2)\n",
+        "answer = records[exercise_neighbors[0][0]]\n",
+        "\n",
+        "assert answer == \"metric\"\n",
+        "answer\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/notebooks/01_dataframe_records_custom_metric.ipynb
+++ b/python/notebooks/01_dataframe_records_custom_metric.ipynb
@@ -1,0 +1,167 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: DataFrame Records With Custom Metric\n",
+        "\n",
+        "Audience:\n",
+        "- Python users with tabular or record-shaped data.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Dictionaries and callable functions.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Load DataFrame-like records with stable IDs.\n",
+        "- Define a domain metric over row dictionaries.\n",
+        "- Query records by ID and position."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the public facade.\n",
+        "2. Define a tiny DataFrame-like object.\n",
+        "3. Build a custom metric over rows.\n",
+        "4. Query distances and stable IDs.\n",
+        "5. Try a small exercise."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric import Space\n",
+        "from metric import metrics\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Define records\n",
+        "\n",
+        "The facade only needs an object with `to_dict(\"records\")`, so this example avoids a pandas dependency."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "class DataFrameLike:\n",
+        "    def __init__(self, rows):\n",
+        "        self._rows = list(rows)\n",
+        "\n",
+        "    def to_dict(self, orient):\n",
+        "        if orient != \"records\":\n",
+        "            raise ValueError(orient)\n",
+        "        return list(self._rows)\n",
+        "\n",
+        "rows = [\n",
+        "    {\"sample_id\": \"pump-a\", \"temperature\": 62.0, \"state\": \"idle\"},\n",
+        "    {\"sample_id\": \"pump-b\", \"temperature\": 65.0, \"state\": \"idle\"},\n",
+        "    {\"sample_id\": \"valve-c\", \"temperature\": 82.0, \"state\": \"alarm\"},\n",
+        "]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - Define a row metric\n",
+        "\n",
+        "The metric can combine numeric and categorical fields in domain units."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def equipment_distance(lhs, rhs):\n",
+        "    state_penalty = 0.0 if lhs[\"state\"] == rhs[\"state\"] else 10.0\n",
+        "    return abs(lhs[\"temperature\"] - rhs[\"temperature\"]) + state_penalty\n",
+        "\n",
+        "space = Space.from_dataframe(\n",
+        "    DataFrameLike(rows),\n",
+        "    metric=equipment_distance,\n",
+        "    id_column=\"sample_id\",\n",
+        "    name=\"equipment\",\n",
+        ")\n",
+        "\n",
+        "assert space.ids == [\"pump-a\", \"pump-b\", \"valve-c\"]\n",
+        "assert space.record(\"pump-a\") == {\"temperature\": 62.0, \"state\": \"idle\"}\n",
+        "space.name\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Query distances by stable ID\n",
+        "\n",
+        "Stable IDs make examples readable and keep record order separate from identity."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "distances = space.pairwise(ids=[\"pump-a\", \"valve-c\"])\n",
+        "\n",
+        "assert distances == [[0.0, 30.0], [30.0, 0.0]]\n",
+        "space.neighbors(space.record(\"pump-b\"), count=1)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Add another idle pump and check that it is closer to `pump-b` than `valve-c` is.\n",
+        "\n",
+        "Common pitfall: leaving the ID column in the row metric. `from_dataframe(..., id_column=...)` removes it from records before the metric sees them."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "extended_rows = rows + [{\"sample_id\": \"pump-d\", \"temperature\": 66.0, \"state\": \"idle\"}]\n",
+        "extended = Space.from_dataframe(DataFrameLike(extended_rows), metric=equipment_distance, id_column=\"sample_id\")\n",
+        "query_record = {\"temperature\": 66.5, \"state\": \"idle\"}\n",
+        "nearest = extended.neighbors(query_record, count=1)\n",
+        "\n",
+        "assert extended.ids[nearest[0][0]] == \"pump-d\"\n",
+        "nearest\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/notebooks/02_neighbors_groups_outliers.ipynb
+++ b/python/notebooks/02_neighbors_groups_outliers.ipynb
@@ -1,0 +1,149 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Neighbors Groups Outliers\n",
+        "\n",
+        "Audience:\n",
+        "- Python users exploring common metric-space intents.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Basic `Space` construction.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Run neighbor, grouping, and outlier intents.\n",
+        "- Use semantic arguments instead of algorithm names.\n",
+        "- Read named result metadata."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the public facade.\n",
+        "2. Build a finite string space.\n",
+        "3. Query neighbors.\n",
+        "4. Find groups and outliers.\n",
+        "5. Try a small exercise."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric import Space\n",
+        "from metric import metrics\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Build a toy space\n",
+        "\n",
+        "The records include two close spelling families and one distant outlier."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "records = [\"cat\", \"cot\", \"coat\", \"dog\", \"dogs\", \"catalog\"]\n",
+        "space = Space(records, metrics.Edit())\n",
+        "\n",
+        "assert len(space) == 6\n",
+        "space.pairwise(ids=[0, 1, 2])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - Ask for neighbors\n",
+        "\n",
+        "`count=` states the intent without choosing an index implementation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "near_cut = space.neighbors(\"cut\", count=3)\n",
+        "labels = [records[record_id] for record_id, _ in near_cut]\n",
+        "\n",
+        "assert labels[:2] == [\"cat\", \"cot\"]\n",
+        "labels\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Find groups and outliers\n",
+        "\n",
+        "Default grouping and outlier scoring are deterministic for small examples."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "groups = space.groups(count=2)\n",
+        "outliers = space.outliers(count=2)\n",
+        "\n",
+        "assert groups.cluster_count == 2\n",
+        "assert len(outliers.outliers) == 2\n",
+        "(groups.algorithm, groups.cluster_sizes, [(item.record_id, item.score) for item in outliers.outliers])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Use a radius query around `cat` and compare it with the nearest-neighbor query.\n",
+        "\n",
+        "Common pitfall: radius and count answer different questions. Radius asks for all records within a threshold; count asks for the best N records."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "within_one = space.neighbors(\"cat\", radius=1)\n",
+        "within_one_labels = [records[record_id] for record_id, _ in within_one]\n",
+        "\n",
+        "assert within_one_labels == [\"cat\", \"cot\", \"coat\"]\n",
+        "within_one_labels\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/notebooks/03_embed_map_denoise.ipynb
+++ b/python/notebooks/03_embed_map_denoise.ipynb
@@ -1,0 +1,175 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Embed Map Denoise\n",
+        "\n",
+        "Audience:\n",
+        "- Python users who want derived views of a metric space.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Callable metrics and simple Python records.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Embed a one-dimensional finite metric space.\n",
+        "- Map records into a derived metric space.\n",
+        "- Denoise by removing isolated records."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the public facade.\n",
+        "2. Build a numeric process space.\n",
+        "3. Embed records into coordinates.\n",
+        "4. Map records into structured records.\n",
+        "5. Denoise a space."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric import Space\n",
+        "from metric import metrics\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Build a numeric metric space\n",
+        "\n",
+        "A plain absolute-distance callable is enough for this tiny process summary."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "records = [0, 1, 2, 10, 11]\n",
+        "space = Space(records, metric=lambda lhs, rhs: abs(lhs - rhs))\n",
+        "\n",
+        "assert space.distance(0, 4) == 11\n",
+        "space.neighbors(1, count=2)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - Embed\n",
+        "\n",
+        "The promoted Python embedding path returns named diagnostics and a derived coordinate space."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "embedding = space.embed(dimensions=1)\n",
+        "\n",
+        "assert embedding.operator_name == \"embed\"\n",
+        "assert embedding.strategy == \"classic_mds\"\n",
+        "assert embedding.coordinates.shape == (5, 1)\n",
+        "assert embedding.diagnostics.finite_coordinates\n",
+        "(embedding.stress, embedding.trustworthiness)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Map into derived records\n",
+        "\n",
+        "`map` preserves source lineage while changing record shape."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "mapped = space.map(\n",
+        "    transform=lambda value: {\"value\": value, \"bucket\": \"high\" if value >= 10 else \"low\"},\n",
+        "    metric=lambda lhs, rhs: abs(lhs[\"value\"] - rhs[\"value\"]),\n",
+        ")\n",
+        "\n",
+        "assert mapped.source_record_ids == (0, 1, 2, 3, 4)\n",
+        "assert mapped.space.records[0][\"bucket\"] == \"low\"\n",
+        "mapped.strategy\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4 - Denoise\n",
+        "\n",
+        "The default denoise path removes records selected by the default outlier score."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "denoised = space.denoise(count=1)\n",
+        "\n",
+        "assert denoised.operator_name == \"denoise\"\n",
+        "assert denoised.source_record_count == 5\n",
+        "assert denoised.target_record_count == 4\n",
+        "denoised.space.records\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Change `count=1` to `count=2` and inspect which source records remain.\n",
+        "\n",
+        "Common pitfall: denoising is lossy. Use `result.source_record_ids` to keep lineage for downstream analysis."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "more_denoised = space.denoise(count=2)\n",
+        "\n",
+        "assert more_denoised.target_record_count == 3\n",
+        "more_denoised.source_record_ids\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/notebooks/04_compare_aligned_spaces.ipynb
+++ b/python/notebooks/04_compare_aligned_spaces.ipynb
@@ -1,0 +1,161 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Compare Aligned Spaces\n",
+        "\n",
+        "Audience:\n",
+        "- Python users comparing two views over the same observations.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Stable record IDs and callable metrics.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Compare spaces by position and by IDs.\n",
+        "- Handle reordered observations.\n",
+        "- Read correlation result metadata."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the public facade.\n",
+        "2. Build two aligned spaces.\n",
+        "3. Compare by position.\n",
+        "4. Compare by stable IDs.\n",
+        "5. Try a small exercise."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric import Space\n",
+        "from metric import metrics\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Build source and quality spaces\n",
+        "\n",
+        "Both spaces describe the same observations with different record values."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "ids = [\"run-a\", \"run-b\", \"run-c\", \"run-d\"]\n",
+        "process = Space([0, 1, 2, 3], metric=lambda lhs, rhs: abs(lhs - rhs), ids=ids)\n",
+        "quality = Space([0, 1, 4, 9], metric=lambda lhs, rhs: abs(lhs - rhs), ids=ids)\n",
+        "\n",
+        "assert process.ids == quality.ids\n",
+        "process.compare(quality).pair_count\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - Compare by position\n",
+        "\n",
+        "The default compares records in their current order."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "position_result = process.compare(quality)\n",
+        "\n",
+        "assert position_result.left_record_count == 4\n",
+        "assert position_result.right_record_count == 4\n",
+        "assert position_result.algorithm == \"distance_profile_correlation\"\n",
+        "round(position_result.value, 6)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Compare by IDs\n",
+        "\n",
+        "ID alignment keeps the comparison stable even when the right-hand space is reordered."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "shuffled_quality = Space(\n",
+        "    [9, 0, 4, 1],\n",
+        "    metric=lambda lhs, rhs: abs(lhs - rhs),\n",
+        "    ids=[\"run-d\", \"run-a\", \"run-c\", \"run-b\"],\n",
+        ")\n",
+        "\n",
+        "id_result = process.compare(shuffled_quality, align=\"ids\")\n",
+        "position_mismatch = process.compare(shuffled_quality, align=\"position\")\n",
+        "\n",
+        "assert round(id_result.value, 12) == round(position_result.value, 12)\n",
+        "assert round(position_mismatch.value, 12) != round(position_result.value, 12)\n",
+        "(id_result.value, position_mismatch.value)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Remove one ID from `shuffled_quality` and confirm that ID alignment fails.\n",
+        "\n",
+        "Common pitfall: `align=\"ids\"` requires both spaces to contain exactly the same IDs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "mismatched = Space([0, 1, 4], metric=lambda lhs, rhs: abs(lhs - rhs), ids=[\"run-a\", \"run-b\", \"run-x\"])\n",
+        "\n",
+        "try:\n",
+        "    process.compare(mismatched, align=\"ids\")\n",
+        "except Exception as exc:\n",
+        "    message = str(exc)\n",
+        "\n",
+        "assert \"same ids\" in message\n",
+        "message\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/notebooks/05_strategy_overrides.ipynb
+++ b/python/notebooks/05_strategy_overrides.ipynb
@@ -1,0 +1,161 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Strategy Overrides\n",
+        "\n",
+        "Audience:\n",
+        "- Python users who need explicit expert strategy choices.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Familiarity with the intent methods from the earlier notebooks.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Import strategies only from `metric.strategies`.\n",
+        "- Override grouping and embedding strategies.\n",
+        "- Recognize roadmap strategy errors."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the public facade.\n",
+        "2. Build a small space.\n",
+        "3. Use promoted strategy overrides.\n",
+        "4. Inspect roadmap-only strategy errors.\n",
+        "5. Try a small exercise."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric import Space\n",
+        "from metric import metrics\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - Build the same kind of space\n",
+        "\n",
+        "The first code cell intentionally imported no algorithm names."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "records = [\"cat\", \"cot\", \"coat\", \"dog\", \"dogs\"]\n",
+        "space = Space(records, metrics.Edit())\n",
+        "\n",
+        "assert space.neighbors(\"cut\", count=2)[0][0] == 0\n",
+        "len(space)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - Import strategies in the expert section\n",
+        "\n",
+        "Algorithm names live under `metric.strategies`, not at the first level of the tutorial."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from metric.exceptions import StrategyUnavailableError\n",
+        "from metric.strategies import DiffusionEmbedding, KMedoids, MDS, PCFA, SOM\n",
+        "\n",
+        "explicit_groups = space.groups(strategy=KMedoids(groups=2))\n",
+        "explicit_embedding = space.embed(strategy=MDS(dimensions=2))\n",
+        "\n",
+        "assert explicit_groups.algorithm == \"kmedoids\"\n",
+        "assert explicit_embedding.strategy == \"classic_mds\"\n",
+        "(explicit_groups.cluster_count, explicit_embedding.dimensions)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Roadmap strategies fail explicitly\n",
+        "\n",
+        "Importable strategy names can be part of stable documentation before their numerical contracts are promoted."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "roadmap_errors = []\n",
+        "for strategy in (DiffusionEmbedding(dimensions=2),):\n",
+        "    try:\n",
+        "        space.embed(strategy=strategy)\n",
+        "    except StrategyUnavailableError as exc:\n",
+        "        roadmap_errors.append(str(exc))\n",
+        "\n",
+        "for strategy in (PCFA(dimensions=2), SOM(grid=(2, 2))):\n",
+        "    try:\n",
+        "        space.reduce(strategy=strategy)\n",
+        "    except StrategyUnavailableError as exc:\n",
+        "        roadmap_errors.append(str(exc))\n",
+        "\n",
+        "assert len(roadmap_errors) == 3\n",
+        "roadmap_errors\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Change `KMedoids(groups=2)` to `KMedoids(groups=3)` and inspect the medoid IDs.\n",
+        "\n",
+        "Common pitfall: importing algorithms from compatibility modules in new examples. New expert examples should import strategy names only from `metric.strategies`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "three_groups = space.groups(strategy=KMedoids(groups=3))\n",
+        "\n",
+        "assert three_groups.cluster_count == 3\n",
+        "three_groups.medoids\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/python/notebooks/smoke_notebooks.py
+++ b/python/notebooks/smoke_notebooks.py
@@ -1,0 +1,80 @@
+"""Execute the promoted Python notebooks without requiring Jupyter.
+
+The notebook smoke path intentionally uses only the standard library. CI builds
+and installs the wheel first, then this script executes each notebook code cell
+in order in an isolated namespace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+NOTEBOOK_DIR = Path(__file__).resolve().parent
+REQUIRED_NOTEBOOKS = (
+    "00_strings_as_metric_space.ipynb",
+    "01_dataframe_records_custom_metric.ipynb",
+    "02_neighbors_groups_outliers.ipynb",
+    "03_embed_map_denoise.ipynb",
+    "04_compare_aligned_spaces.ipynb",
+    "05_strategy_overrides.ipynb",
+)
+FIRST_CODE_CELL = "from metric import Space\nfrom metric import metrics\n"
+
+
+def _source(cell):
+    source = cell.get("source", "")
+    if isinstance(source, list):
+        return "".join(source)
+    return str(source)
+
+
+def _code_cells(notebook):
+    return [cell for cell in notebook.get("cells", []) if cell.get("cell_type") == "code"]
+
+
+def _validate_notebook(path, notebook):
+    if notebook.get("nbformat") != 4:
+        raise AssertionError(f"{path.name}: expected nbformat 4")
+
+    cells = notebook.get("cells")
+    if not isinstance(cells, list) or not cells:
+        raise AssertionError(f"{path.name}: notebook has no cells")
+
+    code_cells = _code_cells(notebook)
+    if not code_cells:
+        raise AssertionError(f"{path.name}: notebook has no code cells")
+
+    first_source = _source(code_cells[0])
+    if first_source != FIRST_CODE_CELL:
+        raise AssertionError(f"{path.name}: first code cell must import only Space and metrics")
+
+    for index, cell in enumerate(code_cells, start=1):
+        if cell.get("outputs") not in ([], None):
+            raise AssertionError(f"{path.name}: code cell {index} must not store outputs")
+
+        source = _source(cell)
+        if "metric.strategies" in source and path.name != "05_strategy_overrides.ipynb":
+            raise AssertionError(f"{path.name}: strategy imports belong in 05_strategy_overrides.ipynb")
+
+
+def _execute_notebook(path, notebook):
+    namespace = {"__name__": f"metric_notebook_{path.stem}"}
+    for index, cell in enumerate(_code_cells(notebook), start=1):
+        source = _source(cell)
+        exec(compile(source, f"{path}:cell-{index}", "exec"), namespace)
+
+
+def main():
+    for filename in REQUIRED_NOTEBOOKS:
+        path = NOTEBOOK_DIR / filename
+        with path.open("r", encoding="utf-8") as handle:
+            notebook = json.load(handle)
+        _validate_notebook(path, notebook)
+        _execute_notebook(path, notebook)
+        print(f"notebook smoke ok: {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -423,6 +423,18 @@ class RevivalApiTest(unittest.TestCase):
                 )
                 self.assertEqual(result.returncode, 0, result.stdout)
 
+    def test_promoted_notebooks_run(self):
+        smoke_script = Path(__file__).resolve().parents[2] / "notebooks" / "smoke_notebooks.py"
+        result = subprocess.run(
+            [sys.executable, str(smoke_script)],
+            check=False,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+
     def test_finite_metric_space_caches_pairwise_distances(self):
         space = FiniteMetricSpace(self.records, self.metric)
 


### PR DESCRIPTION
## Summary
- add the six required Python tutorial notebooks from the UX plan under `python/notebooks/`
- add a standard-library notebook smoke runner that validates first imports, empty outputs, strategy-import placement, and executes each code cell
- wire the smoke runner into the existing Python core API tests so the current Python core wheel CI runs the notebooks without changing workflow permissions
- document the notebook smoke path in the Python README, testing docs, and release checklist

## Verification
- `rm -rf /tmp/metric-python-overlay && mkdir -p /tmp/metric-python-overlay && cp -R python/pkg/metric /tmp/metric-python-overlay/metric && cp -R build/python-venv/lib/python3.12/site-packages/metric/_impl/. /tmp/metric-python-overlay/metric/_impl/. && PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/metric-python-overlay build/python-venv/bin/python python/notebooks/smoke_notebooks.py`
- `rm -rf /tmp/metric-python-overlay && mkdir -p /tmp/metric-python-overlay && cp -R python/pkg/metric /tmp/metric-python-overlay/metric && cp -R build/python-venv/lib/python3.12/site-packages/metric/_impl/. /tmp/metric-python-overlay/metric/_impl/. && PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/metric-python-overlay build/python-venv/bin/python -m unittest discover -s python/tests/core`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`
- `git diff --check`