### PR TITLE
Add Python core facade namespace

### DIFF
--- a/docs/engine/metric-space.md
+++ b/docs/engine/metric-space.md
@@ -33,13 +33,17 @@ The record type is not required to be a vector. A metric can operate on strings,
 
 ```python
 from metric import Edit, Space
+from metric.core import make_space
 
 records = ["metric", "metrics", "matrix", "tree"]
 space = Space(records, Edit())
+same_space = make_space(records, Edit())
 
 distance = space.distance(0, 1)
 matrix = space.to_matrix()
 ```
+
+`metric.core` is the Python namespace for the central engine building blocks: `Metric`, `Space`, `FiniteMetricSpace`, runtime policy metadata, and core metric-space errors. The top-level `metric.Space` import remains the shortest path for examples, while `metric.core` gives contributors a stable namespace that mirrors the engine model.
 
 `to_matrix()` makes materialization explicit in Python. It returns an independent finite matrix-space view with the same records and metric.
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -2,6 +2,7 @@
 
 The revived core API is organized around explicit finite metric spaces:
 
+- ``metric.core`` for central finite metric-space building blocks
 - ``metric.metrics`` for metric constructors
 - ``metric.spaces`` for finite metric-space helpers
 - ``metric.exceptions`` for public METRIC error types
@@ -19,7 +20,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from . import exceptions, intent, mappings, metrics, operators, representations, runtime, spaces, strategies, transforms
+from . import core, exceptions, intent, mappings, metrics, operators, representations, runtime, spaces, strategies, transforms
 from .exceptions import (
     AmbiguousIntentError,
     IncompatibleSpaceError,

--- a/python/pkg/metric/core.py
+++ b/python/pkg/metric/core.py
@@ -1,0 +1,34 @@
+"""Core finite metric-space building blocks for the Python engine facade."""
+
+from metric.exceptions import (
+    MetricError,
+    MissingMetricError,
+    StaleRepresentationError,
+    UnsupportedOperationError,
+)
+from metric.metrics import Edit, Metric
+from metric.runtime import CachePolicy, RuntimeDiagnostics, RuntimePolicy, runtime_diagnostics
+from metric.spaces import FiniteMetricSpace, MatrixSpace, Space
+
+
+def make_space(records, metric=None, **kwargs):
+    """Construct a finite metric Space from records and an explicit metric."""
+    return Space(records, metric=metric, **kwargs)
+
+
+__all__ = [
+    "CachePolicy",
+    "Edit",
+    "FiniteMetricSpace",
+    "MatrixSpace",
+    "Metric",
+    "MetricError",
+    "MissingMetricError",
+    "RuntimeDiagnostics",
+    "RuntimePolicy",
+    "Space",
+    "StaleRepresentationError",
+    "UnsupportedOperationError",
+    "make_space",
+    "runtime_diagnostics",
+]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import metric
 import metric.distance as distance_module
 import numpy as np
-from metric import exceptions, intent, mappings, representations, runtime, transforms
+from metric import core, exceptions, intent, mappings, representations, runtime, transforms
 from metric.exceptions import (
     AmbiguousIntentError,
     IncompatibleSpaceError,
@@ -119,6 +119,19 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(MatrixSpace, FiniteMetricSpace)
         self.assertIs(metric.metrics.Edit, Edit)
         self.assertIs(metric.metrics.Metric, Metric)
+        self.assertIs(metric.core, core)
+        self.assertIs(metric.core.Edit, Edit)
+        self.assertIs(metric.core.Metric, Metric)
+        self.assertIs(metric.core.Space, Space)
+        self.assertIs(metric.core.FiniteMetricSpace, FiniteMetricSpace)
+        self.assertIs(metric.core.MatrixSpace, MatrixSpace)
+        self.assertIs(metric.core.RuntimePolicy, RuntimePolicy)
+        self.assertIs(metric.core.RuntimeDiagnostics, RuntimeDiagnostics)
+        self.assertIs(metric.core.MetricError, MetricError)
+        self.assertIs(metric.core.MissingMetricError, MissingMetricError)
+        self.assertIs(metric.core.StaleRepresentationError, StaleRepresentationError)
+        self.assertIs(metric.core.UnsupportedOperationError, UnsupportedOperationError)
+        self.assertEqual(metric.core.make_space(self.records, self.metric).records, self.records)
         for name in ("Manhattan", "Minkowski", "ThresholdedEuclidean"):
             self.assertTrue(hasattr(metric.metrics, name))
         self.assertIs(metric.spaces.FiniteMetricSpace, FiniteMetricSpace)
@@ -274,6 +287,7 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.UnsupportedOperationError, UnsupportedOperationError)
         self.assertIn("FiniteMetricSpace", metric.__all__)
         self.assertIn("Space", metric.__all__)
+        self.assertIn("core", metric.__all__)
         self.assertIn("exceptions", metric.__all__)
         self.assertIn("MetricError", metric.__all__)
         self.assertIn("Metric", metric.__all__)


### PR DESCRIPTION
## Summary
- add `metric.core` as the Python namespace for central finite metric-space building blocks
- expose `make_space(...)` alongside `Metric`, `Space`, runtime metadata, and core errors
- document and test the new core facade import surface

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `for example in python/examples/metric_space/*.py python/examples/engine/*.py; do PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python "$example" >/dev/null || exit $?; done`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`