### PR TITLE
Teach named Python neighbor results in examples

### DIFF
--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -76,6 +76,7 @@ The current local tree implements the first revival slice:
 - CI-tested Python engine representation-swap example covering implicit search, matrix materialization, exact tree-style lookup, exact kNN graph adjacency, runtime diagnostics, and stale representation checks
 - CI-tested Python engine clustered-space mapping example covering `ClusteringResult` to derived `Space` lineage
 - CI-tested Python engine flagship example for mixed structured records with a custom composite metric
+- promoted Python metric-space and engine examples demonstrate named `Neighbor` / `NeighborResult` fields instead of teaching tuple-indexed neighbor access
 - native C++ DNN baseline smoke coverage for RegressionMSE, RMSProp, row-as-observation network training, dense Autoencoder train/encode/decode/save/load, and fully connected parameter serialization round trips
 - native C++ DNN `Network` training hooks for forward activation capture, anchored layer-output backpropagation, and explicit optimizer updates
 - native C++ DNN `SampleId`, `DnnBatch`, `EncodedDataset`, ID-preserving shuffled batches, and `FlatVectorCodec` with Autoencoder-backed conversion

--- a/python/examples/engine/histogram_transport_space.py
+++ b/python/examples/engine/histogram_transport_space.py
@@ -28,13 +28,14 @@ def main():
 
     space = Space(records, cumulative_transport_distance)
     nearest = space.neighbors(query, 2)
-    assert nearest == [(1, 0.25), (3, 0.25)]
+    assert [neighbor.id for neighbor in nearest.neighbors] == [1, 3]
+    assert [neighbor.distance for neighbor in nearest.neighbors] == [0.25, 0.25]
 
     groups = space.groups(KMedoids(groups=2))
     assert groups.algorithm == "kmedoids"
     assert groups.cluster_count == 2
 
-    print("nearest histograms =", names[nearest[0][0]], names[nearest[1][0]])
+    print("nearest histograms =", names[nearest.neighbors[0].id], names[nearest.neighbors[1].id])
     print("histogram groups =", groups.cluster_count)
 
 

--- a/python/examples/engine/mixed_structured_records.py
+++ b/python/examples/engine/mixed_structured_records.py
@@ -126,9 +126,9 @@ def main():
     space = Space(records, metric=mixed_record_distance, name="mixed_structured_records")
     matrix = space.to_matrix()
     neighbors = space.neighbors(query, count=2)
-    assert [names[index] for index, _distance in neighbors] == ["warmup-drift", "warmup-alert"]
+    assert [names[neighbor.id] for neighbor in neighbors.neighbors] == ["warmup-drift", "warmup-alert"]
 
-    explanation = field_contributions(query, records[neighbors[0][0]])
+    explanation = field_contributions(query, neighbors.neighbors[0].record)
     assert explanation["status"] == 0.0
     assert explanation["curve"] < 0.01
 
@@ -146,7 +146,7 @@ def main():
     diagnostics = space.runtime_diagnostics(representation=matrix, intent="mixed_record_demo")
     assert diagnostics.representation == "matrix"
 
-    print("nearest mixed records =", names[neighbors[0][0]], names[neighbors[1][0]])
+    print("nearest mixed records =", names[neighbors.neighbors[0].id], names[neighbors.neighbors[1].id])
     print("mixed record groups =", groups.cluster_count)
     print("mixed record outlier =", names[outliers.outliers[0].record_id])
 

--- a/python/examples/engine/process_curves_space.py
+++ b/python/examples/engine/process_curves_space.py
@@ -36,9 +36,9 @@ def main():
     query = (0, 1, 1, 1, 2, 4)
 
     space = Space(records, aligned_curve_distance)
-    nearest_id, nearest_distance = space.nearest(query)
-    assert names[nearest_id] == "baseline"
-    assert nearest_distance == 1.0
+    nearest = space.nearest(query)
+    assert names[nearest.id] == "baseline"
+    assert nearest.distance == 1.0
 
     representatives = space.representatives(2)
     assert representatives.strategy == "farthest_first"
@@ -48,7 +48,7 @@ def main():
     assert graph.metadata.strategy == "exact_knn"
     assert graph.metadata.record_count == len(records)
 
-    print("nearest process curve =", names[nearest_id], nearest_distance)
+    print("nearest process curve =", names[nearest.id], nearest.distance)
     print("process curve graph edges =", graph.metadata.edge_count)
 
 

--- a/python/examples/engine/representation_swap.py
+++ b/python/examples/engine/representation_swap.py
@@ -7,7 +7,10 @@ def main():
 
     query = "metricks"
     implicit_neighbors = space.neighbors(query, count=2)
