### PR TITLE
Add Python clustered-space mapping adapter

### DIFF
--- a/docs/engine/mappings.md
+++ b/docs/engine/mappings.md
@@ -28,6 +28,7 @@ The current engine mapping layer includes:
 - PCFA-backed `metric::embed`
 - PCFA-backed `metric::reduce`
 - DBSCAN-noise-filtered `metric::denoise`
+- Python clustered-space mapping from `ClusteringResult`
 - deterministic Python `Space.map`
 - DBSCAN-noise-filtered Python `Space.denoise`
 
@@ -45,7 +46,9 @@ auto coordinates = mapped.space;
 
 ## Python Status
 
-Python exposes `Space.map(transform=..., metric=...)` and `metric.operators.map_space` for deterministic transforms into derived `Space` objects. The positional compatibility form `Space.map(transform, metric)` remains valid, but no-argument map calls raise `metric.AmbiguousIntentError` and target/strategy mapping forms raise `metric.StrategyUnavailableError` until learned or fitted mapping contracts are promoted. Python also exposes `Space.denoise` and `metric.operators.denoise_space` for DBSCAN-noise filtering into derived `Space` objects. Python also exposes `metric.mappings` as a beta compatibility bridge for installed legacy names; learned or inverse mapping facades should be promoted only when they have named result contracts, examples, and wheel CI coverage.
+Python exposes `metric.mappings.make_clustered_space_mapping(...)`, `metric.mappings.fit(...)`, `metric.mappings.transform(...)`, and `metric.mappings.clustered_space(...)` for turning an engine-style `ClusteringResult` into a derived cluster-level `Space`. The derived records are `ClusterRecord` values that keep the cluster label, representative source record, and source members; the derived metric is the source-space distance between cluster representatives.
+
+Python also exposes `Space.map(transform=..., metric=...)` and `metric.operators.map_space` for deterministic transforms into derived `Space` objects. The positional compatibility form `Space.map(transform, metric)` remains valid, but no-argument map calls raise `metric.AmbiguousIntentError` and target/strategy mapping forms raise `metric.StrategyUnavailableError` until learned or fitted mapping contracts are promoted. Python also exposes `Space.denoise` and `metric.operators.denoise_space` for DBSCAN-noise filtering into derived `Space` objects. Python also exposes `metric.mappings` as a beta compatibility bridge for installed legacy names; learned or inverse mapping facades should be promoted only when they have named result contracts, examples, and wheel CI coverage.
 
 ## Promotion Rule
 

