### PR TITLE
Document C++ representation factory helpers

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -95,6 +95,7 @@ The current local tree implements the first revival slice:
 - C++ `MetricSpace` supports stable ID lookup, insertion, replacement, erase, and ID-to-position mapping
 - initial C++ engine representation adapters for implicit distance lookup, matrix caching, exact neighbor-index scaffolds, kNN graph adjacency, graph topology edges, and stale detection
 - C++ representation adapters expose common diagnostics and preserve provider IDs across materialized snapshots
+- C++ representation factory helpers expose `implicit`, `matrix`, `cover_tree`, `knn_graph`/`graph`, and `topology` over `MetricSpace`
 - C++ `MatrixCache` supports eager and lazy fill modes with hit/miss/fill diagnostics and deterministic stale-state reporting
 - C++ `KnnGraphIndex` exposes explicit sampled-recall validation against an exact distance provider
 - initial C++ engine nearest operators with `NeighborSet`, `operators::knn`, and `operators::range` over spaces, distance providers, and neighbor indexes
@@ -352,6 +353,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - CI-tested Python tutorial notebooks and standard-library notebook smoke runner, merged as `4977f3a0aeae84dc2ddc874c2b7e17e35d8c3d71`
 - Python public exception facade with `UnsupportedOperationError` for unsupported inverse reconstruction, merged as `ec94ef66017733624e52465fb96bccbed13ae9c2`
 - C++ semantic `metric::count{...}` target argument support for `find_neighbors`, merged as `806eb4628770e89811a9c27205161d371a325c99`
+- C++ representation factory helpers for `implicit`, `matrix`, `cover_tree`, `knn_graph`/`graph`, and `topology`, merged as `2865f742512e7e3ea389dfc3d1b191945b07b37f`
 - Python representation freshness checks with deterministic stale representation errors, merged as `da591dcbd98d04a5541925170726429e17f836d0`
 - Python runtime-checkable `metric.Metric` protocol and explicit missing-metric errors, merged as `b7512721308d03940b0127f021260e1cee92d65f`
 - Python `Space.from_dataframe(...)`, stable `Space.ids`, `Space.record(...)`, and `Space.pairwise(...)` helpers, merged as `327259e5fc4b1ee1c3e1d6b724ee38021bae434e`


### PR DESCRIPTION
## Summary
- record the merged C++ representation factory helper API in the revival status scope
- add the PR #558 merge commit to the post-v0.3.2 progress log

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`