### PR TITLE
Keep Python strategy classes off top level

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -34,6 +34,8 @@ The records are strings. Edit distance defines the geometry without an embedding
 - `mappings`: beta compatibility bridge for installed mapping bindings
 - `transforms`: beta compatibility bridge for installed transform bindings
 
+Strategy classes are intentionally imported from `metric.strategies`, not from the top-level `metric` package. This keeps the first Python namespace focused on records, metrics, spaces, intent helpers, named results, and runtime policy objects.
+
 When the optional standard distance bindings are installed, `metric.distance`
 and `metric.metrics` expose compatibility aliases for historical names:
 `Manhattan` mirrors `Manhatten`, `Minkowski` mirrors `P_norm`, and

--- a/docs/engine/intent-api.md
+++ b/docs/engine/intent-api.md
@@ -38,7 +38,8 @@ auto structure = metric::describe_structure(space);
 ## Python
 
 ```python
-from metric import DistanceProfileCorrelation, Space
+from metric import Space
+from metric.strategies import DistanceProfileCorrelation
 from metric.strategies import ClassicMDS
 
 space = Space(records, metric)

--- a/docs/engine/strategies.md
+++ b/docs/engine/strategies.md
@@ -58,6 +58,8 @@ The current Python strategy objects include:
 `StrategyUnavailableError` for those strategies until deterministic fixtures,
 diagnostics, and CI-backed result contracts are promoted.
 
+Python strategy classes are not exported from the top-level `metric` package. Import them from `metric.strategies` so algorithm names stay in the strategy layer.
+
 ## Promotion Rule
 
 A strategy should be promoted only when it has:

--- a/python/examples/engine/cross_space_dependency.py
+++ b/python/examples/engine/cross_space_dependency.py
@@ -1,4 +1,5 @@
-from metric import DistanceProfileCorrelation, Space
+from metric import Space
+from metric.strategies import DistanceProfileCorrelation
 
 
 def absolute_distance(lhs, rhs):

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -95,20 +95,6 @@ from .operators import (
 )
 from .runtime import CachePolicy, RuntimeDiagnostics, RuntimePolicy, runtime_diagnostics
 from .spaces import FiniteMetricSpace, MatrixSpace, Space
-from .strategies import (
-    ClassicMDS,
-    DBSCAN,
-    DSPCC,
-    DiffusionEmbedding,
-    DistanceProfileCorrelation,
-    FarthestFirst,
-    KOC,
-    KMedoids,
-    MDS,
-    PCFA,
-    PhateAE,
-    SOM,
-)
 
 __all__ = sorted(
     name

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -244,18 +244,23 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.reduce_space, reduce_space)
         self.assertIs(metric.kmedoids, kmedoids)
         self.assertIs(metric.dbscan, dbscan)
-        self.assertIs(metric.KMedoids, KMedoids)
-        self.assertIs(metric.DBSCAN, DBSCAN)
-        self.assertIs(metric.DistanceProfileCorrelation, DistanceProfileCorrelation)
-        self.assertIs(metric.FarthestFirst, FarthestFirst)
-        self.assertIs(metric.ClassicMDS, ClassicMDS)
-        self.assertIs(metric.MDS, MDS)
-        self.assertIs(metric.DiffusionEmbedding, DiffusionEmbedding)
-        self.assertIs(metric.PCFA, PCFA)
-        self.assertIs(metric.SOM, SOM)
-        self.assertIs(metric.KOC, KOC)
-        self.assertIs(metric.DSPCC, DSPCC)
-        self.assertIs(metric.PhateAE, PhateAE)
+        for strategy_name in (
+            "ClassicMDS",
+            "DBSCAN",
+            "DSPCC",
+            "DiffusionEmbedding",
+            "DistanceProfileCorrelation",
+            "FarthestFirst",
+            "KOC",
+            "KMedoids",
+            "MDS",
+            "PCFA",
+            "PhateAE",
+            "SOM",
+        ):
+            self.assertFalse(hasattr(metric, strategy_name), strategy_name)
+        with self.assertRaises(ImportError):
+            exec("from metric import KMedoids", {})
         self.assertIs(metric.CorrelationResult, CorrelationResult)
         self.assertIs(metric.compare_spaces, compare_spaces)
         self.assertIs(metric.correlate_spaces, correlate_spaces)
@@ -327,18 +332,21 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("compress_space", metric.__all__)
         self.assertIn("kmedoids", metric.__all__)
         self.assertIn("dbscan", metric.__all__)
-        self.assertIn("KMedoids", metric.__all__)
-        self.assertIn("DBSCAN", metric.__all__)
-        self.assertIn("DistanceProfileCorrelation", metric.__all__)
-        self.assertIn("FarthestFirst", metric.__all__)
-        self.assertIn("ClassicMDS", metric.__all__)
-        self.assertIn("MDS", metric.__all__)
-        self.assertIn("DiffusionEmbedding", metric.__all__)
-        self.assertIn("PCFA", metric.__all__)
-        self.assertIn("SOM", metric.__all__)
-        self.assertIn("KOC", metric.__all__)
-        self.assertIn("DSPCC", metric.__all__)
-        self.assertIn("PhateAE", metric.__all__)
+        for strategy_name in (
+            "ClassicMDS",
+            "DBSCAN",
+            "DSPCC",
+            "DiffusionEmbedding",
+            "DistanceProfileCorrelation",
+            "FarthestFirst",
+            "KOC",
+            "KMedoids",
+            "MDS",
+            "PCFA",
+            "PhateAE",
+            "SOM",
+        ):
+            self.assertNotIn(strategy_name, metric.__all__)
         self.assertIn("exact_knn_graph", metric.__all__)
         self.assertIn("exact_knn_graph_edges", metric.__all__)
         self.assertIn("exact_radius_graph", metric.__all__)


### PR DESCRIPTION
## Summary
- stop exporting algorithm strategy classes from the top-level `metric` package
- keep strategy classes available through `metric.strategies`
- update the promoted cross-space example and docs to import strategies from the strategy namespace
- add negative API assertions for `from metric import KMedoids`

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`