### PR TITLE
Document roadmap reduction strategies

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -47,7 +47,7 @@ The current local tree implements the first revival slice:
 - Python engine-style Space map intent for deterministic transforms into derived metric spaces
 - Python map facade accepts `transform=` and reports ambiguous or unavailable mapping forms deterministically
 - Python map facade accepts fresh explicit representations and records representation metadata
-- Python strategy facade exports `MDS`, `DiffusionEmbedding`, `PCFA`, `SOM`, and `PhateAE`, with `MDS` executing the promoted classical-MDS path and roadmap strategies raising explicit unavailable errors
+- Python strategy facade exports `MDS`, `DiffusionEmbedding`, `PCFA`, `SOM`, `KOC`, `DSPCC`, and `PhateAE`, with `MDS` executing the promoted classical-MDS path and roadmap strategies raising explicit unavailable errors
 - Python engine-style Space denoise intent with DBSCAN-noise filtering and mapping-result lineage
 - Python describe facade accepts fresh explicit representations and records representation metadata
 - Python distance compatibility aliases expose `Manhattan`, `Minkowski`, and `ThresholdedEuclidean` when optional historical standard bindings are installed
@@ -109,6 +109,7 @@ The current local tree implements the first revival slice:
 - initial C++ engine describe intent with exact finite-space structure diagnostics
 - initial C++ engine embed intent backed by the PCFA strategy
 - initial C++ engine reduce intent backed by the PCFA strategy
+- C++ roadmap reduction strategy vocabulary for `som`, `koc`, and `dspcc` validates parameters and raises explicit not-promoted reduction errors
 - initial C++ engine outlier intent backed by DBSCAN-noise detection with named result objects
 - initial C++ engine map intent for deterministic transforms into derived metric spaces
 - initial C++ engine denoise intent backed by DBSCAN-noise filtering with mapping-result lineage
@@ -347,6 +348,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - Python neighbor facade support for target `count` and `radius` intent arguments, merged as `e9dd23e217b12aeb8e6e85df612c55d78c66da50`
 - Python representation facade support for `Space.to_tree()` and `Space.to_graph(count=...)`, merged as `adb6222c2f311662678694fb3a92ee25052b89bd`
 - Python strategy facade exports for `MDS`, `DiffusionEmbedding`, `PCFA`, `SOM`, and `PhateAE`, with promoted-vs-roadmap strategy errors covered by wheel CI, merged as `6961fe0dc97185a03a5e48b35b5b32ddaa8423f6`
+- C++ roadmap reduction strategies `som`, `koc`, and `dspcc`, plus Python `KOC` and `DSPCC` roadmap facade exports with explicit not-promoted reduction errors, merged as `a90bce8f650057e142ad144fecdb1040d9131213`
 - CI-tested Python tutorial notebooks and standard-library notebook smoke runner, merged as `4977f3a0aeae84dc2ddc874c2b7e17e35d8c3d71`
 - Python public exception facade with `UnsupportedOperationError` for unsupported inverse reconstruction, merged as `ec94ef66017733624e52465fb96bccbed13ae9c2`
 - C++ semantic `metric::count{...}` target argument support for `find_neighbors`, merged as `806eb4628770e89811a9c27205161d371a325c99`


### PR DESCRIPTION
## Summary
- update revival status for the merged roadmap reduction strategy vocabulary
- record the #556 merge commit and expanded Python strategy facade exports

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`