-    assert implicit_neighbors[0] == (1, 1)
+    nearest = implicit_neighbors.neighbors[0]
+    assert nearest.id == 1
+    assert nearest.record == "metrics"
+    assert nearest.distance == 1
 
     matrix = space.to_matrix()
     assert matrix.representation == "matrix"
@@ -15,13 +18,14 @@ def main():
     assert matrix.distance(0, 2) == 2
 
     tree = space.to_tree()
-    tree_neighbors = tree.neighbors(query, count=2)
-    assert tree_neighbors == implicit_neighbors
+    tree_neighbors = space.neighbors(query, count=2, representation=tree)
+    assert tree_neighbors.as_tuples() == implicit_neighbors.as_tuples()
 
     graph = space.to_graph(count=2)
-    graph_neighbors = graph.neighbors(0)
-    assert graph_neighbors[0] == (1, 1)
-    assert len(graph_neighbors) == 2
+    graph_neighbors = space.neighbors(count=2, representation=graph)
+    assert graph_neighbors.rows[0][0].id == 1
+    assert graph_neighbors.rows[0][0].distance == 1
+    assert len(graph_neighbors.rows[0]) == 2
 
     materialized_groups = space.groups(count=2, representation=matrix)
     assert materialized_groups.representation == "matrix"
@@ -40,9 +44,9 @@ def main():
     assert tree.is_stale()
     assert graph.is_stale()
 
-    print("implicit nearest =", records[implicit_neighbors[0][0]], implicit_neighbors[0][1])
-    print("tree nearest =", records[tree_neighbors[0][0]], tree_neighbors[0][1])
-    print("graph neighbors from metric =", [records[index] for index, _distance in graph_neighbors])
+    print("implicit nearest =", nearest.record, nearest.distance)
+    print("tree nearest =", tree_neighbors.neighbors[0].record, tree_neighbors.neighbors[0].distance)
+    print("graph neighbors from metric =", [neighbor.record for neighbor in graph_neighbors.rows[0]])
     print("runtime representation =", diagnostics.representation)
 
 

--- a/python/examples/engine/strings_edit_space.py
+++ b/python/examples/engine/strings_edit_space.py
@@ -10,13 +10,16 @@ def main():
     assert matrix.distance(0, 1) == 1
 
     neighbors = space.neighbors("metricks", 2)
-    assert neighbors[0] == (1, 1)
+    nearest = neighbors.neighbors[0]
+    assert nearest.id == 1
+    assert nearest.record == "metrics"
+    assert nearest.distance == 1
 
     groups = space.groups(KMedoids(groups=2))
     assert groups.algorithm == "kmedoids"
     assert groups.cluster_count == 2
 
-    print("nearest string =", records[neighbors[0][0]], neighbors[0][1])
+    print("nearest string =", nearest.record, nearest.distance)
     print("string groups =", groups.cluster_count)
 
 

--- a/python/examples/engine/vector_space_special_case.py
+++ b/python/examples/engine/vector_space_special_case.py
@@ -48,16 +48,16 @@ def main():
     assert round(matrix.distance(0, 1), 12) == round(sqrt(0.13), 12)
 
     implicit_neighbors = space.neighbors(query, count=3)
-    assert names[implicit_neighbors[0][0]] == "alpha-0"
+    assert names[implicit_neighbors.neighbors[0].id] == "alpha-0"
 
     tree = space.to_tree()
-    tree_neighbors = tree.neighbors(query, count=3)
-    assert tree_neighbors == implicit_neighbors
+    tree_neighbors = space.neighbors(query, count=3, representation=tree)
+    assert tree_neighbors.as_tuples() == implicit_neighbors.as_tuples()
 
     graph = space.to_graph(count=2)
-    graph_neighbors = graph.neighbors(0)
-    assert len(graph_neighbors) == 2
-    assert names[graph_neighbors[0][0]].startswith("alpha")
+    graph_neighbors = space.neighbors(count=2, representation=graph)
+    assert len(graph_neighbors.rows[0]) == 2
+    assert names[graph_neighbors.rows[0][0].id].startswith("alpha")
 
     groups = space.groups(strategy=KMedoids(groups=3), representation=matrix)
     assert groups.algorithm == "kmedoids"
@@ -97,8 +97,8 @@ def main():
     print("metric_law =", space.metadata["metric_law"])
     print("vector dimension metadata =", space.metadata["dimensions"])
     print("available representations =", ",".join(space.metadata["representations"]))
