### PR TITLE
Add C++ representation factory helpers

### DIFF
--- a/docs/engine/mental-model.md
+++ b/docs/engine/mental-model.md
@@ -130,10 +130,10 @@ auto lhs = space.id(0);
 auto rhs = space.id(1);
 auto distance = space.distance(lhs, rhs);
 
-metric::representations::MatrixCache<decltype(space)> matrix(space);
+auto matrix = metric::representations::matrix(space);
 auto cached_distance = matrix.distance(lhs, rhs);
 
-metric::representations::CoverTreeIndex<decltype(space)> tree(space);
+auto tree = metric::representations::cover_tree(space);
 auto neighbors = tree.knn(std::string("metricks"), 2);
 
 auto exact_neighbors = metric::operators::knn(space, std::string("metricks"), 2);

--- a/docs/engine/representations.md
+++ b/docs/engine/representations.md
@@ -14,6 +14,16 @@ The current C++ engine representation adapters live under `metric::representatio
 - `KnnGraphIndex<Space>`
 - `GraphTopology<Space>`
 
+The factory helpers mirror the Python facade and keep examples focused on the
+representation role:
+
+- `implicit(space)`
+- `matrix(space)`
+- `matrix(space, matrix_cache_mode::lazy)`
+- `cover_tree(space)`
+- `knn_graph(space, k)` / `graph(space, k)`
+- `topology(space)`
+
 Each adapter captures the source `space.version()` when it is built and exposes `is_stale()`.
 
 ## Matrix Cache
@@ -21,11 +31,12 @@ Each adapter captures the source `space.version()` when it is built and exposes 
 `MatrixCache` can eagerly store all pairwise distances or fill entries lazily. Use eager materialization when repeated `RecordId` queries or all-pairs operators make the upfront cost explicit and worthwhile. Use the lazy mode when the workflow needs distance-provider semantics but should only compute requested pairs.
 
 ```cpp
-metric::representations::MatrixCache<decltype(space)> matrix(space);
+auto matrix = metric::representations::matrix(space);
 auto distance = matrix.distance(space.id(0), space.id(1));
 
-metric::representations::MatrixCache<decltype(space)> lazy_matrix(
-    space, metric::representations::matrix_cache_mode::lazy);
+auto lazy_matrix = metric::representations::matrix(
+    space,
+    metric::representations::matrix_cache_mode::lazy);
 auto first = lazy_matrix.distance(space.id(0), space.id(2));  // miss
 auto again = lazy_matrix.distance(space.id(0), space.id(2));  // hit
 auto stats = lazy_matrix.stats();

--- a/metric/representations/cover_tree_index.hpp
+++ b/metric/representations/cover_tree_index.hpp
@@ -128,6 +128,11 @@ template <typename Space> class CoverTreeIndex {
 	std::vector<record_type> records_;
 };
 
+template <typename Space> auto cover_tree(const Space &space) -> CoverTreeIndex<Space>
+{
+	return CoverTreeIndex<Space>(space);
+}
+
 } // namespace metric::representations
 
 #endif

--- a/metric/representations/graph_topology.hpp
+++ b/metric/representations/graph_topology.hpp
@@ -112,6 +112,11 @@ template <typename Space> class GraphTopology {
 	std::vector<edge_type> edges_;
 };
 
+template <typename Space> auto topology(const Space &space) -> GraphTopology<Space>
+{
+	return GraphTopology<Space>(space);
+}
+
 } // namespace metric::representations
 
 #endif

--- a/metric/representations/implicit.hpp
+++ b/metric/representations/implicit.hpp
@@ -46,6 +46,11 @@ template <typename Space> class ImplicitDistanceProvider {
 	const space_type *space_;
 };
 
+template <typename Space> auto implicit(const Space &space) -> ImplicitDistanceProvider<Space>
+{
+	return ImplicitDistanceProvider<Space>(space);
+}
+
 } // namespace metric::representations
 
 #endif

--- a/metric/representations/knn_graph_index.hpp
+++ b/metric/representations/knn_graph_index.hpp
@@ -231,6 +231,16 @@ template <typename Space> class KnnGraphIndex {
 	std::vector<std::vector<neighbor_type>> adjacency_;
 };
 
+template <typename Space> auto knn_graph(const Space &space, std::size_t k) -> KnnGraphIndex<Space>
+{
+	return KnnGraphIndex<Space>(space, k);
+}
+
+template <typename Space> auto graph(const Space &space, std::size_t k) -> KnnGraphIndex<Space>
+{
+	return knn_graph(space, k);
+}
+
 } // namespace metric::representations
 
 #endif

--- a/metric/representations/matrix_cache.hpp
+++ b/metric/representations/matrix_cache.hpp
@@ -145,6 +145,12 @@ template <typename Space> class MatrixCache {
 	mutable std::size_t misses_{};
 };
 