--- a/python/pkg/metric/mappings.py
+++ b/python/pkg/metric/mappings.py
@@ -5,7 +5,74 @@ provides a stable import location without forcing the core wheel to import the
 broader legacy compiled mapping bindings.
 """
 
+from dataclasses import dataclass
+import operator
+
+
 STABILITY = "beta"
+
+
+@dataclass(frozen=True)
+class ClusterRecord:
+    """One derived clustered-space record with source-record lineage."""
+
+    label: int
+    representative: object
+    members: tuple
+    noise: bool = False
+
+
+@dataclass(frozen=True)
+class ClusteredSpaceModel:
+    """Fitted model that derives a cluster-level metric space."""
+
+    records: tuple
+    distances: tuple
+    source_records: tuple
+    representative_records: tuple
+    source_record_count: int
+    strategy: str
+    representation: str
+
+    def transform(self, space=None):
+        if space is not None and len(space) != self.source_record_count:
+            raise ValueError("source space size does not match fitted clustered-space mapping")
+
+        distances = self.distances
+
+        def cluster_distance(lhs, rhs):
+            return distances[lhs.label][rhs.label]
+
+        from metric.operators import MappingResult
+        from metric.spaces import Space
+
+        return MappingResult(
+            space=Space(list(self.records), metric=cluster_distance),
+            source_record_ids=tuple(self.representative_records),
+            source_record_count=self.source_record_count,
+            target_record_count=len(self.records),
+            exact=True,
+            operator_name="map",
+            mapping="clustered_space",
+            strategy=self.strategy,
+            representation=self.representation,
+            inverse_supported=False,
+            source_records=self.source_records,
+            representative_records=self.representative_records,
+        )
+
+    def inverse_supported(self):
+        return False
+
+
+@dataclass(frozen=True)
+class ClusteredSpaceMapping:
+    """Mapping adapter from a ClusteringResult into a clustered Space."""
+
+    clustering: object
+
+    def fit(self, space):
+        return _build_clustered_space_model(space, self.clustering)
 
 
 def _load_legacy_module():
@@ -32,4 +99,115 @@ def legacy_module():
     return module
 
 
-__all__ = ["STABILITY", "available", "legacy_module"]
+def fit(mapping, space):
+    """Fit a promoted mapping adapter to a finite metric space."""
+    return mapping.fit(space)
+
+
+def transform(model, space=None):
+    """Transform a finite metric space through a fitted mapping model."""
+    return model.transform(space)
+
+
+def make_clustered_space_mapping(clustering):
+    """Create a mapping adapter from an engine-style clustering result."""
+    return ClusteredSpaceMapping(clustering)
+
+
+def clustered_space(space, clustering):
+    """Derive a cluster-level Space from a source Space and clustering result."""
+    return make_clustered_space_mapping(clustering).fit(space).transform(space)
+
+
+def _build_clustered_space_model(space, clustering):
+    record_count = _coerce_count(getattr(clustering, "record_count", None), "record_count")
+    if record_count != len(space):
+        raise ValueError("clustering record count does not match source space")
+
+    assignments = tuple(getattr(clustering, "assignments", ()))
+    if len(assignments) != record_count:
+        raise ValueError("clustering assignments do not match record count")
+
+    cluster_count = _coerce_count(getattr(clustering, "cluster_count", None), "cluster_count")
+    if cluster_count == 0:
+        raise ValueError("cannot derive a clustered space without clusters")
+
+    noise_label = getattr(clustering, "noise_label", -1)
+    source_ids = tuple(getattr(space, "ids", tuple(range(record_count))))
+    source_records = [[] for _ in range(cluster_count)]
+
+    for index, label in enumerate(assignments):
+        if label == noise_label:
+            continue
+        label = _coerce_count(label, "cluster assignment")
+        if label >= cluster_count:
+            raise ValueError("clustering assignment references an unknown cluster")
+        source_records[label].append(source_ids[index])
+
+    medoids = tuple(getattr(clustering, "medoids", ()))
+    representative_positions = []
+    representative_records = []
+    records = []
+
+    for label, members in enumerate(source_records):
+        if not members:
+            raise ValueError("cannot derive a clustered space with empty clusters")
+        representative_position = (
+            _coerce_count(medoids[label], "cluster medoid")
+            if label < len(medoids)
+            else _position_for_source_id(space, members[0])
+        )
+        if representative_position >= record_count:
+            raise ValueError("clustering medoid references an unknown source record")
+        representative_positions.append(representative_position)
+        representative = source_ids[representative_position]
+        representative_records.append(representative)
+        records.append(
+            ClusterRecord(label=label, representative=representative, members=tuple(members))
+        )
+
+    distances = tuple(
+        tuple(space.distance(lhs, rhs) for rhs in representative_positions)
+        for lhs in representative_positions
+    )
+
+    return ClusteredSpaceModel(
+        records=tuple(records),
+        distances=distances,
+        source_records=tuple(tuple(members) for members in source_records),
+        representative_records=tuple(representative_records),
+        source_record_count=record_count,
+        strategy=getattr(clustering, "algorithm", "clustering"),
+        representation=getattr(clustering, "representation", "metric_space"),
+    )
+
+
+def _coerce_count(value, name):
+    try:
+        value = operator.index(value)
+    except TypeError:
+        raise TypeError(f"{name} must be an integer") from None
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
+
+
+def _position_for_source_id(space, source_id):
+    try:
+        return space.ids.index(source_id)
+    except ValueError:
+        raise ValueError("cluster source record is not present in the source space") from None
+
+
+__all__ = [
+    "STABILITY",
+    "ClusterRecord",
+    "ClusteredSpaceMapping",
+    "ClusteredSpaceModel",
+    "available",
+    "clustered_space",
+    "fit",
+    "legacy_module",
+    "make_clustered_space_mapping",
+    "transform",
+]

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -229,6 +229,8 @@ class MappingResult:
     strategy: str
     representation: str
     inverse_supported: bool
+    source_records: tuple = ()
+    representative_records: tuple = ()
 
     def inverse_transform(self, *args, **kwargs):
         _raise_unsupported_inverse(self)

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -348,6 +348,10 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("RuntimeDiagnostics", metric.__all__)
         self.assertIn("runtime_diagnostics", metric.__all__)
         self.assertEqual(mappings.STABILITY, "beta")
+        self.assertTrue(callable(mappings.clustered_space))
+        self.assertTrue(callable(mappings.make_clustered_space_mapping))
+        self.assertTrue(callable(mappings.fit))
+        self.assertTrue(callable(mappings.transform))
         self.assertEqual(transforms.STABILITY, "beta")
         self.assertIsInstance(representations.matrix(Space(self.records, self.metric)), MatrixSpace)
         self.assertIsInstance(representations.matrix_space(self.records, self.metric), MatrixSpace)
@@ -602,6 +606,36 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(matrix_groups.representation, "matrix")
         self.assertEqual(matrix_groups.assignments, groups.assignments)
 
+        clustered = mappings.clustered_space(group_space, groups)
+        self.assertIsInstance(clustered, MappingResult)
+        self.assertIsInstance(clustered.space, Space)
+        self.assertEqual(clustered.mapping, "clustered_space")
+        self.assertEqual(clustered.strategy, "kmedoids")
+        self.assertEqual(clustered.representation, "metric_space")
+        self.assertEqual(clustered.source_record_count, 5)
+        self.assertEqual(clustered.target_record_count, 2)
+        self.assertEqual(clustered.source_record_ids, (1, 3))
+        self.assertEqual(clustered.source_records, ((0, 1, 2), (3, 4)))
+        self.assertEqual(clustered.representative_records, (1, 3))
+        self.assertFalse(clustered.inverse_supported)
+        self.assertEqual(
+            clustered.space.records[0],
+            mappings.ClusterRecord(label=0, representative=1, members=(0, 1, 2)),
+        )
+        self.assertEqual(clustered.space.records[1].members, (3, 4))
+        self.assertEqual(clustered.space.distance(0, 1), group_space.distance(1, 3))
+        mapping = mappings.make_clustered_space_mapping(groups)
+        model = mappings.fit(mapping, group_space)
+        self.assertFalse(model.inverse_supported())
+        self.assertEqual(
+            mappings.transform(model, group_space).source_records,
+            clustered.source_records,
+        )
+        id_space = Space([0, 1, 10], metric=lambda lhs, rhs: abs(lhs - rhs), ids=["a", "b", "c"])
+        id_clustered = mappings.clustered_space(id_space, id_space.groups(KMedoids(groups=2)))
+        self.assertEqual(id_clustered.source_records, (("a", "b"), ("c",)))
+        self.assertEqual(id_clustered.representative_records, ("a", "c"))
+
         density_groups = group_space.groups(DBSCAN(radius=1, min_points=2))
         self.assertIsInstance(density_groups, ClusteringResult)
         self.assertEqual(density_groups.assignments, (0, 0, 0, 1, 1))
@@ -620,6 +654,11 @@ class RevivalApiTest(unittest.TestCase):
             group_space.groups(KMedoids(groups=2), count=2)
 
         outlier_space = Space([0, 1, 10, 11, 30], metric=lambda lhs, rhs: abs(lhs - rhs))
+        noise_groups = outlier_space.groups(DBSCAN(radius=2, min_points=2))
+        noise_clustered = mappings.clustered_space(outlier_space, noise_groups)
+        self.assertEqual(noise_clustered.source_records, ((0, 1), (2, 3)))
+        self.assertEqual(noise_clustered.representative_records, (0, 2))
+        self.assertEqual(noise_clustered.target_record_count, 2)
         outliers = outlier_space.outliers(DBSCAN(radius=2, min_points=2))
         self.assertIsInstance(outliers, OutlierResult)
         self.assertEqual(outliers.outliers, (Outlier(record_id=4, score=19),))


### PR DESCRIPTION
## Summary
- add Python `metric.mappings` clustered-space mapping helpers matching the C++ fit/transform adapter shape
- carry grouped source-record lineage and representative records through `MappingResult`
- document and test deriving a cluster-level `Space` from KMedoids and DBSCAN `ClusteringResult` values

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `for example in python/examples/metric_space/*.py python/examples/engine/*.py; do PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python "$example" >/dev/null || exit $?; done`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`