### PR TITLE
Add Python neighbor result conversions

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -277,6 +277,8 @@ same exact metric path as `Space.within_radius(...)`. Queryless
 `Space.neighbors(count=...)` stores one row of `Neighbor` objects per source
 record in `result.rows`. The older `k` name remains a compatibility alias for
 count-based nearest-neighbor calls, but new examples should prefer `count`.
+Use `NeighborResult.to_dict()` for structured Python data, `to_numpy()` for the
+numeric distance array, and `to_pandas()` when pandas is installed.
 
 `find_groups` returns a `ClusteringResult` with source-record assignments, medoid record IDs, cluster sizes, optional DBSCAN core/noise records, iteration metadata, algorithm metadata, and representation metadata. `Space.groups(...)` exposes the same result from the `Space` facade. Passing an integer group count selects deterministic `KMedoids`; passing `KMedoids` or `DBSCAN` makes the strategy explicit. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`. Passing `runtime=RuntimePolicy(cache="materialized")` records `representation == "matrix"` when no explicit representation override is supplied.
 

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 
 import numpy as np
 
-from metric.exceptions import StrategyUnavailableError, UnsupportedOperationError
+from metric.exceptions import OptionalDependencyError, StrategyUnavailableError, UnsupportedOperationError
 from metric.spaces import FiniteMetricSpace
 from metric.strategies import (
     ClassicMDS,
@@ -127,6 +127,14 @@ class Neighbor:
     def as_tuple(self):
         return (self.id, self.distance)
 
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "record": self.record,
+            "distance": self.distance,
+            "rank": self.rank,
+        }
+
     def __iter__(self):
         return iter(self.as_tuple())
 
@@ -195,6 +203,47 @@ class NeighborResult:
         if self.rows:
             return [[neighbor.as_tuple() for neighbor in row] for row in self.rows]
         return [neighbor.as_tuple() for neighbor in self.neighbors]
+
+    def to_dict(self):
+        return {
+            "query": self.query,
+            "query_id": self.query_id,
+            "neighbors": [neighbor.to_dict() for neighbor in self.neighbors],
+            "rows": [
+                [neighbor.to_dict() for neighbor in row]
+                for row in self.rows
+            ],
+            "distances": self.distances,
+            "exact": self.exact,
+            "strategy": self.strategy,
+            "representation": self.representation,
+            "diagnostics": self.diagnostics,
+        }
+
+    def to_numpy(self):
+        try:
+            return np.asarray(self.distances, dtype=float)
+        except ValueError:
+            return np.asarray(self.distances, dtype=object)
+
+    def to_pandas(self):
+        try:
+            import pandas as pd
+        except ModuleNotFoundError:
+            raise OptionalDependencyError(
+                "NeighborResult.to_pandas() requires pandas. Install pandas or use to_dict()."
+            ) from None
+
+        records = []
+        if self.rows:
+            for source_id, row in enumerate(self.rows):
+                for neighbor in row:
+                    record = neighbor.to_dict()
+                    record["source_id"] = source_id
+                    records.append(record)
+        else:
+            records = [neighbor.to_dict() for neighbor in self.neighbors]
+        return pd.DataFrame.from_records(records)
 
 
 @dataclass(frozen=True)

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -683,6 +683,12 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(neighbors.neighbors[0].record, "cat")
         self.assertEqual(neighbors.neighbors[0].rank, 0)
         self.assertEqual(neighbors.distances, (1, 1))
+        self.assertEqual(
+            neighbors.neighbors[0].to_dict(),
+            {"id": 0, "record": "cat", "distance": 1, "rank": 0},
+        )
+        self.assertEqual(neighbors.to_dict()["neighbors"][1]["record"], "cot")
+        np.testing.assert_array_equal(neighbors.to_numpy(), np.asarray([1.0, 1.0]))
         self.assertTrue(neighbors.exact)
         self.assertEqual(neighbors.strategy, "exact_scan")
         self.assertEqual(neighbors.representation, "metric_space")
@@ -1528,6 +1534,11 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(rows, [[(1, 1)], [(0, 1)], [(0, 1)], [(1, 2)]])
         self.assertEqual(rows.rows[0][0].record, "cot")
         self.assertEqual(rows.distances, ((1,), (1,), (1,), (2,)))
+        self.assertEqual(rows.to_dict()["rows"][0][0]["record"], "cot")
+        np.testing.assert_array_equal(
+            rows.to_numpy(),
+            np.asarray([[1.0], [1.0], [1.0], [2.0]]),
+        )
         self.assertEqual(space.neighbors(count=1, include_self=True)[0], [(0, 0)])
         self.assertEqual(space.neighbors(radius=1)[0], [(1, 1), (2, 1)])
         self.assertEqual(space.nearest("cut"), (0, 1))


### PR DESCRIPTION
## Summary
- add `Neighbor.to_dict()` and `NeighborResult.to_dict()`
- add `NeighborResult.to_numpy()` for distance arrays and optional `to_pandas()` output
- cover conversion helpers in the core Revival API test and document the surface

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`