### PR TITLE
Add Python structure result conversions

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -320,7 +320,7 @@ numeric distance array, and `to_pandas()` when pandas is installed.
 
 `intrinsic_dimension` returns an expansion-dimension estimate based on finite-space neighborhood growth. Treat it as a diagnostic that depends on the metric, sample density, duplicates, and available radii.
 
-`describe_structure` returns a `StructureDescription` with record count, evaluated pair count, zero-distance pair count, minimum nonzero distance, maximum distance, average distance, and intrinsic-dimension estimate. `Space.describe()` and `Space.describe_structure()` expose the same diagnostics from the `Space` facade. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`.
+`describe_structure` returns a `StructureDescription` with record count, evaluated pair count, zero-distance pair count, minimum nonzero distance, maximum distance, average distance, and intrinsic-dimension estimate. `Space.describe()` and `Space.describe_structure()` expose the same diagnostics from the `Space` facade. Pass a fresh `representation=` to record representation metadata; stale representations raise `metric.StaleRepresentationError`. Use `StructureDescription.to_dict()` for structured metadata, `to_numpy()` for the ordered numeric diagnostic vector, and `to_pandas()` for a one-row diagnostics table when pandas is installed.
 
 ## Custom Metrics
 

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -39,6 +39,7 @@ The current local tree implements the first revival slice:
 - Python grouping facade accepts fresh explicit representations and records representation metadata
 - Python `ClusteringResult` exposes `to_dict()`, `to_numpy()`, and optional `to_pandas()` conversion helpers
 - Python engine-style Space intent facade methods for representatives and structure diagnostics
+- Python `StructureDescription` exposes structured conversion helpers for metadata, numeric diagnostics, and optional pandas tables
 - Python representatives facade accepts semantic `count=` target arguments
 - Python representatives facade accepts fresh explicit representations and records representation metadata
 - Python `RepresentativeSet` exposes structured conversion helpers for metadata, selected IDs, and optional pandas coverage rows

--- a/python/pkg/metric/operators.py
+++ b/python/pkg/metric/operators.py
@@ -515,6 +515,45 @@ class StructureDescription:
     strategy: str
     representation: str
 
+    def to_dict(self):
+        return {
+            "record_count": self.record_count,
+            "pair_count": self.pair_count,
+            "zero_distance_pair_count": self.zero_distance_pair_count,
+            "minimum_nonzero_distance": self.minimum_nonzero_distance,
+            "maximum_distance": self.maximum_distance,
+            "average_distance": self.average_distance,
+            "intrinsic_dimension": self.intrinsic_dimension,
+            "has_nonzero_distances": self.has_nonzero_distances,
+            "exact": self.exact,
+            "strategy": self.strategy,
+            "representation": self.representation,
+        }
+
+    def to_numpy(self):
+        return np.asarray(
+            [
+                self.record_count,
+                self.pair_count,
+                self.zero_distance_pair_count,
+                self.minimum_nonzero_distance,
+                self.maximum_distance,
+                self.average_distance,
+                self.intrinsic_dimension,
+            ],
+            dtype=float,
+        )
+
+    def to_pandas(self):
+        try:
+            import pandas as pd
+        except ModuleNotFoundError:
+            raise OptionalDependencyError(
+                "StructureDescription.to_pandas() requires pandas. Install pandas or use to_dict()."
+            ) from None
+
+        return pd.DataFrame.from_records([self.to_dict()])
+
 
 @dataclass(frozen=True)
 class CorrelationResult:

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -1067,6 +1067,19 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(description.maximum_distance, 4)
         self.assertAlmostEqual(description.average_distance, 2.0)
         self.assertAlmostEqual(description.intrinsic_dimension, np.log2(5.0 / 3.0))
+        description_record = description.to_dict()
+        self.assertEqual(description_record["record_count"], 5)
+        self.assertEqual(description_record["strategy"], "exact_all_pairs")
+        np.testing.assert_allclose(
+            description.to_numpy(),
+            np.asarray([5.0, 10.0, 0.0, 1.0, 4.0, 2.0, np.log2(5.0 / 3.0)]),
+        )
+        try:
+            description_frame = description.to_pandas()
+        except exceptions.OptionalDependencyError:
+            description_frame = None
+        if description_frame is not None:
+            self.assertEqual(description_frame.loc[0, "pair_count"], 10)
         self.assertEqual(space.describe_structure(), description)
         matrix_description = space.describe(representation=space.to_matrix())
         self.assertEqual(matrix_description.representation, "matrix")


### PR DESCRIPTION
## Summary
- add `StructureDescription.to_dict()`, `to_numpy()`, and optional `to_pandas()` helpers
- expose an ordered numeric diagnostics vector and one-row pandas diagnostics table
- cover the helpers through the existing structure intent test and document the API/status

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`