### PR TITLE
Add runtime representation policies for neighbors

### DIFF
--- a/docs/engine/runtime.md
+++ b/docs/engine/runtime.md
@@ -10,6 +10,10 @@ The first C++ runtime policy surface lives under `metric::runtime`:
 - `materialized`
 - `serial`
 - `parallel`
+- `using_implicit`
+- `using_matrix_cache`
+- `using_cover_tree`
+- `using_knn_graph`
 - `cache`
 - `diagnostics`
 
@@ -27,6 +31,17 @@ Metrics are treated as thread-safe by default. A metric can specialize `metric::
 `runtime::exact()` uses the lazy metric-space path for neighbor lookup.
 
 `runtime::materialized(runtime::exact())` uses a `MatrixCache` for `RecordId` neighbor lookup and reports `representation == "matrix_cache"` in the returned `NeighborSet`.
+
+Explicit representation policies can select the promoted neighbor execution structure:
+
+```cpp
+auto implicit = metric::runtime::using_implicit();
+auto matrix = metric::runtime::using_matrix_cache();
+auto tree = metric::runtime::using_cover_tree();
+auto graph = metric::runtime::using_knn_graph(3);
+```
+
+`using_matrix_cache()` requires a `RecordId` query because the cache indexes existing records. `using_cover_tree()` and `using_knn_graph(k)` work for record queries and `RecordId` queries, then report `cover_tree_index` or `knn_graph_index` in the returned `NeighborSet`.
 
 `runtime::approximate()` is reserved. It currently throws for neighbor lookup instead of silently selecting an approximate algorithm.
 

--- a/metric/intent/neighbors.hpp
+++ b/metric/intent/neighbors.hpp
@@ -138,8 +138,35 @@ auto find_neighbors(const Space &space, const typename Space::record_type &query
 {
 	runtime::require_exact_neighbors(runtime_policy);
 	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
-	if (runtime_policy.uses_materialization()) {
+	switch (runtime_policy.representation_mode()) {
+	case runtime::representation::matrix_cache:
 		throw std::invalid_argument("materialized neighbor runtime policy requires a RecordId query");
+	case runtime::representation::cover_tree: {
+		representations::CoverTreeIndex<Space> index(space);
+		auto result = operators::knn(index, query, count);
+		result.representation = runtime::neighbor_representation(runtime_policy);
+		return result;
+	}
+	case runtime::representation::knn_graph: {
+		const auto graph_neighbors = runtime_policy.graph_neighbors() == 0 ? count : runtime_policy.graph_neighbors();
+		representations::KnnGraphIndex<Space> index(space, graph_neighbors);
+		auto result = operators::knn(index, query, count);
+		result.representation = runtime::neighbor_representation(runtime_policy);
+		return result;
+	}
+	case runtime::representation::implicit: {
+		auto result = find_neighbors(space, query, count, strategies::brute_force{});
+		result.representation = runtime::neighbor_representation(runtime_policy);
+		return result;
+	}
+	case runtime::representation::automatic: {
+		if (runtime_policy.uses_materialization()) {
+			throw std::invalid_argument("materialized neighbor runtime policy requires a RecordId query");
+		}
+		auto result = find_neighbors(space, query, count, strategies::brute_force{});
+		result.representation = runtime::neighbor_representation(runtime_policy);
+		return result;
+	}
 	}
 	return find_neighbors(space, query, count, strategies::brute_force{});
 }
@@ -157,9 +184,43 @@ auto find_neighbors(const Space &space, RecordId query_id, std::size_t count, ru
 {
 	runtime::require_exact_neighbors(runtime_policy);
 	runtime::require_parallel_metric<typename Space::metric_type>(runtime_policy);
-	if (runtime_policy.uses_materialization()) {
+	if (runtime_policy.representation_mode() == runtime::representation::matrix_cache ||
+		(runtime_policy.representation_mode() == runtime::representation::automatic &&
+		 runtime_policy.uses_materialization())) {
 		representations::MatrixCache<Space> matrix(space);
 		auto result = operators::knn(matrix, query_id, count);
+		result.representation = runtime::neighbor_representation(runtime_policy);
+		return result;
+	}
+
+	if (runtime_policy.representation_mode() == runtime::representation::cover_tree) {
+		representations::CoverTreeIndex<Space> index(space);
+		NeighborSet<typename Space::distance_type> result;
+		result.record_count = index.record_count();
+		result.requested_count = count;
+		result.exact = true;
+		result.operator_name = "knn";
+		result.representation = runtime::neighbor_representation(runtime_policy);
+		if (count == 0) {
+			return result;
+		}
+
+		auto neighbors = index.knn(space.record(query_id), count + 1);
+		for (const auto &neighbor : neighbors) {
+			if (neighbor.id == query_id) {
+				continue;
+			}
+			result.neighbors.push_back(neighbor);
+			if (result.neighbors.size() == count) {
+				break;
+			}
+		}
+		return result;
+	}
+
+	if (runtime_policy.representation_mode() == runtime::representation::knn_graph) {
+		const auto graph_neighbors = runtime_policy.graph_neighbors() == 0 ? count : runtime_policy.graph_neighbors();
+		auto result = find_neighbors(space, query_id, count, strategies::knn_graph(graph_neighbors));
 		result.representation = runtime::neighbor_representation(runtime_policy);
 		return result;
 	}

--- a/metric/runtime/execution.hpp
+++ b/metric/runtime/execution.hpp
@@ -139,7 +139,19 @@ inline auto require_parallel_metric(policy runtime_policy) -> void
 
 inline auto execution_representation(policy runtime_policy) -> std::string
 {
-	return runtime_policy.uses_materialization() ? "matrix_cache" : "metric_space";
+	switch (runtime_policy.representation_mode()) {
+	case representation::implicit:
+		return "implicit";
+	case representation::matrix_cache:
+		return "matrix_cache";
+	case representation::cover_tree:
+		return "cover_tree_index";
+	case representation::knn_graph:
+		return "knn_graph_index";
+	case representation::automatic:
+		return runtime_policy.uses_materialization() ? "matrix_cache" : "metric_space";
+	}
+	return "metric_space";
 }
 
 inline auto neighbor_representation(policy runtime_policy) -> std::string

--- a/metric/runtime/policy.hpp
+++ b/metric/runtime/policy.hpp
@@ -5,6 +5,7 @@
 #ifndef _METRIC_RUNTIME_POLICY_HPP
 #define _METRIC_RUNTIME_POLICY_HPP
 
+#include <cstddef>
 #include <string>
 
 namespace metric::runtime {
@@ -24,32 +25,62 @@ enum class execution {
 	parallel,
 };
 
+enum class representation {
+	automatic,
+	implicit,
+	matrix_cache,
+	cover_tree,
+	knn_graph,
+};
+
 class policy {
   public:
 	constexpr policy(accuracy accuracy_mode = accuracy::exact,
 					 materialization materialization_mode = materialization::lazy,
-					 execution execution_mode = execution::serial)
+					 execution execution_mode = execution::serial,
+					 representation representation_mode = representation::automatic,
+					 std::size_t graph_neighbors = 0)
 		: accuracy_(accuracy_mode)
 		, materialization_(materialization_mode)
 		, execution_(execution_mode)
+		, representation_(representation_mode)
+		, graph_neighbors_(graph_neighbors)
 	{
 	}
 
 	constexpr auto accuracy_mode() const noexcept -> accuracy { return accuracy_; }
 	constexpr auto materialization_mode() const noexcept -> materialization { return materialization_; }
 	constexpr auto execution_mode() const noexcept -> execution { return execution_; }
+	constexpr auto representation_mode() const noexcept -> representation { return representation_; }
+	constexpr auto graph_neighbors() const noexcept -> std::size_t { return graph_neighbors_; }
 
 	constexpr auto is_exact() const noexcept -> bool { return accuracy_ == accuracy::exact; }
 	constexpr auto is_approximate() const noexcept -> bool { return accuracy_ == accuracy::approximate; }
 	constexpr auto uses_materialization() const noexcept -> bool
 	{
-		return materialization_ == materialization::materialized;
+		return materialization_ == materialization::materialized || representation_requires_materialization();
 	}
 	constexpr auto uses_parallel_execution() const noexcept -> bool { return execution_ == execution::parallel; }
+	constexpr auto has_representation_preference() const noexcept -> bool
+	{
+		return representation_ != representation::automatic;
+	}
 
 	auto representation_preference() const -> std::string
 	{
-		return uses_materialization() ? "matrix_cache" : "implicit";
+		switch (representation_) {
+		case representation::implicit:
+			return "implicit";
+		case representation::matrix_cache:
+			return "matrix_cache";
+		case representation::cover_tree:
+			return "cover_tree_index";
+		case representation::knn_graph:
+			return "knn_graph_index";
+		case representation::automatic:
+			return materialization_ == materialization::materialized ? "matrix_cache" : "implicit";
+		}
+		return "implicit";
 	}
 
 	auto name() const -> std::string
@@ -61,9 +92,17 @@ class policy {
 	}
 
   private:
+	constexpr auto representation_requires_materialization() const noexcept -> bool
+	{
+		return representation_ == representation::matrix_cache || representation_ == representation::cover_tree ||
+			   representation_ == representation::knn_graph;
+	}
+
 	accuracy accuracy_;
 	materialization materialization_;
 	execution execution_;
+	representation representation_;
+	std::size_t graph_neighbors_;
 };
 
 constexpr auto exact() -> policy
@@ -78,22 +117,50 @@ constexpr auto approximate() -> policy
 
 constexpr auto lazy(policy base = exact()) -> policy
 {
-	return policy(base.accuracy_mode(), materialization::lazy, base.execution_mode());
+	return policy(base.accuracy_mode(), materialization::lazy, base.execution_mode(), base.representation_mode(),
+				  base.graph_neighbors());
 }
 
 constexpr auto materialized(policy base = exact()) -> policy
 {
-	return policy(base.accuracy_mode(), materialization::materialized, base.execution_mode());
+	return policy(base.accuracy_mode(), materialization::materialized, base.execution_mode(), base.representation_mode(),
+				  base.graph_neighbors());
 }
 
 constexpr auto serial(policy base = exact()) -> policy
 {
-	return policy(base.accuracy_mode(), base.materialization_mode(), execution::serial);
+	return policy(base.accuracy_mode(), base.materialization_mode(), execution::serial, base.representation_mode(),
+				  base.graph_neighbors());
 }
 
 constexpr auto parallel(policy base = exact()) -> policy
 {
-	return policy(base.accuracy_mode(), base.materialization_mode(), execution::parallel);
+	return policy(base.accuracy_mode(), base.materialization_mode(), execution::parallel, base.representation_mode(),
+				  base.graph_neighbors());
+}
+
+constexpr auto using_implicit(policy base = exact()) -> policy
+{
+	return policy(base.accuracy_mode(), materialization::lazy, base.execution_mode(), representation::implicit,
+				  base.graph_neighbors());
+}
+
+constexpr auto using_matrix_cache(policy base = exact()) -> policy
+{
+	return policy(base.accuracy_mode(), materialization::materialized, base.execution_mode(),
+				  representation::matrix_cache, base.graph_neighbors());
+}
+
+constexpr auto using_cover_tree(policy base = exact()) -> policy
+{
+	return policy(base.accuracy_mode(), materialization::materialized, base.execution_mode(),
+				  representation::cover_tree, base.graph_neighbors());
+}
+
+constexpr auto using_knn_graph(std::size_t graph_neighbors = 0, policy base = exact()) -> policy
+{
+	return policy(base.accuracy_mode(), materialization::materialized, base.execution_mode(), representation::knn_graph,
+				  graph_neighbors);
 }
 
 } // namespace metric::runtime

--- a/tests/core_smoke/engine_runtime_policy_smoke.cpp
+++ b/tests/core_smoke/engine_runtime_policy_smoke.cpp
@@ -63,6 +63,17 @@ int main()
 	assert(lazy_neighbors.size() == 2);
 	assert(lazy_neighbors[0].id == space.id(1));
 
+	const auto explicit_implicit_policy = metric::runtime::using_implicit();
+	assert(explicit_implicit_policy.name() == "exact_lazy_serial");
+	assert(explicit_implicit_policy.representation_preference() == "implicit");
+	const auto explicit_implicit_diagnostics =
+		metric::runtime::diagnostics(explicit_implicit_policy, {}, "neighbors");
+	assert(explicit_implicit_diagnostics.representation == "implicit");
+	const auto explicit_implicit_neighbors =
+		metric::find_neighbors(space, std::string("ee"), 2, explicit_implicit_policy);
+	assert(explicit_implicit_neighbors.representation == "implicit");
+	assert(explicit_implicit_neighbors[0].id == space.id(1));
+
 	const auto materialized_policy = metric::runtime::materialized(metric::runtime::exact());
 	assert(materialized_policy.name() == "exact_materialized_serial");
 	assert(materialized_policy.representation_preference() == "matrix_cache");
@@ -82,6 +93,43 @@ int main()
 		metric::find_neighbors(space, space.id(0), metric::count{2}, materialized_policy);
 	assert(counted_materialized_neighbors.representation == "matrix_cache");
 	assert(counted_materialized_neighbors[0].id == materialized_neighbors[0].id);
+
+	const auto matrix_policy = metric::runtime::using_matrix_cache();
+	assert(matrix_policy.name() == "exact_materialized_serial");
+	assert(matrix_policy.representation_preference() == "matrix_cache");
+	const auto matrix_policy_neighbors = metric::find_neighbors(space, space.id(0), 2, matrix_policy);
+	assert(matrix_policy_neighbors.representation == "matrix_cache");
+	assert(matrix_policy_neighbors[0].id == materialized_neighbors[0].id);
+
+	const auto tree_policy = metric::runtime::using_cover_tree();
+	assert(tree_policy.name() == "exact_materialized_serial");
+	assert(tree_policy.representation_preference() == "cover_tree_index");
+	const auto tree_diagnostics = metric::runtime::diagnostics(tree_policy, {}, "neighbors");
+	assert(tree_diagnostics.materialized);
+	assert(tree_diagnostics.representation == "cover_tree_index");
+	const auto tree_query_neighbors = metric::find_neighbors(space, std::string("ee"), 2, tree_policy);
+	assert(tree_query_neighbors.representation == "cover_tree_index");
+	assert(tree_query_neighbors[0].id == space.id(1));
+	const auto tree_id_neighbors = metric::find_neighbors(space, space.id(0), 2, tree_policy);
+	assert(tree_id_neighbors.representation == "cover_tree_index");
+	assert(tree_id_neighbors.size() == lazy_neighbors.size());
+	assert(tree_id_neighbors[0].id == lazy_neighbors[0].id);
+	const auto empty_tree_id_neighbors = metric::find_neighbors(space, space.id(0), 0, tree_policy);
+	assert(empty_tree_id_neighbors.representation == "cover_tree_index");
+	assert(empty_tree_id_neighbors.empty());
+
+	const auto graph_policy = metric::runtime::using_knn_graph(2);
+	assert(graph_policy.name() == "exact_materialized_serial");
+	assert(graph_policy.graph_neighbors() == 2);
+	assert(graph_policy.representation_preference() == "knn_graph_index");
+	const auto graph_diagnostics = metric::runtime::diagnostics(graph_policy, {}, "neighbors");
+	assert(graph_diagnostics.representation == "knn_graph_index");
+	const auto graph_query_neighbors = metric::find_neighbors(space, std::string("ee"), 2, graph_policy);
+	assert(graph_query_neighbors.representation == "knn_graph_index");
+	assert(graph_query_neighbors[0].id == tree_query_neighbors[0].id);
+	const auto graph_id_neighbors = metric::find_neighbors(space, space.id(0), 2, graph_policy);
+	assert(graph_id_neighbors.representation == "knn_graph_index");
+	assert(graph_id_neighbors[0].id == materialized_neighbors[0].id);
 
 	const auto parallel_policy = metric::runtime::parallel(materialized_policy);
 	assert(parallel_policy.name() == "exact_materialized_parallel");


### PR DESCRIPTION
## Summary
- add explicit C++ runtime representation preferences for implicit, matrix-cache, cover-tree, and kNN-graph neighbor execution
- route `find_neighbors(..., runtime::policy)` through those preferences while preserving existing automatic lazy/materialized behavior
- document the new runtime helpers and cover them in the runtime policy smoke test

## Verification
- `cmake --build --preset core --target engine_runtime_policy_smoke --parallel 2`
- `ctest --test-dir build/core -R engine_runtime_policy_smoke --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --build --preset core --parallel 2`
- `ctest --preset core --output-on-failure`