### PR TITLE
Route mapping adapters through map intent

### DIFF
--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -13,7 +13,7 @@ Intent APIs are named by what users want to do, not by the algorithm used to do 
 | Find outliers | `find_outliers` | `Space.outliers` | C++ and Python DBSCAN-noise path |
 | Reduce complexity | `reduce` | `Space.reduce` | C++ PCFA-backed path; Python representative/medoid reduction path |
 | Compress a space | `compress` | `Space.compress` | C++ farthest-first representative path; Python representative/medoid path |
-| Map to another space | `map`, `metric::mappings::*` | `Space.map` | C++ and Python deterministic transform paths; C++ mapping conventions |
+| Map to another space | `map`, `metric::mappings::*` | `Space.map` | C++ deterministic transform and mapping-adapter paths; Python deterministic transform path |
 | Denoise a space | `denoise` | `Space.denoise` | C++ and Python DBSCAN-noise filter paths |
 
 The operator layer may still use algorithm names because it is the implementation layer. The intent layer is the recommended user-facing vocabulary.
@@ -30,6 +30,7 @@ auto dependency = metric::compare(space_a, space_b, metric::strategies::mgc{});
 auto embedding = metric::embed(space, metric::strategies::pcfa(2));
 auto compression = metric::compress(space, 2, metric::strategies::farthest_first{});
 auto mapped = metric::map(space, transform, target_metric);
+auto learned_map = metric::map(space, metric::mappings::pcfa(2));
 auto denoised = metric::denoise(space, metric::strategies::dbscan(2.0, 2));
 auto structure = metric::describe_structure(space);
 ```

--- a/docs/engine/mappings.md
+++ b/docs/engine/mappings.md
@@ -20,6 +20,7 @@ The current engine mapping layer includes:
 
 - `metric::MappingResult`
 - deterministic C++ `metric::map`
+- C++ `metric::map(space, mapping_adapter)` over promoted mapping adapters
 - `metric::mappings::fit`
 - `metric::mappings::transform`
 - clustered-space mapping from `ClusteringResult`
@@ -30,7 +31,17 @@ The current engine mapping layer includes:
 - deterministic Python `Space.map`
 - DBSCAN-noise-filtered Python `Space.denoise`
 
-`MappingResult` stores the derived space plus source-record lineage. Inverse reconstruction is explicit and optional. The C++ `metric::embed` intent returns a PCFA-derived coordinate space with one-to-one lineage and `mapping == "pcfa_embedding"`. The C++ `metric::denoise` and Python `Space.denoise` intents also return `MappingResult` values, preserving one-to-one lineage for non-noise records kept after DBSCAN noise filtering.
+`MappingResult` stores the derived space plus source-record lineage. Inverse reconstruction is explicit and optional.
+The C++ `metric::map(space, metric::mappings::pcfa(components))` form fits a promoted mapping adapter
+and transforms the same source space through the semantic map intent. The C++ `metric::embed` intent returns a
+PCFA-derived coordinate space with one-to-one lineage and `mapping == "pcfa_embedding"`. The C++ `metric::denoise`
+and Python `Space.denoise` intents also return `MappingResult` values, preserving one-to-one lineage for non-noise
+records kept after DBSCAN noise filtering.
+
+```cpp
+auto mapped = metric::map(space, metric::mappings::pcfa(2));
+auto coordinates = mapped.space;
+```
 
 ## Python Status
 

--- a/metric/intent/map.hpp
+++ b/metric/intent/map.hpp
@@ -13,6 +13,7 @@
 #include "../core/metric_space.hpp"
 #include "../core/record_id.hpp"
 #include "../core/result.hpp"
+#include "../mappings/mapping.hpp"
 #include "../runtime/execution.hpp"
 
 namespace metric::intent {
@@ -58,6 +59,26 @@ auto map(const Space &space, Transform transform, TargetMetric metric, runtime::
 	runtime::require_lazy_map(runtime_policy);
 	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
 	auto result = map(space, std::move(transform), std::move(metric));
+	result.representation = runtime::map_representation(runtime_policy);
+	return result;
+}
+
+template <typename Space, typename Mapping,
+		  typename std::enable_if<MetricSpaceLike_v<Space> && Mapping_v<Mapping, Space>, int>::type = 0>
+auto map(const Space &space, const Mapping &mapping) -> decltype(mappings::transform(mappings::fit(mapping, space), space))
+{
+	auto model = mappings::fit(mapping, space);
+	return mappings::transform(model, space);
+}
+
+template <typename Space, typename Mapping,
+		  typename std::enable_if<MetricSpaceLike_v<Space> && Mapping_v<Mapping, Space>, int>::type = 0>
+auto map(const Space &space, const Mapping &mapping, runtime::policy runtime_policy) -> decltype(map(space, mapping))
+{
+	runtime::require_exact_map(runtime_policy);
+	runtime::require_lazy_map(runtime_policy);
+	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
+	auto result = map(space, mapping);
 	result.representation = runtime::map_representation(runtime_policy);
 	return result;
 }

--- a/tests/core_smoke/engine_pcfa_mapping_smoke.cpp
+++ b/tests/core_smoke/engine_pcfa_mapping_smoke.cpp
@@ -59,6 +59,25 @@ int main()
 	assert(direct.space.size() == reduced.space.size());
 	assert(direct.source_records == reduced.source_records);
 
+	const auto intent_mapped = metric::map(space, mapping);
+	using intent_mapped_type = typename std::decay<decltype(intent_mapped)>::type;
+	static_assert(std::is_same<typename intent_mapped_type::space_type::record_type, record_type>::value,
+				  "map intent should produce the mapping adapter target record type");
+	assert(intent_mapped.mapping == "pcfa");
+	assert(intent_mapped.strategy == "pcfa");
+	assert(intent_mapped.representation == "metric_space");
+	assert(intent_mapped.inverse_supported);
+	assert(intent_mapped.source_record_count == space.size());
+	assert(intent_mapped.source_records == reduced.source_records);
+	assert(intent_mapped.space.size() == reduced.space.size());
+	assert(close(intent_mapped.space.record(intent_mapped.space.id(0))[0], -0.5));
+	assert(close(intent_mapped.space.record(intent_mapped.space.id(1))[0], 0.5));
+
+	const auto runtime_intent_mapped = metric::map(space, mapping, metric::runtime::exact());
+	assert(runtime_intent_mapped.mapping == "pcfa");
+	assert(runtime_intent_mapped.representation == "metric_space");
+	assert(runtime_intent_mapped.source_records == intent_mapped.source_records);
+
 	bool rejected_zero_components = false;
 	try {
 		(void)metric::mappings::pcfa(0);


### PR DESCRIPTION
## Summary
- add a generic C++ `metric::map(space, mapping_adapter)` overload over the promoted `metric::mappings::fit/transform` concepts
- add a runtime-policy overload for mapping-adapter map execution
- cover PCFA mapping adapters through the semantic map intent in the LAPACK-gated PCFA smoke test and document the public form

## Verification
- `cmake --build --preset core --target engine_map_intent_smoke --parallel 2`
- `cmake --build --preset core --target engine_pcfa_mapping_smoke --parallel 2`
- `ctest --test-dir build/core -R 'engine_(map_intent|pcfa_mapping)_smoke' --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`