-    print("nearest vector =", names[implicit_neighbors[0][0]], round(implicit_neighbors[0][1], 3))
-    print("indexed nearest =", names[tree_neighbors[0][0]], "via", tree.representation)
+    print("nearest vector =", implicit_neighbors.neighbors[0].record, round(implicit_neighbors.neighbors[0].distance, 3))
+    print("indexed nearest =", tree_neighbors.neighbors[0].record, "via", tree.representation)
     print("runtime policy =", exact_diagnostics.policy_name, "via", exact_diagnostics.representation)
     print("matrix cache reuse =", groups.representation, outliers.representation)
     print("vector groups =", groups.cluster_count)

--- a/python/examples/metric_space/histogram_transport_space.py
+++ b/python/examples/metric_space/histogram_transport_space.py
@@ -28,18 +28,18 @@ def main():
     query = (0.25, 0.75, 0.0, 0.0)
 
     space = Space(records, cumulative_transport_distance)
-    nearest_id, nearest_distance = space.nearest(query)
+    nearest = space.nearest(query)
     distances = pairwise_distance_matrix(records, cumulative_transport_distance)
     dimension = intrinsic_dimension(records, cumulative_transport_distance)
 
-    assert names[nearest_id] == "one-step"
-    assert nearest_distance == 0.25
+    assert names[nearest.id] == "one-step"
+    assert nearest.distance == 0.25
     assert distances[0][1] == 1.0
     assert distances[0][2] == 3.0
     assert distances[3][4] == 1.0
     assert dimension > 0.0
 
-    print("nearest histogram =", names[nearest_id], nearest_distance)
+    print("nearest histogram =", names[nearest.id], nearest.distance)
     print("distance(left-edge, right-edge) =", distances[0][2])
     print("intrinsic dimension estimate =", round(dimension, 3))
 

--- a/python/examples/metric_space/string_edit_space.py
+++ b/python/examples/metric_space/string_edit_space.py
@@ -7,8 +7,8 @@ def main():
 
     print("distance(cat, cot) =", space(0, 1))
 
-    for record_id, distance in space.neighbors("cut", 2):
-        print(f"{records[record_id]}: {distance}")
+    for neighbor in space.neighbors("cut", 2).neighbors:
+        print(f"{neighbor.record}: {neighbor.distance}")
 
 
 if __name__ == "__main__":

--- a/python/examples/metric_space/structured_record_space.py
+++ b/python/examples/metric_space/structured_record_space.py
@@ -26,9 +26,9 @@ def main():
     query = {"status": "ok", "temperature_c": 63.0, "events": ("start", "load", "idle")}
 
     space = Space(records, structured_record_distance)
-    nearest_id, nearest_distance = space.nearest(query)
+    nearest = space.nearest(query)
 
-    print("nearest structured record =", records[nearest_id]["id"], nearest_distance)
+    print("nearest structured record =", nearest.record["id"], nearest.distance)
     print("distance(pump-a, valve-c) =", space.distance(0, 2))
     print("pairwise rows =", len(pairwise_distance_matrix(records, structured_record_distance)))
 

--- a/python/examples/metric_space/time_series_alignment_space.py
+++ b/python/examples/metric_space/time_series_alignment_space.py
@@ -37,17 +37,17 @@ def main():
     query = (0, 1, 1, 1, 2, 4)
 
     space = Space(records, aligned_curve_distance)
-    nearest_id, nearest_distance = space.nearest(query)
+    nearest = space.nearest(query)
     distances = pairwise_distance_matrix(records, aligned_curve_distance)
     dimension = intrinsic_dimension(records, aligned_curve_distance)
 
-    assert names[nearest_id] == "baseline"
-    assert nearest_distance == 1.0
+    assert names[nearest.id] == "baseline"
+    assert nearest.distance == 1.0
     assert distances[0][1] == 2.0
     assert distances[0][2] == 6.0
     assert dimension > 0.0
 
-    print("nearest process curve =", names[nearest_id], nearest_distance)
+    print("nearest process curve =", names[nearest.id], nearest.distance)
     print("distance(baseline, shifted) =", distances[0][1])
     print("intrinsic dimension estimate =", round(dimension, 3))
 


### PR DESCRIPTION
## Summary
- update promoted Python metric-space and engine examples to read named `Neighbor` / `NeighborResult` fields
- route tree and graph representation examples through `Space.neighbors(..., representation=...)` so the teaching path stays on named result objects
- record the example cleanup in `docs/revival-status.md`

## Verification
- `for example in python/examples/metric_space/*.py python/examples/engine/*.py; do PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python "$example"; done`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`