### PR TITLE
Document map intent adapter support

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -113,6 +113,7 @@ The current local tree implements the first revival slice:
 - C++ roadmap reduction strategy vocabulary for `som`, `koc`, and `dspcc` validates parameters and raises explicit not-promoted reduction errors
 - initial C++ engine outlier intent backed by DBSCAN-noise detection with named result objects
 - initial C++ engine map intent for deterministic transforms into derived metric spaces
+- C++ engine map intent accepts promoted mapping adapters through `metric::mappings::fit`/`transform`
 - initial C++ engine denoise intent backed by DBSCAN-noise filtering with mapping-result lineage
 - C++ engine umbrella header exposure for the PCFA-backed reduce intent
 - initial C++ engine runtime policy scaffolding for exact lazy/materialized neighbor, grouping, representative, compression, structure-diagnostic, cross-space comparison, outlier, denoise, and record-space embed/reduce/map execution with representation-cache staleness
@@ -354,6 +355,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - Python public exception facade with `UnsupportedOperationError` for unsupported inverse reconstruction, merged as `ec94ef66017733624e52465fb96bccbed13ae9c2`
 - C++ semantic `metric::count{...}` target argument support for `find_neighbors`, merged as `806eb4628770e89811a9c27205161d371a325c99`
 - C++ representation factory helpers for `implicit`, `matrix`, `cover_tree`, `knn_graph`/`graph`, and `topology`, merged as `2865f742512e7e3ea389dfc3d1b191945b07b37f`
+- C++ map intent support for promoted mapping adapters through `metric::mappings::fit`/`transform`, merged as `23e753ab9c27ea75ef056ee17871a3f3ae4dbaef`
 - Python representation freshness checks with deterministic stale representation errors, merged as `da591dcbd98d04a5541925170726429e17f836d0`
 - Python runtime-checkable `metric.Metric` protocol and explicit missing-metric errors, merged as `b7512721308d03940b0127f021260e1cee92d65f`
 - Python `Space.from_dataframe(...)`, stable `Space.ids`, `Space.record(...)`, and `Space.pairwise(...)` helpers, merged as `327259e5fc4b1ee1c3e1d6b724ee38021bae434e`


### PR DESCRIPTION
## Summary
- record C++ map intent support for promoted mapping adapters in the revival status scope
- add the PR #560 merge commit to the post-v0.3.2 progress log

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`