### PR TITLE
Add C++ engine compatibility adapters

### DIFF
--- a/docs/engine/migration.md
+++ b/docs/engine/migration.md
@@ -30,9 +30,20 @@ The following remain valid for existing code:
 - `metric::MatrixSpace`
 - `metric::GraphSpace`
 - `metric::TreeSpace`
+- C++ compatibility aliases under `metric/compat/aliases.hpp`
+- C++ legacy-space adapters under `metric/compat/legacy_space_adapters.hpp`
 - historical mapping classes
 - historical transform classes
 - Python compatibility modules under `metric.distance`, `metric.correlation`, `metric.mapping`, `metric.space`, and `metric.transform`
+
+Legacy index-based C++ spaces can be copied into the engine model explicitly when the metric object is available:
+
+```cpp
+#include <metric/compat/legacy_space_adapters.hpp>
+
+auto engine_space = metric::compat::to_metric_space(legacy_space, metric);
+auto id = metric::compat::record_id_from_legacy_index(0);
+```
 
 ## Migration Steps
 

--- a/metric/compat/aliases.hpp
+++ b/metric/compat/aliases.hpp
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_COMPAT_ALIASES_HPP
+#define _METRIC_COMPAT_ALIASES_HPP
+
+#include "../space.hpp"
+
+namespace metric::compat {
+
+template <typename RecType, typename Metric>
+using LegacyMatrix = metric::Matrix<RecType, Metric>;
+
+template <typename RecType, typename Metric>
+using LegacyMatrixSpace = metric::MatrixSpace<RecType, Metric>;
+
+template <typename RecType, typename Metric>
+using LegacyTree = metric::Tree<RecType, Metric>;
+
+template <typename RecType, typename Metric>
+using LegacyTreeSpace = metric::TreeSpace<RecType, Metric>;
+
+template <typename Sample, typename Distance, typename WeightType = bool, bool isDense = false, bool isSymmetric = true>
+using LegacyGraphSpace = metric::GraphSpace<Sample, Distance, WeightType, isDense, isSymmetric>;
+
+template <typename RecType, typename Metric>
+using LegacyFiniteSpace = metric::FiniteSpace<RecType, Metric>;
+
+} // namespace metric::compat
+
+#endif

--- a/metric/compat/legacy_space_adapters.hpp
+++ b/metric/compat/legacy_space_adapters.hpp
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef _METRIC_COMPAT_LEGACY_SPACE_ADAPTERS_HPP
+#define _METRIC_COMPAT_LEGACY_SPACE_ADAPTERS_HPP
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "../core/metric_space.hpp"
+#include "../core/record_id.hpp"
+
+namespace metric::compat {
+
+inline constexpr auto record_id_from_legacy_index(std::size_t index) -> metric::RecordId
+{
+	return metric::RecordId::from_index(index);
+}
+
+inline constexpr auto legacy_index(metric::RecordId id) -> std::size_t { return id.index(); }
+
+namespace detail {
+template <typename LegacySpace>
+using legacy_record_t =
+	std::decay_t<decltype(std::declval<const LegacySpace &>()[std::declval<std::size_t>()])>;
+} // namespace detail
+
+template <typename LegacySpace>
+auto legacy_records(const LegacySpace &legacy) -> std::vector<detail::legacy_record_t<LegacySpace>>
+{
+	std::vector<detail::legacy_record_t<LegacySpace>> records;
+	records.reserve(legacy.size());
+	for (std::size_t index = 0; index < legacy.size(); ++index) {
+		records.push_back(legacy[index]);
+	}
+	return records;
+}
+
+template <typename LegacySpace, typename Metric>
+auto to_metric_space(const LegacySpace &legacy, Metric metric)
+	-> metric::MetricSpace<detail::legacy_record_t<LegacySpace>, std::decay_t<Metric>>
+{
+	return metric::make_space(legacy_records(legacy), std::move(metric));
+}
+
+} // namespace metric::compat
+
+#endif

--- a/tests/core_smoke/CMakeLists.txt
+++ b/tests/core_smoke/CMakeLists.txt
@@ -26,6 +26,9 @@ target_link_libraries(space_consistency_smoke PRIVATE ${METRIC_TARGET_NAME})
 add_executable(engine_core_smoke engine_core_smoke.cpp)
 target_link_libraries(engine_core_smoke PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_compat_smoke engine_compat_smoke.cpp)
+target_link_libraries(engine_compat_smoke PRIVATE ${METRIC_TARGET_NAME})
+
 add_executable(engine_representations_smoke engine_representations_smoke.cpp)
 target_link_libraries(engine_representations_smoke PRIVATE ${METRIC_TARGET_NAME})
 
@@ -104,6 +107,7 @@ endif ()
 add_test(NAME metric_contracts_smoke COMMAND metric_contracts_smoke)
 add_test(NAME space_consistency_smoke COMMAND space_consistency_smoke)
 add_test(NAME engine_core_smoke COMMAND engine_core_smoke)
+add_test(NAME engine_compat_smoke COMMAND engine_compat_smoke)
 add_test(NAME engine_representations_smoke COMMAND engine_representations_smoke)
 add_test(NAME engine_nearest_operators_smoke COMMAND engine_nearest_operators_smoke)
 add_test(NAME engine_clustering_operators_smoke COMMAND engine_clustering_operators_smoke)

--- a/tests/core_smoke/engine_compat_smoke.cpp
+++ b/tests/core_smoke/engine_compat_smoke.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "metric/compat/aliases.hpp"
+#include "metric/compat/legacy_space_adapters.hpp"
+#include "metric/distance.hpp"
+
+int main()
+{
+	std::vector<std::string> records = {"metric", "metrics", "matrix"};
+
+	using legacy_matrix = metric::compat::LegacyMatrixSpace<std::string, metric::Edit<char>>;
+	static_assert(std::is_same<legacy_matrix, metric::Matrix<std::string, metric::Edit<char>>>::value);
+
+	metric::compat::LegacyFiniteSpace<std::string, metric::Edit<char>> legacy_space(records, metric::Edit<char>{});
+	const auto engine_space = metric::compat::to_metric_space(legacy_space, metric::Edit<char>{});
+
+	static_assert(metric::MetricSpaceLike_v<decltype(engine_space)>);
+	assert(engine_space.size() == legacy_space.size());
+	assert(engine_space.record(metric::compat::record_id_from_legacy_index(1)) == legacy_space[1]);
+	assert(engine_space.distance(engine_space.id(0), engine_space.id(1)) == legacy_space.distance(0, 1));
+	assert(metric::compat::legacy_index(engine_space.id(2)) == 2);
+
+	legacy_matrix matrix_space(records, metric::Edit<char>{});
+	const auto engine_from_matrix = metric::compat::to_metric_space(matrix_space, metric::Edit<char>{});
+	assert(engine_from_matrix.size() == matrix_space.size());
+	assert(engine_from_matrix.record(engine_from_matrix.id(2)) == "matrix");
+	assert(engine_from_matrix.distance(engine_from_matrix.id(0), engine_from_matrix.id(1)) == matrix_space(0, 1));
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add explicit C++ compatibility aliases under `metric::compat`
- add legacy-space adapters that copy index-based legacy spaces into engine `MetricSpace` objects with stable `RecordId` mapping
- cover the adapter path with a new core smoke test and migration docs

## Verification
- `cmake --preset core`
- `cmake --build --preset core --target engine_compat_smoke --parallel 2`
- `ctest --test-dir build/core -R engine_compat_smoke --output-on-failure`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`