### PR TITLE
Add roadmap reduction strategy vocabulary

### DIFF
--- a/docs/engine/strategies.md
+++ b/docs/engine/strategies.md
@@ -10,7 +10,7 @@ Algorithm names belong at this layer. A user asks to find groups; `k_medoids` or
 
 ## C++ Strategies
 
-The current C++ strategy objects include:
+The current promoted C++ strategy objects include:
 
 - `metric::strategies::brute_force`
 - `metric::strategies::matrix_cache`
@@ -22,6 +22,16 @@ The current C++ strategy objects include:
 - `metric::strategies::farthest_first`
 - `metric::strategies::mgc`
 - `metric::strategies::pcfa`
+
+The current C++ roadmap strategy objects include:
+
+- `metric::strategies::som`
+- `metric::strategies::koc`
+- `metric::strategies::dspcc`
+
+They validate strategy parameters and raise clear `std::invalid_argument`
+messages from the engine reduction intent until deterministic mapping
+contracts, diagnostics, and CI-backed examples are promoted.
 
 ## Python Strategies
 
@@ -35,7 +45,7 @@ The current Python strategy objects include:
 - `DistanceProfileCorrelation`
 
 `MDS` and `ClassicMDS` execute the promoted classical-MDS embedding path.
-`DiffusionEmbedding`, `PCFA`, `SOM`, and `PhateAE` are also importable from
+`DiffusionEmbedding`, `PCFA`, `SOM`, `KOC`, `DSPCC`, and `PhateAE` are also importable from
 `metric.strategies` as roadmap vocabulary, but Python intent methods raise
 `StrategyUnavailableError` for those strategies until deterministic fixtures,
 diagnostics, and CI-backed result contracts are promoted.

--- a/metric/intent/reduce.hpp
+++ b/metric/intent/reduce.hpp
@@ -6,14 +6,34 @@
 #define _METRIC_INTENT_REDUCE_HPP
 
 #include <cstddef>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
+#include <vector>
 
 #include "../core/concepts.hpp"
