### PR TITLE
Add vector space special-case engine demo

### DIFF
--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -24,10 +24,11 @@ The first implementation slices are documented in [Engine Mental Model](mental-m
 ## Flagship Examples
 
 The first CI-tested engine demos live under `examples/engine/` and `python/examples/engine/`.
-They start with non-vector records and use the engine vocabulary directly:
+They use the engine vocabulary directly across native metric spaces and the vector special case:
 
 - strings with edit distance for neighbor search and grouping
 - process curves with an alignment metric, representative selection, and graph construction
+- vectors with Euclidean distance as one record type among others
 - histograms with cumulative transport distance, matrix materialization, and grouping
 - cross-space dependency over two aligned finite metric spaces
 

--- a/examples/engine/CMakeLists.txt
+++ b/examples/engine/CMakeLists.txt
@@ -4,6 +4,9 @@ target_link_libraries(engine_strings_edit_space PRIVATE ${METRIC_TARGET_NAME})
 add_executable(engine_process_curves_space process_curves_space.cpp)
 target_link_libraries(engine_process_curves_space PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_vector_space_special_case vector_space_special_case.cpp)
+target_link_libraries(engine_vector_space_special_case PRIVATE ${METRIC_TARGET_NAME})
+
 add_executable(engine_histogram_transport_space histogram_transport_space.cpp)
 target_link_libraries(engine_histogram_transport_space PRIVATE ${METRIC_TARGET_NAME})
 
@@ -19,6 +22,7 @@ target_link_libraries(engine_phate_autoencoder_map PRIVATE ${METRIC_TARGET_NAME}
 if (BUILD_TESTING)
     add_test(NAME example_engine_strings_edit_space COMMAND engine_strings_edit_space)
     add_test(NAME example_engine_process_curves_space COMMAND engine_process_curves_space)
+    add_test(NAME example_engine_vector_space_special_case COMMAND engine_vector_space_special_case)
     add_test(NAME example_engine_histogram_transport_space COMMAND engine_histogram_transport_space)
     add_test(NAME example_engine_cross_space_mgc COMMAND engine_cross_space_mgc)
     add_test(NAME example_engine_representation_swap COMMAND engine_representation_swap)

--- a/examples/engine/vector_space_special_case.cpp
+++ b/examples/engine/vector_space_special_case.cpp
@@ -1,0 +1,149 @@
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <metric/distance.hpp>
+#include <metric/engine.hpp>
+
+namespace {
+
+using Point = std::vector<double>;
+
+auto metric_law_name(metric::metric_law law) -> std::string
+{
+    switch (law) {
+    case metric::metric_law::distance:
+        return "distance";
+    case metric::metric_law::metric:
+        return "metric";
+    case metric::metric_law::pseudo_metric:
+        return "pseudo_metric";
+    case metric::metric_law::unknown:
+        return "unknown";
+    }
+    return "unknown";
+}
+
+auto record_kind_name(metric::record_kind kind) -> std::string
+{
+    switch (kind) {
+    case metric::record_kind::custom:
+        return "custom";
+    case metric::record_kind::vector:
+        return "vector";
+    case metric::record_kind::aligned_vector:
+        return "aligned_vector";
+    case metric::record_kind::string:
+        return "string";
+    case metric::record_kind::sequence:
+        return "sequence";
+    case metric::record_kind::structured:
+        return "structured";
+    }
+    return "custom";
+}
+
+auto close(double lhs, double rhs) -> bool
+{
+    return std::fabs(lhs - rhs) < 1e-9;
+}
+
+} // namespace
+
+int main()
+{
+    static_assert(metric::metric_traits<metric::Euclidean<double>>::law == metric::metric_law::metric,
+                  "Euclidean distance should satisfy the metric law");
+    static_assert(metric::metric_traits<metric::Euclidean<double>>::records == metric::record_kind::aligned_vector,
+                  "Euclidean vector records should be inspectable as aligned vectors");
+
+    const std::vector<std::string> names = {
+        "alpha-0", "alpha-1", "alpha-2", "beta-0", "beta-1", "beta-2", "gamma-0", "gamma-1", "outlier"};
+    const std::vector<Point> records = {
+        {0.0, 0.0},  {0.3, 0.2},  {0.2, -0.1}, {5.0, 5.0},  {5.2, 4.9},
+        {4.8, 5.1},  {-4.0, 4.0}, {-4.2, 4.1}, {10.0, -5.0},
+    };
+
+    auto space = metric::make_space(records, metric::Euclidean<double>{});
+    assert(space.size() == records.size());
+
+    metric::representations::MatrixCache<decltype(space)> matrix(space);
+    assert(close(matrix.distance(space.id(0), space.id(1)), std::sqrt(0.13)));
+
+    metric::representations::CoverTreeIndex<decltype(space)> tree(space);
+    const Point query = {0.1, 0.1};
+    const auto tree_neighbors = tree.knn(query, 3);
+    assert(tree_neighbors.size() == 3);
+    assert(tree_neighbors[0].id == space.id(0));
+
+    const auto implicit_neighbors = metric::find_neighbors(space, query, metric::count{3});
+    assert(implicit_neighbors.representation == "metric_space");
+    assert(implicit_neighbors[0].id == tree_neighbors[0].id);
+
+    const auto exact_diagnostics = metric::runtime::diagnostics_for_space(space, metric::runtime::exact(), {}, "neighbors");
+    assert(exact_diagnostics.policy_name == "exact_lazy_serial");
+    assert(exact_diagnostics.representation == "metric_space");
+    assert(exact_diagnostics.supported);
+
+    const auto indexed_neighbors =
+        metric::find_neighbors(space, query, metric::count{3}, metric::strategies::cover_tree{});
+    assert(indexed_neighbors.representation == "cover_tree_index");
+    assert(indexed_neighbors[0].id == tree_neighbors[0].id);
+    const auto indexed_diagnostics =
+        metric::runtime::diagnostics_for_space(space, metric::runtime::exact(), indexed_neighbors.representation,
+                                               "neighbors");
+    assert(indexed_diagnostics.representation == "cover_tree_index");
+
+    metric::representations::KnnGraphIndex<decltype(space)> graph(space, 2);
+    const auto graph_stats = graph.stats_against(matrix, 4);
+    assert(graph_stats.nodes == records.size());
+    assert(graph_stats.recall_validated);
+    assert(close(graph_stats.sampled_recall, 1.0));
+
+    const auto materialized_policy = metric::runtime::materialized(metric::runtime::exact());
+    const auto materialized_neighbors = metric::find_neighbors(space, space.id(0), metric::count{3}, materialized_policy);
+    assert(materialized_neighbors.representation == "matrix_cache");
+
+    const auto groups = metric::find_groups(space, metric::strategies::k_medoids(3), materialized_policy);
+    assert(groups.algorithm == "kmedoids");
+    assert(groups.cluster_count == 3);
+    assert(groups.record_count == records.size());
+    assert(groups.representation == "matrix_cache");
+
+    const auto outliers = metric::find_outliers(space, metric::strategies::dbscan(0.7, 2), materialized_policy);
+    assert(outliers.strategy == "dbscan_noise");
+    assert(outliers.noise_count == 1);
+    assert(outliers.outliers.front().id == space.id(8));
+    assert(outliers.representation == "matrix_cache");
+
+    const auto mapped = metric::map(
+        space,
+        [](const Point &record) -> Point {
+            return {record[0] / 10.0, record[1] / 10.0};
+        },
+        metric::Euclidean<double>{});
+    assert(mapped.mapping == "deterministic_transform");
+    assert(mapped.strategy == "deterministic_transform");
+    assert(mapped.space.size() == space.size());
+    assert(mapped.space.record(mapped.space.id(0)).size() == 2);
+
+    std::cout << "record_kind = " << record_kind_name(metric::metric_traits<metric::Euclidean<double>>::records) << "\n";
+    std::cout << "metric_law = " << metric_law_name(metric::metric_traits<metric::Euclidean<double>>::law) << "\n";
+    std::cout << "vector dimension metadata = " << records.front().size() << "\n";
+    std::cout << "available representations = metric_space,matrix_cache,cover_tree_index,knn_graph_index\n";
+    std::cout << "nearest vector = " << names[implicit_neighbors[0].id.index()] << " at "
+              << implicit_neighbors[0].distance << "\n";
+    std::cout << "indexed nearest = " << names[indexed_neighbors[0].id.index()] << " via "
+              << indexed_neighbors.representation << "\n";
+    std::cout << "runtime policy = " << exact_diagnostics.policy_name << " via "
+              << exact_diagnostics.representation << "\n";
+    std::cout << "matrix cache reuse = " << groups.representation << "," << outliers.representation << "\n";
+    std::cout << "vector groups = " << groups.cluster_count << "\n";
+    std::cout << "vector outlier = " << names[outliers.outliers.front().id.index()] << " score "
+              << outliers.outliers.front().score << "\n";
+    std::cout << "mapped vector dimensions = " << mapped.space.record(mapped.space.id(0)).size() << "\n";
+
+    return 0;
+}

--- a/metric/core/metric_traits.hpp
+++ b/metric/core/metric_traits.hpp
@@ -17,6 +17,7 @@ enum class metric_law {
 enum class record_kind {
 	custom,
 	vector,
+	aligned_vector,
 	string,
 	sequence,
 	structured,

--- a/metric/distance/k-related/Standards.hpp
+++ b/metric/distance/k-related/Standards.hpp
@@ -12,6 +12,8 @@ Copyright (c) 2018 Michael Welsch
 #include <type_traits>
 #include <vector>
 
+#include "../../core/metric_traits.hpp"
+
 namespace metric {
 
 /**
@@ -56,6 +58,20 @@ template <typename V = double> struct Euclidean {
 	template <template <typename, bool> class Container, typename ValueType, bool F> // detect Blaze object by signature
 	double operator()(const Container<ValueType, F> &a, const Container<ValueType, F> &b) const;
 };
+
+} // namespace metric
+
+namespace metric::core {
+
+template <typename V> struct metric_traits<::metric::Euclidean<V>> {
+	static constexpr auto law = metric_law::metric;
+	static constexpr auto records = record_kind::aligned_vector;
+	static constexpr bool thread_safe = true;
+};
+
+} // namespace metric::core
+
+namespace metric {
 
 /**
  * @class Manhatten

--- a/python/examples/engine/vector_space_special_case.py
+++ b/python/examples/engine/vector_space_special_case.py
@@ -1,0 +1,110 @@
+from math import sqrt
+
+from metric import RuntimePolicy, Space
+from metric.strategies import DBSCAN, KMedoids, MDS
+
+
+def euclidean(lhs, rhs):
+    return sqrt(sum((left - right) ** 2 for left, right in zip(lhs, rhs)))
+
+
+def main():
+    names = [
+        "alpha-0",
+        "alpha-1",
+        "alpha-2",
+        "beta-0",
+        "beta-1",
+        "beta-2",
+        "gamma-0",
+        "gamma-1",
+        "outlier",
+    ]
+    records = [
+        (0.0, 0.0),
+        (0.3, 0.2),
+        (0.2, -0.1),
+        (5.0, 5.0),
+        (5.2, 4.9),
+        (4.8, 5.1),
+        (-4.0, 4.0),
+        (-4.2, 4.1),
+        (10.0, -5.0),
+    ]
+    query = (0.1, 0.1)
+
+    metadata = {
+        "record_kind": "aligned_vector",
+        "metric_law": "metric",
+        "dimensions": len(records[0]),
+        "representations": ("metric_space", "matrix", "exact_tree_index", "exact_knn_graph"),
+    }
+    space = Space(records, metric=euclidean, name="vector_space_special_case", metadata=metadata)
+    assert space.metadata["record_kind"] == "aligned_vector"
+    assert space.metadata["metric_law"] == "metric"
+    assert space.metadata["dimensions"] == 2
+
+    matrix = space.to_matrix()
+    assert round(matrix.distance(0, 1), 12) == round(sqrt(0.13), 12)
+
+    implicit_neighbors = space.neighbors(query, count=3)
+    assert names[implicit_neighbors[0][0]] == "alpha-0"
+
+    tree = space.to_tree()
+    tree_neighbors = tree.neighbors(query, count=3)
+    assert tree_neighbors == implicit_neighbors
+
+    graph = space.to_graph(count=2)
+    graph_neighbors = graph.neighbors(0)
+    assert len(graph_neighbors) == 2
+    assert names[graph_neighbors[0][0]].startswith("alpha")
+
+    groups = space.groups(strategy=KMedoids(groups=3), representation=matrix)
+    assert groups.algorithm == "kmedoids"
+    assert groups.cluster_count == 3
+    assert groups.representation == "matrix"
+
+    outliers = space.outliers(strategy=DBSCAN(radius=0.7, min_points=2), representation=matrix)
+    assert outliers.strategy == "dbscan_noise"
+    assert outliers.noise_count == 1
+    assert names[outliers.outliers[0].record_id] == "outlier"
+
+    embedding = space.embed(strategy=MDS(dimensions=2), representation=matrix)
+    assert embedding.strategy == "classic_mds"
+    assert embedding.dimensions == 2
+    assert embedding.coordinates.shape == (len(records), 2)
+
+    diagnostics = space.runtime_diagnostics(
+        representation=matrix,
+        runtime=RuntimePolicy(exact=True, cache="materialized"),
+        intent="vector_space_special_case",
+    )
+    assert diagnostics.representation == "matrix"
+
+    exact_diagnostics = space.runtime_diagnostics(
+        runtime=RuntimePolicy(exact=True, cache="lazy"),
+        intent="neighbors",
+    )
+    tree_diagnostics = space.runtime_diagnostics(
+        representation=tree,
+        runtime=RuntimePolicy(exact=True, cache="lazy"),
+        intent="neighbors",
+    )
+    assert exact_diagnostics.representation == "metric_space"
+    assert tree_diagnostics.representation == "exact_tree_index"
+
+    print("record_kind =", space.metadata["record_kind"])
+    print("metric_law =", space.metadata["metric_law"])
+    print("vector dimension metadata =", space.metadata["dimensions"])
+    print("available representations =", ",".join(space.metadata["representations"]))
+    print("nearest vector =", names[implicit_neighbors[0][0]], round(implicit_neighbors[0][1], 3))
+    print("indexed nearest =", names[tree_neighbors[0][0]], "via", tree.representation)
+    print("runtime policy =", exact_diagnostics.policy_name, "via", exact_diagnostics.representation)
+    print("matrix cache reuse =", groups.representation, outliers.representation)
+    print("vector groups =", groups.cluster_count)
+    print("vector outlier =", names[outliers.outliers[0].record_id], "score", round(outliers.outliers[0].score, 3))
+    print("mds embedding dimensions =", embedding.dimensions)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CI-tested C++ engine demo showing vectors as the aligned-vector special case
- expose Euclidean metric traits as `metric_law::metric` / `record_kind::aligned_vector`
- add the matching Python example and list the vector demo in engine docs

## Verification
- `cmake --build --preset core --target engine_vector_space_special_case --parallel 2`
- `./build/core/examples/engine/engine_vector_space_special_case`
- `ctest --test-dir build/core -R example_engine_vector_space_special_case --output-on-failure`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/metric-python-overlay build/python-venv/bin/python python/examples/engine/vector_space_special_case.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/metric-python-overlay build/python-venv/bin/python -m unittest discover -s python/tests/core`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`