### PR TITLE
Add Python neighbor result objects

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -189,6 +189,8 @@ from metric.operators import (
     GraphDegreeDiagnostics,
     GraphStretchDiagnostics,
     MappingResult,
+    Neighbor,
+    NeighborResult,
     Outlier,
     OutlierResult,
     RepresentativeSet,
@@ -266,7 +268,15 @@ mapped = map_space(records, transform, target_metric)
 structure = describe_structure(records, Edit())
 ```
 
-`Space.neighbors(query, count=...)` returns nearest `(record_id, distance)` tuples. `Space.neighbors(query, radius=...)` returns range-neighbor tuples through the same exact metric path as `Space.within_radius(...)`. The older `k` name remains a compatibility alias for count-based nearest-neighbor calls, but new examples should prefer `count`.
+`Space.neighbors(query, count=...)` returns a `NeighborResult` with named
+`Neighbor` objects, `.distances`, exactness, strategy, and representation
+metadata. It remains sequence-compatible with older `(record_id, distance)`
+tuple lists, so existing unpacking and comparisons continue to work.
+`Space.neighbors(query, radius=...)` returns range-neighbor results through the
+same exact metric path as `Space.within_radius(...)`. Queryless
+`Space.neighbors(count=...)` stores one row of `Neighbor` objects per source
+record in `result.rows`. The older `k` name remains a compatibility alias for
+count-based nearest-neighbor calls, but new examples should prefer `count`.
 
 `find_groups` returns a `ClusteringResult` with source-record assignments, medoid record IDs, cluster sizes, optional DBSCAN core/noise records, iteration metadata, algorithm metadata, and representation metadata. `Space.groups(...)` exposes the same result from the `Space` facade. Passing an integer group count selects deterministic `KMedoids`; passing `KMedoids` or `DBSCAN` makes the strategy explicit. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`. Passing `runtime=RuntimePolicy(cache="materialized")` records `representation == "matrix"` when no explicit representation override is supplied.
 

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -53,6 +53,8 @@ from .operators import (
     GraphConstructionMetadata,
     GraphConstructionResult,
     MappingResult,
+    Neighbor,
+    NeighborResult,
     Outlier,
     OutlierResult,
     RepresentativeSet,

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -116,6 +116,88 @@ class GraphStretchDiagnostics:
 
 
 @dataclass(frozen=True)
+class Neighbor:
+    """One neighbor record with compatibility tuple behavior."""
+
+    id: int
+    record: object
+    distance: object
+    rank: int
+
+    def as_tuple(self):
+        return (self.id, self.distance)
+
+    def __iter__(self):
+        return iter(self.as_tuple())
+
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, index):
+        return self.as_tuple()[index]
+
+    def __eq__(self, other):
+        if isinstance(other, Neighbor):
+            return (
+                self.id == other.id
+                and self.record == other.record
+                and self.distance == other.distance
+                and self.rank == other.rank
+            )
+        if isinstance(other, (list, tuple)) and len(other) == 2:
+            return self.as_tuple() == tuple(other)
+        return False
+
+
+@dataclass(frozen=True)
+class NeighborResult:
+    """Engine-style neighbor result with sequence compatibility."""
+
+    query: object
+    query_id: object
+    neighbors: tuple
+    rows: tuple
+    distances: tuple
+    exact: bool
+    strategy: str
+    representation: str
+    diagnostics: object = None
+
+    def __len__(self):
+        return len(self.rows) if self.rows else len(self.neighbors)
+
+    def __iter__(self):
+        if self.rows:
+            return iter([list(row) for row in self.rows])
+        return iter(self.neighbors)
+
+    def __getitem__(self, index):
+        if self.rows:
+            return list(self.rows[index])
+        return self.neighbors[index]
+
+    def __eq__(self, other):
+        if isinstance(other, NeighborResult):
+            return (
+                self.query == other.query
+                and self.query_id == other.query_id
+                and self.neighbors == other.neighbors
+                and self.rows == other.rows
+                and self.distances == other.distances
+                and self.exact == other.exact
+                and self.strategy == other.strategy
+                and self.representation == other.representation
+                and self.diagnostics == other.diagnostics
+            )
+        return list(self) == other
+
+    def as_tuples(self):
+        if self.rows:
+            return [[neighbor.as_tuple() for neighbor in row] for row in self.rows]
+        return [neighbor.as_tuple() for neighbor in self.neighbors]
+
+
+@dataclass(frozen=True)
 class ClusteringResult:
     """Engine-style grouping result with assignments and cluster metadata."""
 
@@ -314,17 +396,72 @@ def pairwise_distance_matrix(records, metric):
     return FiniteMetricSpace(records, metric).pairwise_distances()
 
 
-def nearest_neighbors(records, metric, query, k=None, count=None):
-    if k is not None and count is not None:
-        raise ValueError("use either k or count, not both")
-    return FiniteMetricSpace(records, metric).knn(
-        query,
-        1 if k is None and count is None else count if count is not None else k,
+def neighbor_result(
+    records,
+    *,
+    query=None,
+    query_id=None,
+    neighbors=None,
+    rows=None,
+    exact=True,
+    strategy="exact_scan",
+    representation="metric_space",
+    diagnostics=None,
+):
+    def make_neighbor(raw_neighbor, rank):
+        record_id, distance = raw_neighbor
+        return Neighbor(
+            id=record_id,
+            record=records[record_id],
+            distance=distance,
+            rank=rank,
+        )
+
+    if rows is not None:
+        result_rows = tuple(
+            tuple(make_neighbor(raw_neighbor, rank) for rank, raw_neighbor in enumerate(row))
+            for row in rows
+        )
+        distances = tuple(
+            tuple(neighbor.distance for neighbor in row)
+            for row in result_rows
+        )
+        result_neighbors = ()
+    else:
+        result_neighbors = tuple(
+            make_neighbor(raw_neighbor, rank)
+            for rank, raw_neighbor in enumerate(() if neighbors is None else neighbors)
+        )
+        result_rows = ()
+        distances = tuple(neighbor.distance for neighbor in result_neighbors)
+
+    return NeighborResult(
+        query=query,
+        query_id=query_id,
+        neighbors=result_neighbors,
+        rows=result_rows,
+        distances=distances,
+        exact=exact,
+        strategy=strategy,
+        representation=representation,
+        diagnostics=diagnostics,
     )
 
 
+def nearest_neighbors(records, metric, query, k=None, count=None):
+    if k is not None and count is not None:
+        raise ValueError("use either k or count, not both")
+    space = FiniteMetricSpace(records, metric)
+    neighbors = space.knn(
+        query,
+        1 if k is None and count is None else count if count is not None else k,
+    )
+    return neighbor_result(space.records, query=query, neighbors=neighbors)
+
+
 def range_neighbors(records, metric, query, radius):
-    return FiniteMetricSpace(records, metric).rnn(query, radius)
+    space = FiniteMetricSpace(records, metric)
+    return neighbor_result(space.records, query=query, neighbors=space.rnn(query, radius))
 
 
 def _coerce_graph_k(k):
@@ -1907,6 +2044,8 @@ __all__ = [
     "GraphConstructionMetadata",
     "GraphConstructionResult",
     "MappingResult",
+    "Neighbor",
+    "NeighborResult",
     "Outlier",
     "OutlierResult",
     "RepresentativeSet",

--- a/python/pkg/metric/spaces.py
+++ b/python/pkg/metric/spaces.py
@@ -381,6 +381,8 @@ class Space(FiniteMetricSpace):
         representation=None,
         runtime=None,
     ):
+        from metric.operators import neighbor_result
+
         runtime_policy = require_exact_runtime(runtime)
         if strategy is not None:
             raise ValueError("strategy overrides are not promoted for Python neighbors yet")
@@ -396,31 +398,46 @@ class Space(FiniteMetricSpace):
                 include_self=include_self,
             )
         if query is not None and representation is not None:
-            return representation.neighbors(query, k=k, count=count, radius=radius)
+            return neighbor_result(
+                self.records,
+                query=query,
+                neighbors=representation.neighbors(query, k=k, count=count, radius=radius),
+                representation=getattr(representation, "representation", "metric_space"),
+            )
         if representation is not None:
             representation.ensure_fresh()
             if getattr(representation, "representation", None) == "exact_knn_graph":
-                return [
+                rows = [
                     list(representation.neighbors(source_index))[:neighbor_count]
                     for source_index in range(len(self.records))
                 ]
+                return neighbor_result(
+                    self.records,
+                    rows=rows,
+                    representation=representation.representation,
+                )
 
         if query is None:
-            return [
+            rows = [
                 self._neighbor_row(source_index, neighbor_count, radius=radius, include_self=include_self)
                 for source_index in range(len(self.records))
             ]
+            return neighbor_result(self.records, rows=rows)
 
         if radius is not None:
             neighbors = self.rnn(query, radius)
-            return neighbors if neighbor_count is None else neighbors[:neighbor_count]
-        return self.knn(query, neighbor_count)
+            return neighbor_result(
+                self.records,
+                query=query,
+                neighbors=neighbors if neighbor_count is None else neighbors[:neighbor_count],
+            )
+        return neighbor_result(self.records, query=query, neighbors=self.knn(query, neighbor_count))
 
     def nearest(self, query):
-        return self.nn(query)
+        return self.neighbors(query, count=1).neighbors[0]
 
     def within_radius(self, query, radius):
-        return self.rnn(query, radius)
+        return self.neighbors(query, radius=radius)
 
     def groups(self, strategy=None, *, count="auto", radius=None, min_size=1, representation=None, runtime=None):
         runtime_policy = require_exact_runtime(runtime)

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -34,6 +34,8 @@ from metric.operators import (
     GraphConstructionMetadata,
     GraphConstructionResult,
     MappingResult,
+    Neighbor,
+    NeighborResult,
     Outlier,
     OutlierResult,
     RepresentativeSet,
@@ -165,6 +167,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.operators.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.operators.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.operators.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.operators.Neighbor, Neighbor)
+        self.assertIs(metric.operators.NeighborResult, NeighborResult)
         self.assertIs(metric.operators.CompressionResult, CompressionResult)
         self.assertIs(metric.operators.MappingResult, MappingResult)
         self.assertIs(metric.operators.EmbeddingDiagnostics, EmbeddingDiagnostics)
@@ -227,6 +231,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIs(metric.GraphStretchDiagnostics, GraphStretchDiagnostics)
         self.assertIs(metric.GraphConstructionMetadata, GraphConstructionMetadata)
         self.assertIs(metric.GraphConstructionResult, GraphConstructionResult)
+        self.assertIs(metric.Neighbor, Neighbor)
+        self.assertIs(metric.NeighborResult, NeighborResult)
         self.assertIs(metric.MappingResult, MappingResult)
         self.assertIs(metric.EmbeddingDiagnostics, EmbeddingDiagnostics)
         self.assertIs(metric.EmbeddingModel, EmbeddingModel)
@@ -314,6 +320,8 @@ class RevivalApiTest(unittest.TestCase):
         self.assertIn("GraphStretchDiagnostics", metric.__all__)
         self.assertIn("GraphConstructionMetadata", metric.__all__)
         self.assertIn("GraphConstructionResult", metric.__all__)
+        self.assertIn("Neighbor", metric.__all__)
+        self.assertIn("NeighborResult", metric.__all__)
         self.assertIn("CompressionResult", metric.__all__)
         self.assertIn("MappingResult", metric.__all__)
         self.assertIn("EmbeddingDiagnostics", metric.__all__)
@@ -668,7 +676,16 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(space.knn("cut", 2), [(0, 1), (1, 1)])
         self.assertEqual(space.nn("cut"), (0, 1))
         self.assertEqual(space.rnn("cut", 1), [(0, 1), (1, 1)])
-        self.assertEqual(nearest_neighbors(self.records, self.metric, "cut", 2), [(0, 1), (1, 1)])
+        neighbors = nearest_neighbors(self.records, self.metric, "cut", 2)
+        self.assertIsInstance(neighbors, NeighborResult)
+        self.assertEqual(neighbors, [(0, 1), (1, 1)])
+        self.assertEqual(neighbors.neighbors[0], (0, 1))
+        self.assertEqual(neighbors.neighbors[0].record, "cat")
+        self.assertEqual(neighbors.neighbors[0].rank, 0)
+        self.assertEqual(neighbors.distances, (1, 1))
+        self.assertTrue(neighbors.exact)
+        self.assertEqual(neighbors.strategy, "exact_scan")
+        self.assertEqual(neighbors.representation, "metric_space")
         self.assertEqual(nearest_neighbors(self.records, self.metric, "cut", count=2), [(0, 1), (1, 1)])
         self.assertEqual(range_neighbors(self.records, self.metric, "cut", 1), [(0, 1), (1, 1)])
         self.assertEqual(pairwise_distance_matrix(self.records, self.metric)[0][1], 1)
@@ -1498,14 +1515,23 @@ class RevivalApiTest(unittest.TestCase):
         space = Space(self.records, self.metric)
 
         self.assertIsInstance(space, FiniteMetricSpace)
-        self.assertEqual(space.neighbors("cut", 2), [(0, 1), (1, 1)])
+        neighbors = space.neighbors("cut", 2)
+        self.assertIsInstance(neighbors, NeighborResult)
+        self.assertEqual(neighbors, [(0, 1), (1, 1)])
+        self.assertEqual(neighbors.query, "cut")
+        self.assertEqual(neighbors.neighbors[0].record, "cat")
         self.assertEqual(space.neighbors("cut", count=2), [(0, 1), (1, 1)])
         self.assertEqual(space.neighbors("cut", radius=1), [(0, 1), (1, 1)])
         self.assertEqual(space.neighbors("cut", count=1, radius=1), [(0, 1)])
-        self.assertEqual(space.neighbors(count=1), [[(1, 1)], [(0, 1)], [(0, 1)], [(1, 2)]])
+        rows = space.neighbors(count=1)
+        self.assertIsInstance(rows, NeighborResult)
+        self.assertEqual(rows, [[(1, 1)], [(0, 1)], [(0, 1)], [(1, 2)]])
+        self.assertEqual(rows.rows[0][0].record, "cot")
+        self.assertEqual(rows.distances, ((1,), (1,), (1,), (2,)))
         self.assertEqual(space.neighbors(count=1, include_self=True)[0], [(0, 0)])
         self.assertEqual(space.neighbors(radius=1)[0], [(1, 1), (2, 1)])
         self.assertEqual(space.nearest("cut"), (0, 1))
+        self.assertIsInstance(space.nearest("cut"), Neighbor)
         self.assertEqual(space.within_radius("cut", 1), [(0, 1), (1, 1)])
         with self.assertRaises(ValueError):
             space.neighbors("cut", k=1, count=2)


### PR DESCRIPTION
## Summary
- add `Neighbor` and `NeighborResult` to the promoted Python operator result surface
- make `Space.neighbors(...)`, `Space.nearest(...)`, `Space.within_radius(...)`, `nearest_neighbors(...)`, and `range_neighbors(...)` return named results while preserving tuple/list compatibility
- document the new neighbor result contract and test export/field behavior

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`