### PR TITLE
Add Python runtime representation policies

### DIFF
--- a/docs/engine/runtime.md
+++ b/docs/engine/runtime.md
@@ -91,6 +91,8 @@ Approximate runtime policies throw for these promoted paths until backed by expl
 
 Python exposes `RuntimePolicy`, `CachePolicy`, `RuntimeDiagnostics`, and `runtime_diagnostics(...)` through `metric.runtime` and the top-level `metric` package. Promoted `Space` intent methods accept `runtime=` and currently execute exact deterministic paths only; approximate policies are explicit placeholders. `Space.groups(..., runtime=RuntimePolicy(cache="materialized"))` records `representation == "matrix"` when no explicit representation override is supplied.
 
+Python neighbor execution also accepts runtime representation helpers through `metric.runtime`: `using_implicit()`, `using_matrix()`, `using_tree()`, and `using_graph(count)`. Matrix and tree policies can answer record queries. Graph policies use the exact kNN graph representation for queryless neighbor rows and reject arbitrary record queries because the promoted Python graph facade stores source-index adjacency.
+
 ```python
 from metric import RuntimePolicy
 

--- a/python/pkg/metric/runtime.py
+++ b/python/pkg/metric/runtime.py
@@ -1,11 +1,13 @@
 """Runtime policy objects for the revived Python engine facade."""
 
 from dataclasses import dataclass
+import operator
 
 from metric.exceptions import StrategyParameterError, StrategyUnavailableError
 
 
 _CACHE_MODES = {"auto", "lazy", "materialized", "none"}
+_REPRESENTATION_MODES = {"auto", "metric_space", "matrix", "tree", "graph"}
 
 
 @dataclass(frozen=True)
@@ -28,6 +30,8 @@ class RuntimePolicy:
     exact: bool = True
     parallel: bool = False
     cache: str | CachePolicy = "auto"
+    representation: str = "auto"
+    graph_count: int | None = None
 
     def __post_init__(self):
         if not isinstance(self.exact, bool):
@@ -35,11 +39,38 @@ class RuntimePolicy:
         if not isinstance(self.parallel, bool):
             raise StrategyParameterError("parallel must be a bool")
         cache = self.cache if isinstance(self.cache, CachePolicy) else CachePolicy(self.cache)
+        if not isinstance(self.representation, str):
+            raise StrategyParameterError("representation must be a string")
+        if self.representation not in _REPRESENTATION_MODES:
+            raise StrategyParameterError(
+                f"representation must be one of {sorted(_REPRESENTATION_MODES)!r}"
+            )
+        graph_count = self.graph_count
+        if graph_count is not None:
+            try:
+                graph_count = operator.index(graph_count)
+            except TypeError:
+                raise StrategyParameterError("graph_count must be an integer") from None
+            if graph_count < 0:
+                raise StrategyParameterError("graph_count must be non-negative")
         object.__setattr__(self, "cache", cache)
+        object.__setattr__(self, "graph_count", graph_count)
 
     @property
     def cache_mode(self):
         return self.cache.mode
+
+    @property
+    def representation_preference(self):
+        if self.representation == "matrix":
+            return "matrix"
+        if self.representation == "tree":
+            return "exact_tree_index"
+        if self.representation == "graph":
+            return "exact_knn_graph"
+        if self.representation == "metric_space":
+            return "metric_space"
+        return "matrix" if self.cache_mode == "materialized" else "metric_space"
 
     @property
     def name(self):
@@ -86,7 +117,7 @@ def require_exact_runtime(runtime=None):
     return policy
 
 
-def runtime_diagnostics(runtime=None, *, representation="metric_space", intent=None):
+def runtime_diagnostics(runtime=None, *, representation=None, intent=None):
     """Describe the normalized runtime policy and chosen representation."""
 
     policy = runtime_policy(runtime)
@@ -99,7 +130,9 @@ def runtime_diagnostics(runtime=None, *, representation="metric_space", intent=N
         exact=policy.exact,
         parallel=policy.parallel,
         cache_mode=policy.cache_mode,
-        representation="metric_space" if representation is None else representation,
+        representation=(
+            policy.representation_preference if representation is None else representation
+        ),
         intent=intent,
         supported=supported,
         reason=reason,
@@ -116,22 +149,87 @@ def approximate(cache="auto", parallel=False):
 
 def materialized(policy=None):
     policy = runtime_policy(policy)
-    return RuntimePolicy(exact=policy.exact, parallel=policy.parallel, cache="materialized")
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=policy.parallel,
+        cache="materialized",
+        representation=policy.representation,
+        graph_count=policy.graph_count,
+    )
 
 
 def lazy(policy=None):
     policy = runtime_policy(policy)
-    return RuntimePolicy(exact=policy.exact, parallel=policy.parallel, cache="lazy")
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=policy.parallel,
+        cache="lazy",
+        representation=policy.representation,
+        graph_count=policy.graph_count,
+    )
 
 
 def parallel(policy=None):
     policy = runtime_policy(policy)
-    return RuntimePolicy(exact=policy.exact, parallel=True, cache=policy.cache)
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=True,
+        cache=policy.cache,
+        representation=policy.representation,
+        graph_count=policy.graph_count,
+    )
 
 
 def serial(policy=None):
     policy = runtime_policy(policy)
-    return RuntimePolicy(exact=policy.exact, parallel=False, cache=policy.cache)
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=False,
+        cache=policy.cache,
+        representation=policy.representation,
+        graph_count=policy.graph_count,
+    )
+
+
+def using_implicit(policy=None):
+    policy = runtime_policy(policy)
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=policy.parallel,
+        cache="lazy",
+        representation="metric_space",
+    )
+
+
+def using_matrix(policy=None):
+    policy = runtime_policy(policy)
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=policy.parallel,
+        cache="materialized",
+        representation="matrix",
+    )
+
+
+def using_tree(policy=None):
+    policy = runtime_policy(policy)
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=policy.parallel,
+        cache="materialized",
+        representation="tree",
+    )
+
+
+def using_graph(count=None, policy=None):
+    policy = runtime_policy(policy)
+    return RuntimePolicy(
+        exact=policy.exact,
+        parallel=policy.parallel,
+        cache="materialized",
+        representation="graph",
+        graph_count=count,
+    )
 
 
 __all__ = [
@@ -147,4 +245,8 @@ __all__ = [
     "runtime_diagnostics",
     "runtime_policy",
     "serial",
+    "using_graph",
+    "using_implicit",
+    "using_matrix",
+    "using_tree",
 ]

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -188,6 +188,16 @@ class FiniteMetricSpace:
             if distance <= radius
         ]
 
+    def neighbors(self, query, k=None, count=None, radius=None):
+        if k is not None and count is not None:
+            raise ValueError("use either k or count, not both")
+        if radius is not None:
+            if k is not None or count is not None:
+                raise ValueError("radius cannot be combined with k or count")
+            return self.rnn(query, radius)
+        value = 1 if k is None and count is None else count if count is not None else k
+        return self.knn(query, _coerce_non_negative_integer(value, "count"))
+
 
 class Space(FiniteMetricSpace):
     """Intent-first facade for a finite metric space.
@@ -229,16 +239,30 @@ class Space(FiniteMetricSpace):
         representation=None,
         runtime=None,
     ):
-        require_exact_runtime(runtime)
+        runtime_policy = require_exact_runtime(runtime)
         if strategy is not None:
             raise ValueError("strategy overrides are not promoted for Python neighbors yet")
+
+        has_explicit_count = k is not None or count is not None
+        neighbor_count = self._neighbor_count(k, count) if has_explicit_count or radius is None else None
+        if representation is None:
+            representation = self._runtime_neighbor_representation(
+                runtime_policy,
+                query=query,
+                count=neighbor_count,
+                radius=radius,
+                include_self=include_self,
+            )
         if query is not None and representation is not None:
             return representation.neighbors(query, k=k, count=count, radius=radius)
         if representation is not None:
             representation.ensure_fresh()
+            if getattr(representation, "representation", None) == "exact_knn_graph":
+                return [
+                    list(representation.neighbors(source_index))[:neighbor_count]
+                    for source_index in range(len(self.records))
+                ]
 
-        has_explicit_count = k is not None or count is not None
-        neighbor_count = self._neighbor_count(k, count) if has_explicit_count or radius is None else None
         if query is None:
             return [
                 self._neighbor_row(source_index, neighbor_count, radius=radius, include_self=include_self)
@@ -411,6 +435,49 @@ class Space(FiniteMetricSpace):
             representation.ensure_fresh()
             representation_name = getattr(representation, "representation", representation_name)
         return representation_name
+
+    def _runtime_neighbor_representation(
+        self,
+        runtime_policy,
+        *,
+        query,
+        count,
+        radius,
+        include_self,
+    ):
+        if runtime_policy.representation == "auto":
+            if runtime_policy.cache_mode == "materialized":
+                return self.to_matrix()
+            return None
+        if runtime_policy.representation == "metric_space":
+            return None
+        if runtime_policy.representation == "matrix":
+            return self.to_matrix()
+        if runtime_policy.representation == "tree":
+            return self.to_tree()
+        if runtime_policy.representation == "graph":
+            if query is not None:
+                raise StrategyUnavailableError(
+                    "graph runtime representation requires queryless Space.neighbors(...) "
+                    "in the Python facade"
+                )
+            if radius is not None:
+                raise StrategyUnavailableError(
+                    "graph runtime representation does not support radius neighbor queries "
+                    "in the Python facade"
+                )
+            if include_self:
+                raise StrategyUnavailableError(
+                    "graph runtime representation does not support include_self=True "
+                    "in the Python facade"
+                )
+            graph_count = (
+                runtime_policy.graph_count
+                if runtime_policy.graph_count is not None
+                else count
+            )
+            return self.to_graph(count=0 if graph_count is None else graph_count)
+        return None
 
     def reduce(self, count=None, strategy=None, *, representation=None, runtime=None):
         require_exact_runtime(runtime)

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -1393,6 +1393,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(policy.cache_mode, "materialized")
         self.assertEqual(policy.name, "exact_materialized_parallel")
         self.assertEqual(runtime.materialized(runtime.parallel()).name, "exact_materialized_parallel")
+        self.assertEqual(runtime.using_matrix().representation_preference, "matrix")
+        self.assertEqual(runtime.using_tree().representation_preference, "exact_tree_index")
+        self.assertEqual(runtime.using_graph(1).representation_preference, "exact_knn_graph")
         diagnostics = runtime_diagnostics(policy, representation="matrix", intent="neighbors")
         self.assertIsInstance(diagnostics, RuntimeDiagnostics)
         self.assertEqual(diagnostics.policy_name, "exact_materialized_parallel")
@@ -1414,18 +1417,41 @@ class RevivalApiTest(unittest.TestCase):
         self.assertFalse(approximate_diagnostics.supported)
         self.assertIn("approximate", approximate_diagnostics.reason)
         self.assertEqual(space.neighbors("cut", count=2, runtime=policy), [(0, 1), (1, 1)])
-        self.assertEqual(space.neighbors("cut", count=2, representation=space.to_tree(), runtime=policy), [(0, 1), (1, 1)])
+        self.assertEqual(
+            space.neighbors("cut", count=2, representation=space.to_tree(), runtime=policy),
+            [(0, 1), (1, 1)],
+        )
+        self.assertEqual(
+            space.neighbors("cut", count=2, runtime=runtime.using_matrix()),
+            [(0, 1), (1, 1)],
+        )
+        self.assertEqual(
+            space.neighbors("cut", count=2, runtime=runtime.using_tree()),
+            [(0, 1), (1, 1)],
+        )
+        graph_policy = runtime.using_graph(1)
+        self.assertEqual(runtime_diagnostics(graph_policy).representation, "exact_knn_graph")
+        self.assertEqual(
+            space.neighbors(count=1, runtime=graph_policy),
+            [[(1, 1)], [(0, 1)], [(0, 1)], [(1, 2)]],
+        )
         self.assertEqual(space.groups(count=2, runtime=policy).representation, "matrix")
         self.assertEqual(space.describe(runtime=policy).record_count, len(self.records))
         self.assertEqual(space.describe_structure(runtime=policy).record_count, len(self.records))
         self.assertEqual(space.compare(space, runtime=policy).left_record_count, len(self.records))
 
+        with self.assertRaisesRegex(StrategyUnavailableError, "queryless"):
+            space.neighbors("cut", count=2, runtime=graph_policy)
         with self.assertRaises(StrategyUnavailableError):
             space.neighbors("cut", count=2, runtime=RuntimePolicy(exact=False))
         with self.assertRaises(StrategyUnavailableError):
             space.groups(count=2, runtime=RuntimePolicy(exact=False))
         with self.assertRaises(StrategyParameterError):
             RuntimePolicy(cache="unknown")
+        with self.assertRaises(StrategyParameterError):
+            RuntimePolicy(representation="unknown")
+        with self.assertRaises(StrategyParameterError):
+            RuntimePolicy(representation="graph", graph_count=-1)
         with self.assertRaises(StrategyParameterError):
             RuntimePolicy(parallel="yes")
 


### PR DESCRIPTION
## Summary
- add Python `RuntimePolicy` representation preferences for metric-space, matrix, tree, and graph neighbor execution
- route `Space.neighbors(..., runtime=...)` through matrix/tree preferences and queryless graph adjacency
- document and test the Python runtime representation helpers

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `for example in python/examples/metric_space/*.py python/examples/engine/*.py; do PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python "$example" >/dev/null || exit $?; done`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`