### PR TITLE
Add Python Space vectors constructor

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -133,6 +133,8 @@ space.describe_structure(representation=space.to_matrix())
 space.knn(query, k=10)
 space.nn(query)
 space.rnn(query, radius=1)
+Space.vectors(records)
+Space.vectors(records, metric=custom_vector_metric)
 ```
 
 `repr(space)` reports the engine object shape: size, metric, record type, and optional name.
@@ -142,6 +144,12 @@ DataFrame-like tabular records. The constructor reads rows through
 `to_dict("records")`, uses `id_column` as stable record IDs, and removes that ID
 column from the row dictionaries passed to the metric. It does not require pandas
 at import time.
+
+Use `Space.vectors(records)` for vector-specific inputs when Euclidean distance
+is the intended domain metric. The default is implemented in pure Python so the
+core wheel does not require optional standard-distance bindings. Pass
+`metric=...` to use Manhattan, cosine-derived, normalized, or domain-specific
+vector distances.
 
 Runtime policy objects live in `metric.runtime` and are re-exported from
 `metric`:
@@ -331,6 +339,9 @@ def euclidean(lhs, rhs) -> float:
 
 space = Space(records, euclidean)
 print(space.distance(0, 1))
+
+vector_space = Space.vectors(records)
+print(vector_space.distance(0, 1))
 ```
 
 `pairwise()` and `pairwise_distances()` currently return Python lists of lists.

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -10,6 +10,7 @@ from metric.exceptions import (
     AmbiguousIntentError,
     IncompatibleSpaceError,
     MetricContractError,
+    MetricInputError,
     MissingMetricError,
     StaleRepresentationError,
     StrategyUnavailableError,
@@ -26,6 +27,35 @@ class RecordId(int):
 
     def __new__(cls, value):
         return int.__new__(cls, value)
+
+
+class _EuclideanVectorMetric:
+    name = "Euclidean"
+
+    def __call__(self, lhs, rhs):
+        lhs_values = self._values(lhs)
+        rhs_values = self._values(rhs)
+        if len(lhs_values) != len(rhs_values):
+            raise MetricInputError("vector records must have the same length")
+
+        total = 0.0
+        for lhs_value, rhs_value in zip(lhs_values, rhs_values):
+            try:
+                delta = float(lhs_value) - float(rhs_value)
+            except (TypeError, ValueError):
+                raise MetricInputError("vector records must contain numeric values") from None
+            total += delta * delta
+        return math.sqrt(total)
+
+    def __repr__(self):
+        return "Euclidean()"
+
+    @staticmethod
+    def _values(record):
+        try:
+            return list(record)
+        except TypeError:
+            raise MetricInputError("vector records must be one-dimensional sequences") from None
 
 
 def _coerce_non_negative_integer(value, name):
@@ -134,6 +164,20 @@ class FiniteMetricSpace:
 
     def __call__(self, lhs_index, rhs_index):
         return self.distance(lhs_index, rhs_index)
+
+    @classmethod
+    def vectors(cls, records, metric=None, **kwargs):
+        """Construct a finite metric space from vector records.
+
+        Defaults to a pure Python Euclidean metric so the convenience remains
+        available in the core wheel without optional standard-distance bindings.
+        """
+
+        return cls(
+            records,
+            metric=_EuclideanVectorMetric() if metric is None else metric,
+            **kwargs,
+        )
 
     @classmethod
     def from_dataframe(cls, dataframe, metric=None, id_column=None, **kwargs):

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -13,6 +13,7 @@ from metric.exceptions import (
     IncompatibleSpaceError,
     MetricContractError,
     MetricError,
+    MetricInputError,
     MissingMetricError,
     StaleRepresentationError,
     StrategyParameterError,
@@ -1594,6 +1595,7 @@ class RevivalApiTest(unittest.TestCase):
             return float(np.linalg.norm(lhs - rhs))
 
         space = Space(records, euclidean)
+        vector_space = Space.vectors(records, ids=["origin", "middle", "far"], name="vectors")
 
         self.assertEqual(len(space), 3)
         self.assertAlmostEqual(space.distance(0, 1), 5.0)
@@ -1601,6 +1603,21 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(range_neighbors(records, euclidean, np.array([3.0, 4.0]), 0.0), [(1, 0.0)])
         self.assertAlmostEqual(pairwise_distance_matrix(records, euclidean)[1][2], 5.0)
         self.assertMetricContracts(records, euclidean)
+        self.assertEqual(vector_space.ids, ["origin", "middle", "far"])
+        self.assertEqual(vector_space.name, "vectors")
+        self.assertEqual(vector_space.metric.name, "Euclidean")
+        self.assertIn("metric=Euclidean()", repr(vector_space))
+        self.assertAlmostEqual(vector_space.distance(0, 1), 5.0)
+        self.assertEqual(vector_space.nearest(np.array([3.0, 4.0])), (1, 0.0))
+        self.assertMetricContracts(records, vector_space.metric)
+
+        manhattan_space = Space.vectors(
+            records,
+            metric=lambda lhs, rhs: float(np.abs(lhs - rhs).sum()),
+        )
+        self.assertEqual(manhattan_space.distance(0, 1), 7.0)
+        with self.assertRaisesRegex(MetricInputError, "same length"):
+            Space.vectors([[0.0], [0.0, 1.0]])
 
     def test_structured_records_use_domain_metric_callable(self):
         records = [


### PR DESCRIPTION
## Summary
- add `Space.vectors(...)` as a vector-specific construction convenience
- provide a pure Python Euclidean default so the core wheel does not depend on optional standard-distance bindings
- cover default Euclidean, custom vector metrics, and vector shape errors in the Revival API test

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`