### PR TITLE
Add trait-driven metric contract smoke coverage

### DIFF
--- a/tests/core_smoke/metric_contracts_smoke.cpp
+++ b/tests/core_smoke/metric_contracts_smoke.cpp
@@ -26,6 +26,16 @@ struct PaddedHamming {
     }
 };
 
+struct DirectedIntegerDistance {
+    auto operator()(int lhs, int rhs) const -> int
+    {
+        if (lhs <= rhs) {
+            return rhs - lhs;
+        }
+        return 2 * (lhs - rhs);
+    }
+};
+
 template <typename Record, typename Metric>
 void assert_metric_contracts(const std::vector<Record> &records, Metric metric)
 {
@@ -46,11 +56,43 @@ void assert_metric_contracts(const std::vector<Record> &records, Metric metric)
     }
 }
 
+template <typename Record, typename Metric>
+void assert_declared_metric_contracts(const std::vector<Record> &records, Metric metric)
+{
+    for (const auto &lhs : records) {
+        assert(metric(lhs, lhs) == 0);
+
+        for (const auto &rhs : records) {
+            const auto lhs_rhs = metric(lhs, rhs);
+            assert(lhs_rhs >= 0);
+
+            if constexpr (metric::metric_traits<Metric>::law == metric::metric_law::metric ||
+                          metric::metric_traits<Metric>::law == metric::metric_law::pseudo_metric) {
+                assert(lhs_rhs == metric(rhs, lhs));
+
+                for (const auto &through : records) {
+                    assert(metric(lhs, through) <= lhs_rhs + metric(rhs, through));
+                }
+            }
+
+            if constexpr (metric::metric_traits<Metric>::law == metric::metric_law::metric) {
+                if (lhs_rhs == 0) {
+                    assert(lhs == rhs);
+                }
+            }
+        }
+    }
+}
+
 int main()
 {
     static_assert(std::is_same_v<metric::Manhattan<double>, metric::Manhatten<double>>);
     static_assert(std::is_same_v<metric::Manhattan_standardized<double>, metric::Manhatten_standardized<double>>);
     static_assert(metric::is_metric_callable_v<PaddedHamming, std::string>);
+    static_assert(metric::metric_traits<metric::Euclidean<double>>::law == metric::metric_law::metric);
+    static_assert(metric::metric_traits<metric::Euclidean<double>>::records == metric::record_kind::aligned_vector);
+    static_assert(metric::metric_thread_safe_v<metric::Euclidean<double>>);
+    static_assert(metric::metric_traits<DirectedIntegerDistance>::law == metric::metric_law::distance);
 
     const auto padded_hamming = metric::make_metric<std::string>(PaddedHamming{});
     static_assert(metric::is_metric_callable_v<decltype(padded_hamming), std::string>);
@@ -66,6 +108,14 @@ int main()
     assert_metric_contracts(
         std::vector<std::string>{"red", "reed", "road", "blue"},
         padded_hamming);
+
+    assert_declared_metric_contracts(
+        std::vector<std::vector<double>>{{0.0, 0.0}, {1.0, 0.0}, {1.0, 2.0}, {3.0, 3.0}},
+        metric::Euclidean<double>{});
+
+    assert_declared_metric_contracts(
+        std::vector<int>{0, 1, 3},
+        DirectedIntegerDistance{});
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- extend the C++ metric-contract smoke test with trait-driven axiom validation
- assert the promoted Euclidean traits as `metric` and `aligned_vector`
- cover an asymmetric custom distance without over-validating it as a metric

## Verification
- `cmake --build --preset core --target metric_contracts_smoke --parallel 2`
- `ctest --test-dir build/core -R metric_contracts_smoke --output-on-failure`
- `ctest --preset core --output-on-failure`
- `cmake --build --preset core --parallel 2`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`