+#include "../core/metric_space.hpp"
+#include "../core/result.hpp"
+#include "../distance/k-related/Standards.hpp"
 #include "../mappings/pcfa.hpp"
 #include "../runtime/execution.hpp"
 #include "../strategies/reduction.hpp"
 
 namespace metric {
+
+namespace engine_reduce_detail {
+
+template <typename Space>
+using roadmap_reduction_result_t = MappingResult<MetricSpace<std::vector<double>, Euclidean<double>>>;
+
+[[noreturn]] inline auto throw_unpromoted_reduction_strategy(const char *strategy) -> void
+{
+	throw std::invalid_argument(std::string(strategy) +
+								" reduction strategy is not promoted yet; use metric::strategies::pcfa(...) for the "
+								"promoted C++ reduction path");
+}
+
+} // namespace engine_reduce_detail
 
 template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
 auto reduce(const Space &space, strategies::pcfa strategy)
@@ -46,6 +66,54 @@ auto reduce(const Space &space, std::size_t components, runtime::policy runtime_
 	-> decltype(reduce(space, strategies::pcfa(components), runtime_policy))
 {
 	return reduce(space, strategies::pcfa(components), runtime_policy);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto reduce(const Space &, strategies::som) -> engine_reduce_detail::roadmap_reduction_result_t<Space>
+{
+	engine_reduce_detail::throw_unpromoted_reduction_strategy("SOM");
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto reduce(const Space &space, strategies::som strategy, runtime::policy runtime_policy)
+	-> decltype(reduce(space, strategy))
+{
+	runtime::require_exact_reduce(runtime_policy);
+	runtime::require_lazy_reduce(runtime_policy);
+	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
+	return reduce(space, strategy);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto reduce(const Space &, strategies::koc) -> engine_reduce_detail::roadmap_reduction_result_t<Space>
+{
+	engine_reduce_detail::throw_unpromoted_reduction_strategy("KOC");
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto reduce(const Space &space, strategies::koc strategy, runtime::policy runtime_policy)
+	-> decltype(reduce(space, strategy))
+{
+	runtime::require_exact_reduce(runtime_policy);
+	runtime::require_lazy_reduce(runtime_policy);
+	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
+	return reduce(space, strategy);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto reduce(const Space &, strategies::dspcc) -> engine_reduce_detail::roadmap_reduction_result_t<Space>
+{
+	engine_reduce_detail::throw_unpromoted_reduction_strategy("DSPCC");
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto reduce(const Space &space, strategies::dspcc strategy, runtime::policy runtime_policy)
+	-> decltype(reduce(space, strategy))
+{
+	runtime::require_exact_reduce(runtime_policy);
+	runtime::require_lazy_reduce(runtime_policy);
+	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
+	return reduce(space, strategy);
 }
 
 } // namespace metric

--- a/metric/strategies/reduction.hpp
+++ b/metric/strategies/reduction.hpp
@@ -22,6 +22,44 @@ struct pcfa {
 	std::size_t components{};
 };
 
+struct som {
+	som(std::size_t width, std::size_t height)
+		: width(width)
+		, height(height)
+	{
+		if (width == 0 || height == 0) {
+			throw std::invalid_argument("SOM grid dimensions must be positive");
+		}
+	}
+
+	std::size_t width{};
+	std::size_t height{};
+};
+
+struct koc {
+	explicit koc(std::size_t clusters)
+		: clusters(clusters)
+	{
+		if (clusters == 0) {
+			throw std::invalid_argument("KOC cluster count must be positive");
+		}
+	}
+
+	std::size_t clusters{};
+};
+
+struct dspcc {
+	explicit dspcc(std::size_t components)
+		: components(components)
+	{
+		if (components == 0) {
+			throw std::invalid_argument("DSPCC component count must be positive");
+		}
+	}
+
+	std::size_t components{};
+};
+
 } // namespace metric::strategies
 
 #endif

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -96,9 +96,11 @@ from .spaces import FiniteMetricSpace, MatrixSpace, Space
 from .strategies import (
     ClassicMDS,
     DBSCAN,
+    DSPCC,
     DiffusionEmbedding,
     DistanceProfileCorrelation,
     FarthestFirst,
+    KOC,
     KMedoids,
     MDS,
     PCFA,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -12,9 +12,11 @@ from metric.spaces import FiniteMetricSpace
 from metric.strategies import (
     ClassicMDS,
     DBSCAN,
+    DSPCC,
     DiffusionEmbedding,
     DistanceProfileCorrelation,
     FarthestFirst,
+    KOC,
     KMedoids,
     PCFA,
     PhateAE,
@@ -1311,7 +1313,7 @@ def find_representatives(records, metric, k=None, strategy=None, *, count=None, 
 
 def _is_strategy_like(value):
     return (
-        isinstance(value, (FarthestFirst, KMedoids, PCFA, SOM))
+        isinstance(value, (FarthestFirst, KMedoids, PCFA, SOM, KOC, DSPCC))
         or hasattr(value, "seed_index")
         or hasattr(value, "groups")
     )
@@ -1328,7 +1330,7 @@ def _coerce_reduction_request(count, strategy):
         pass
     elif isinstance(strategy, KMedoids):
         pass
-    elif isinstance(strategy, (PCFA, SOM)):
+    elif isinstance(strategy, (PCFA, SOM, KOC, DSPCC)):
         raise StrategyUnavailableError(
             f"{type(strategy).__name__} reduction is not promoted yet. "
             "Use FarthestFirst or KMedoids until a reconstruction or quantization contract is CI-backed."

--- a/python/pkg/metric/strategies.py
+++ b/python/pkg/metric/strategies.py
@@ -44,6 +44,20 @@ class SOM:
 
 
 @dataclass(frozen=True)
+class KOC:
+    """Roadmap Kohonen outlier chart reduction or mapping strategy."""
+
+    clusters: int = 2
+
+
+@dataclass(frozen=True)
+class DSPCC:
+    """Roadmap DSPCC reduction or mapping strategy."""
+
+    dimensions: int = 2
+
+
+@dataclass(frozen=True)
 class PhateAE:
     """Roadmap PHATE-AE-style learnable mapping strategy."""
 
@@ -84,9 +98,11 @@ class DistanceProfileCorrelation:
 __all__ = [
     "ClassicMDS",
     "DBSCAN",
+    "DSPCC",
     "DiffusionEmbedding",
     "DistanceProfileCorrelation",
     "FarthestFirst",
+    "KOC",
     "KMedoids",
     "MDS",
     "PCFA",

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -78,9 +78,11 @@ from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
 from metric.strategies import (
     ClassicMDS,
     DBSCAN,
+    DSPCC,
     DiffusionEmbedding,
     DistanceProfileCorrelation,
     FarthestFirst,
+    KOC,
     KMedoids,
     MDS,
     PCFA,
@@ -199,6 +201,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.strategies.DiffusionEmbedding, DiffusionEmbedding)
         self.assertIs(metric.strategies.PCFA, PCFA)
         self.assertIs(metric.strategies.SOM, SOM)
+        self.assertIs(metric.strategies.KOC, KOC)
+        self.assertIs(metric.strategies.DSPCC, DSPCC)
         self.assertIs(metric.strategies.PhateAE, PhateAE)
         self.assertIs(metric.transforms, transforms)
         self.assertIs(metric.Edit, Edit)
@@ -236,6 +240,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.DiffusionEmbedding, DiffusionEmbedding)
         self.assertIs(metric.PCFA, PCFA)
         self.assertIs(metric.SOM, SOM)
+        self.assertIs(metric.KOC, KOC)
+        self.assertIs(metric.DSPCC, DSPCC)
         self.assertIs(metric.PhateAE, PhateAE)
         self.assertIs(metric.CorrelationResult, CorrelationResult)
         self.assertIs(metric.compare_spaces, compare_spaces)
@@ -316,6 +322,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("DiffusionEmbedding", metric.__all__)
         self.assertIn("PCFA", metric.__all__)
         self.assertIn("SOM", metric.__all__)
+        self.assertIn("KOC", metric.__all__)
+        self.assertIn("DSPCC", metric.__all__)
         self.assertIn("PhateAE", metric.__all__)
         self.assertIn("exact_knn_graph", metric.__all__)
         self.assertIn("exact_knn_graph_edges", metric.__all__)
@@ -960,6 +968,10 @@ class RevivalApiTest(unittest.TestCase):
             space.reduce(strategy=PCFA(dimensions=2))
         with self.assertRaisesRegex(StrategyUnavailableError, "SOM reduction is not promoted"):
             space.reduce(strategy=SOM(grid=(2, 2)))
+        with self.assertRaisesRegex(StrategyUnavailableError, "KOC reduction is not promoted"):
+            space.reduce(strategy=KOC(clusters=2))
+        with self.assertRaisesRegex(StrategyUnavailableError, "DSPCC reduction is not promoted"):
+            space.reduce(strategy=DSPCC(dimensions=2))
         with self.assertRaisesRegex(TypeError, "count is required"):
             space.representatives()
         with self.assertRaisesRegex(ValueError, "either k or count"):

--- a/tests/core_smoke/engine_reduce_intent_smoke.cpp
+++ b/tests/core_smoke/engine_reduce_intent_smoke.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <cmath>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "metric/distance.hpp"
@@ -11,6 +12,18 @@ namespace {
 auto close(double lhs, double rhs) -> bool
 {
 	return std::fabs(lhs - rhs) < 1e-9;
+}
+
+template <typename Space, typename Strategy>
+auto rejects_unpromoted_strategy(const Space &space, Strategy strategy, const std::string &name) -> bool
+{
+	try {
+		(void)metric::reduce(space, strategy);
+	} catch (const std::invalid_argument &error) {
+		const std::string message = error.what();
+		return message.find(name) != std::string::npos && message.find("not promoted") != std::string::npos;
+	}
+	return false;
 }
 
 } // namespace
@@ -69,6 +82,43 @@ int main()
 		rejected_approximate_runtime = true;
 	}
 	assert(rejected_approximate_runtime);
+
+	const auto som_strategy = metric::strategies::som(2, 2);
+	assert(som_strategy.width == 2);
+	assert(som_strategy.height == 2);
+	assert(rejects_unpromoted_strategy(space, som_strategy, "SOM"));
+
+	const auto koc_strategy = metric::strategies::koc(2);
+	assert(koc_strategy.clusters == 2);
+	assert(rejects_unpromoted_strategy(space, koc_strategy, "KOC"));
+
+	const auto dspcc_strategy = metric::strategies::dspcc(2);
+	assert(dspcc_strategy.components == 2);
+	assert(rejects_unpromoted_strategy(space, dspcc_strategy, "DSPCC"));
+
+	bool rejected_invalid_som = false;
+	try {
+		(void)metric::strategies::som(0, 2);
+	} catch (const std::invalid_argument &) {
+		rejected_invalid_som = true;
+	}
+	assert(rejected_invalid_som);
+
+	bool rejected_invalid_koc = false;
+	try {
+		(void)metric::strategies::koc(0);
+	} catch (const std::invalid_argument &) {
+		rejected_invalid_koc = true;
+	}
+	assert(rejected_invalid_koc);
+
+	bool rejected_invalid_dspcc = false;
+	try {
+		(void)metric::strategies::dspcc(0);
+	} catch (const std::invalid_argument &) {
+		rejected_invalid_dspcc = true;
+	}
+	assert(rejected_invalid_dspcc);
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
- add validated C++ roadmap reduction strategy objects for SOM, KOC, and DSPCC
- make C++ reduce(...) report clear not-promoted errors for roadmap strategies instead of leaving users with template failures
- expose Python KOC and DSPCC roadmap strategy objects with matching StrategyUnavailableError behavior
- document promoted vs roadmap strategy vocabulary

## Verification
- `cmake --build --preset core --target engine_reduce_intent_smoke --parallel 2`
- `ctest --test-dir build/core -R engine_reduce_intent_smoke --output-on-failure`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`
- `rm -rf /tmp/metric-python-overlay && mkdir -p /tmp/metric-python-overlay && cp -R python/pkg/metric /tmp/metric-python-overlay/metric && cp -R build/python-venv/lib/python3.12/site-packages/metric/_impl/. /tmp/metric-python-overlay/metric/_impl/. && PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/tmp/metric-python-overlay build/python-venv/bin/python -m unittest discover -s python/tests/core -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`