### PR TITLE
Materialize representations from strategies

### DIFF
--- a/docs/engine/representations.md
+++ b/docs/engine/representations.md
@@ -24,6 +24,15 @@ representation role:
 - `knn_graph(space, k)` / `graph(space, k)`
 - `topology(space)`
 
+Search strategies can also materialize the matching representation explicitly:
+
+```cpp
+auto implicit = metric::representations::make(space, metric::strategies::brute_force{});
+auto matrix = metric::representations::make(space, metric::strategies::matrix_cache{});
+auto tree = metric::representations::make(space, metric::strategies::cover_tree{});
+auto graph = metric::representations::make(space, metric::strategies::knn_graph(3));
+```
+
 Each adapter captures the source `space.version()` when it is built and exposes `is_stale()`.
 
 ## Matrix Cache

--- a/docs/engine/strategies.md
+++ b/docs/engine/strategies.md
@@ -33,6 +33,14 @@ They validate strategy parameters and raise clear `std::invalid_argument`
 messages from the engine reduction intent until deterministic mapping
 contracts, diagnostics, and CI-backed examples are promoted.
 
+Search strategies also provide the promoted representation-selection vocabulary.
+`metric::representations::make(space, strategy)` materializes:
+
+- `brute_force` as an implicit distance provider
+- `matrix_cache` as a matrix cache
+- `cover_tree` as a cover-tree index
+- `knn_graph(k)` as a kNN graph index
+
 ## Python Strategies
 
 The current Python strategy objects include:

--- a/metric/engine.hpp
+++ b/metric/engine.hpp
@@ -37,6 +37,7 @@
 #include "representations/implicit.hpp"
 #include "representations/knn_graph_index.hpp"
 #include "representations/matrix_cache.hpp"
+#include "representations/strategy.hpp"
 #include "runtime/cache.hpp"
 #include "runtime/execution.hpp"
 #include "runtime/policy.hpp"

--- a/metric/representations/strategy.hpp
+++ b/metric/representations/strategy.hpp
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_REPRESENTATIONS_STRATEGY_HPP
+#define _METRIC_REPRESENTATIONS_STRATEGY_HPP
+
+#include <stdexcept>
+#include <type_traits>
+
+#include "../core/concepts.hpp"
+#include "../strategies/search.hpp"
+#include "cover_tree_index.hpp"
+#include "implicit.hpp"
+#include "knn_graph_index.hpp"
+#include "matrix_cache.hpp"
+
+namespace metric::representations {
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto make(const Space &space, strategies::brute_force) -> ImplicitDistanceProvider<Space>
+{
+	return implicit(space);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto make(const Space &space, strategies::matrix_cache) -> MatrixCache<Space>
+{
+	return matrix(space);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto make(const Space &space, strategies::cover_tree) -> CoverTreeIndex<Space>
+{
+	return cover_tree(space);
+}
+
+template <typename Space, typename std::enable_if<MetricSpaceLike_v<Space>, int>::type = 0>
+auto make(const Space &space, strategies::knn_graph strategy) -> KnnGraphIndex<Space>
+{
+	if (strategy.graph_neighbors == 0) {
+		throw std::invalid_argument("kNN graph representation strategy requires positive neighbor count");
+	}
+
+	return knn_graph(space, strategy.graph_neighbors);
+}
+
+} // namespace metric::representations
+
+#endif

--- a/tests/core_smoke/engine_representations_smoke.cpp
+++ b/tests/core_smoke/engine_representations_smoke.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "metric/engine.hpp"
@@ -30,6 +31,9 @@ int main()
 	assert(implicit_diagnostics.materialized == metric::representations::materialization::lazy);
 	assert(implicit_diagnostics.updates == metric::representations::update_mode::live);
 	assert(!implicit_diagnostics.stale);
+	auto strategy_implicit = metric::representations::make(space, metric::strategies::brute_force{});
+	static_assert(metric::DistanceProvider_v<decltype(strategy_implicit)>);
+	assert(strategy_implicit.distance(id0, id2) == implicit.distance(id0, id2));
 
 	auto matrix = metric::representations::matrix(space);
 	static_assert(metric::DistanceProvider_v<decltype(matrix)>);
@@ -46,6 +50,9 @@ int main()
 	assert(!matrix_diagnostics.stale);
 	assert(matrix.stats().fill_ratio == 1.0);
 	assert(matrix.stats().hits == 2);
+	auto strategy_matrix = metric::representations::make(space, metric::strategies::matrix_cache{});
+	static_assert(metric::DistanceProvider_v<decltype(strategy_matrix)>);
+	assert(strategy_matrix.distance(id0, id2) == matrix.distance(id0, id2));
 
 	auto lazy_matrix = metric::representations::matrix(space, metric::representations::matrix_cache_mode::lazy);
 	assert(lazy_matrix.cached_distances() == 0);
@@ -78,6 +85,9 @@ int main()
 	assert(tree_diagnostics.kind == metric::representations::representation_kind::cover_tree_index);
 	assert(tree_diagnostics.records == space.size());
 	assert(tree.stats().nodes == space.size());
+	auto strategy_tree = metric::representations::make(space, metric::strategies::cover_tree{});
+	static_assert(metric::NeighborSearchIndex_v<decltype(strategy_tree)>);
+	assert(strategy_tree.knn(4, 2)[0].id == tree_neighbors[0].id);
 
 	auto graph = metric::representations::knn_graph(space, 1);
 	static_assert(metric::NeighborSearchIndex_v<decltype(graph)>);
@@ -99,6 +109,17 @@ int main()
 	const auto graph_alias = metric::representations::graph(space, 1);
 	assert(graph_alias.k() == graph.k());
 	assert(graph_alias.neighbors(id0)[0].id == graph.neighbors(id0)[0].id);
+	auto strategy_graph = metric::representations::make(space, metric::strategies::knn_graph(1));
+	static_assert(metric::NeighborSearchIndex_v<decltype(strategy_graph)>);
+	assert(strategy_graph.k() == graph.k());
+	assert(strategy_graph.neighbors(id0)[0].id == graph.neighbors(id0)[0].id);
+	bool rejected_missing_graph_neighbors = false;
+	try {
+		(void)metric::representations::make(space, metric::strategies::knn_graph{});
+	} catch (const std::invalid_argument &) {
+		rejected_missing_graph_neighbors = true;
+	}
+	assert(rejected_missing_graph_neighbors);
 
 	auto topology = metric::representations::topology(space);
 	static_assert(metric::GraphTopology_v<decltype(topology)>);


### PR DESCRIPTION
## Summary
- add C++ `metric::representations::make(space, strategy)` helpers for promoted search/representation strategies
- cover brute-force, matrix-cache, cover-tree, and kNN-graph strategy materialization in the representation smoke test
- document strategy-driven representation selection in the engine docs

## Verification
- `cmake --build --preset core --target engine_representations_smoke --parallel 2`
- `ctest --test-dir build/core -R engine_representations_smoke --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`