### PR TITLE
Document C++ compat adapter status

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -125,6 +125,7 @@ The current local tree implements the first revival slice:
 - C++ engine runtime diagnostics with policy, representation, support, and reason metadata
 - C++ engine runtime policies select implicit, matrix-cache, cover-tree, and kNN-graph neighbor execution representations explicitly
 - C++ engine runtime policies account for `metric_traits<Metric>::thread_safe` when parallel execution is requested
+- C++ engine compatibility aliases and legacy-space adapters under `metric/compat`
 - initial C++ engine mapping conventions with `MappingResult` lineage metadata and clustered-space derivation
 - initial C++ engine PCFA mapping adapter with explicit fit, transform, and inverse-transform support
 - documentation for concepts, APIs, examples, stability, testing, and release gates
@@ -384,6 +385,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - Python legacy Tree binding fixes for boolean `empty()`, explicit `size()`, and named `insert_if(...)`, merged as `b11d339fe9c0867d76aee20ff8ed02762fe67a12`
 - Python legacy kmeans binding keyword corrected from `random_see` to `random_seed`, merged as `e8faf336ffc9a7087eec95213593bf339d2f52e4`
 - CI-tested C++ engine representation-swap example covering implicit search, matrix cache, cover-tree index, kNN graph index, and stale representation diagnostics, merged as `6692769a33300ba316da4720b4064307a4060e3d`
+- C++ engine compatibility aliases and legacy-space adapters under `metric/compat`, merged as `53f20ed254af9eb7367174b2496ec562ea0a73e4`
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary
- record the merged C++ `metric/compat` aliases and legacy-space adapters in the revival status local scope
- add the post-v0.3.2 progress entry for the adapter merge

## Verification
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`