### PR TITLE
Add Python compat facade

### DIFF
--- a/docs/engine/migration.md
+++ b/docs/engine/migration.md
@@ -35,6 +35,7 @@ The following remain valid for existing code:
 - historical mapping classes
 - historical transform classes
 - Python compatibility modules under `metric.distance`, `metric.correlation`, `metric.mapping`, `metric.space`, and `metric.transform`
+- Python compatibility discovery through `metric.compat`
 
 Legacy index-based C++ spaces can be copied into the engine model explicitly when the metric object is available:
 
@@ -43,6 +44,15 @@ Legacy index-based C++ spaces can be copied into the engine model explicitly whe
 
 auto engine_space = metric::compat::to_metric_space(legacy_space, metric);
 auto id = metric::compat::record_id_from_legacy_index(0);
+```
+
+Python legacy import paths are discoverable without eagerly importing every historical extension module:
+
+```python
+from metric import compat
+
+if "mapping" in compat.available_modules():
+    legacy_mapping = compat.legacy_module("mapping")
 ```
 
 ## Migration Steps

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -9,6 +9,7 @@ The revived core API is organized around explicit finite metric spaces:
 - ``metric.operators`` for small metric-space operators
 - ``metric.runtime`` for runtime policy objects
 - ``metric.mappings`` and ``metric.transforms`` for beta compatibility bridges
+- ``metric.compat`` for lazy legacy import-path discovery
 
 Legacy compiled extension names remain available when their modules are present.
 """
@@ -20,7 +21,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-from . import core, exceptions, intent, mappings, metrics, operators, representations, runtime, spaces, strategies, transforms
+from . import compat, core, exceptions, intent, mappings, metrics, operators, representations, runtime, spaces, strategies, transforms
 from .exceptions import (
     AmbiguousIntentError,
     IncompatibleSpaceError,

--- a/python/pkg/metric/compat/__init__.py
+++ b/python/pkg/metric/compat/__init__.py
@@ -1,0 +1,37 @@
+"""Compatibility helpers for legacy Python METRIC import paths.
+
+This module keeps compatibility discovery explicit and lazy. It does not import
+heavy historical extension modules unless callers request them.
+"""
+
+from importlib import import_module
+
+
+STABILITY = "compatibility"
+
+LEGACY_MODULES = ("correlation", "distance", "mapping", "space", "transform")
+
+
+def legacy_module(name):
+    """Return a legacy ``metric.<name>`` module when it is available."""
+    if name not in LEGACY_MODULES:
+        raise ValueError(f"unknown legacy METRIC module: {name}")
+    try:
+        return import_module(f"metric.{name}")
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise ImportError(f"metric.{name} is not available in this wheel") from exc
+
+
+def available_modules():
+    """Return legacy module names importable in the installed wheel."""
+    available = []
+    for name in LEGACY_MODULES:
+        try:
+            legacy_module(name)
+        except ImportError:
+            continue
+        available.append(name)
+    return tuple(available)
+
+
+__all__ = ["LEGACY_MODULES", "STABILITY", "available_modules", "legacy_module"]

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import metric
 import metric.distance as distance_module
 import numpy as np
-from metric import core, exceptions, intent, mappings, representations, runtime, transforms
+from metric import compat, core, exceptions, intent, mappings, representations, runtime, transforms
 from metric.exceptions import (
     AmbiguousIntentError,
     IncompatibleSpaceError,
@@ -361,6 +361,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("CachePolicy", metric.__all__)
         self.assertIn("RuntimeDiagnostics", metric.__all__)
         self.assertIn("runtime_diagnostics", metric.__all__)
+        self.assertIn("compat", metric.__all__)
+        self.assertEqual(compat.STABILITY, "compatibility")
+        self.assertIn("distance", compat.LEGACY_MODULES)
+        self.assertIs(compat.legacy_module("distance"), distance_module)
+        self.assertIsInstance(compat.available_modules(), tuple)
         self.assertEqual(mappings.STABILITY, "beta")
         self.assertTrue(callable(mappings.clustered_space))
         self.assertTrue(callable(mappings.make_clustered_space_mapping))
@@ -371,6 +376,9 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIsInstance(representations.matrix_space(self.records, self.metric), MatrixSpace)
         self.assertIsInstance(mappings.available(), tuple)
         self.assertIsInstance(transforms.available(), tuple)
+
+        with self.assertRaisesRegex(ValueError, "unknown legacy METRIC module"):
+            compat.legacy_module("unknown")
 
     def test_distance_compatibility_aliases_are_lazy(self):
         manhatten = object()


### PR DESCRIPTION
## Summary
- add `metric.compat` as a lazy compatibility-discovery facade for legacy Python import paths
- expose `compat` from the top-level package and public API test surface
- document the compatibility-discovery path in the engine migration guide

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`