+template <typename Space>
+auto matrix(const Space &space, matrix_cache_mode mode = matrix_cache_mode::eager) -> MatrixCache<Space>
+{
+	return MatrixCache<Space>(space, mode);
+}
+
 } // namespace metric::representations
 
 #endif

--- a/tests/core_smoke/engine_representations_smoke.cpp
+++ b/tests/core_smoke/engine_representations_smoke.cpp
@@ -17,7 +17,7 @@ int main()
 	const auto id2 = space.id(2);
 	const auto id3 = space.id(3);
 
-	metric::representations::ImplicitDistanceProvider<decltype(space)> implicit(space);
+	auto implicit = metric::representations::implicit(space);
 	static_assert(metric::DistanceProvider_v<decltype(implicit)>);
 	assert(implicit.record_count() == space.size());
 	assert(implicit.id(0) == id0);
@@ -31,7 +31,7 @@ int main()
 	assert(implicit_diagnostics.updates == metric::representations::update_mode::live);
 	assert(!implicit_diagnostics.stale);
 
-	metric::representations::MatrixCache<decltype(space)> matrix(space);
+	auto matrix = metric::representations::matrix(space);
 	static_assert(metric::DistanceProvider_v<decltype(matrix)>);
 	assert(matrix.record_count() == space.size());
 	assert(matrix.id(2) == id2);
@@ -47,8 +47,7 @@ int main()
 	assert(matrix.stats().fill_ratio == 1.0);
 	assert(matrix.stats().hits == 2);
 
-	metric::representations::MatrixCache<decltype(space)> lazy_matrix(
-		space, metric::representations::matrix_cache_mode::lazy);
+	auto lazy_matrix = metric::representations::matrix(space, metric::representations::matrix_cache_mode::lazy);
 	assert(lazy_matrix.cached_distances() == 0);
 	const auto lazy_initial_diagnostics = lazy_matrix.diagnostics();
 	assert(lazy_initial_diagnostics.materialized == metric::representations::materialization::lazy);
@@ -65,7 +64,7 @@ int main()
 	assert(lazy_diagnostics.cached_distances == 2);
 	assert(lazy_diagnostics.distance_evaluations == 2);
 
-	metric::representations::CoverTreeIndex<decltype(space)> tree(space);
+	auto tree = metric::representations::cover_tree(space);
 	static_assert(metric::NeighborSearchIndex_v<decltype(tree)>);
 	assert(tree.id(3) == id3);
 	assert(tree.contains(id0));
@@ -80,7 +79,7 @@ int main()
 	assert(tree_diagnostics.records == space.size());
 	assert(tree.stats().nodes == space.size());
 
-	metric::representations::KnnGraphIndex<decltype(space)> graph(space, 1);
+	auto graph = metric::representations::knn_graph(space, 1);
 	static_assert(metric::NeighborSearchIndex_v<decltype(graph)>);
 	assert(graph.k() == 1);
 	assert(graph.id(0) == id0);
@@ -97,8 +96,11 @@ int main()
 	assert(graph_recall_stats.recall_validated);
 	assert(graph_recall_stats.sampled_recall == 1.0);
 	assert(graph.sampled_recall(matrix, 2) == 1.0);
+	const auto graph_alias = metric::representations::graph(space, 1);
+	assert(graph_alias.k() == graph.k());
+	assert(graph_alias.neighbors(id0)[0].id == graph.neighbors(id0)[0].id);
 
-	metric::representations::GraphTopology<decltype(space)> topology(space);
+	auto topology = metric::representations::topology(space);
 	static_assert(metric::GraphTopology_v<decltype(topology)>);
 	assert(topology.id(1) == id1);
 	assert(topology.contains(id2));
@@ -141,7 +143,7 @@ int main()
 	assert(matrix.position_of(id3) == 3);
 	assert(matrix.distance(id1, id3) == 7);
 
-	metric::representations::MatrixCache<decltype(space)> refreshed_matrix(space);
+	auto refreshed_matrix = metric::representations::matrix(space);
 	assert(refreshed_matrix.record_count() == space.size());
 	assert(!refreshed_matrix.contains(id1));
 	assert(refreshed_matrix.id(1) == id2);


### PR DESCRIPTION
## Summary
- add C++ representation factory helpers matching the engine plan public shape
- cover implicit, matrix, cover-tree, kNN graph/graph alias, and topology factories in the representation smoke test
- update engine representation docs and mental model snippets to use the helper form

## Verification
- `cmake --build --preset core --target engine_representations_smoke --parallel 2`
- `ctest --test-dir build/core -R engine_representations_smoke --output-on-failure`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`