### PR TITLE
Add Python runtime diagnostics conversions

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -171,7 +171,9 @@ policy with `exact=False` raises `StrategyUnavailableError` instead of silently
 returning approximate results. `RuntimeDiagnostics` and
 `runtime_diagnostics(...)` expose normalized policy metadata, support status,
 cache mode, serial/parallel selection, and the representation used for an
-intent.
+intent. Use `CachePolicy.to_dict()`, `RuntimePolicy.to_dict()`, and
+`RuntimeDiagnostics.to_dict()` for structured metadata; `RuntimeDiagnostics`
+also exposes `to_pandas()` when pandas is installed.
 
 ## Operators
 

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -25,6 +25,7 @@ The current local tree implements the first revival slice:
 - Python top-level facade exposes integer-compatible `RecordId` defaults for generated stable IDs
 - Python runtime facade exposes `RuntimePolicy`, `CachePolicy`, and `runtime=` on promoted Space intent methods with materialized grouping representation metadata
 - Python runtime facade exposes `RuntimeDiagnostics` with policy, support, and representation metadata
+- Python runtime policy and diagnostics objects expose structured conversion helpers for runtime metadata
 - Python runtime policy helpers select metric-space, matrix, tree, and queryless graph neighbor execution representations
 - Python engine facade modules under `metric.intent` and `metric.representations`
 - Python representation facade exposes `Space.to_matrix()`, `Space.to_tree()`, and `Space.to_graph(count=...)`

--- a/python/pkg/metric/runtime.py
+++ b/python/pkg/metric/runtime.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 import operator
 
-from metric.exceptions import StrategyParameterError, StrategyUnavailableError
+from metric.exceptions import OptionalDependencyError, StrategyParameterError, StrategyUnavailableError
 
 
 _CACHE_MODES = {"auto", "lazy", "materialized", "none"}
@@ -21,6 +21,9 @@ class CachePolicy:
             raise StrategyParameterError("cache mode must be a string")
         if self.mode not in _CACHE_MODES:
             raise StrategyParameterError(f"cache mode must be one of {sorted(_CACHE_MODES)!r}")
+
+    def to_dict(self):
+        return {"mode": self.mode}
 
 
 @dataclass(frozen=True)
@@ -78,6 +81,18 @@ class RuntimePolicy:
         execution = "parallel" if self.parallel else "serial"
         return f"{accuracy}_{self.cache_mode}_{execution}"
 
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "exact": self.exact,
+            "parallel": self.parallel,
+            "cache": self.cache.to_dict(),
+            "cache_mode": self.cache_mode,
+            "representation": self.representation,
+            "representation_preference": self.representation_preference,
+            "graph_count": self.graph_count,
+        }
+
 
 @dataclass(frozen=True)
 class RuntimeDiagnostics:
@@ -91,6 +106,28 @@ class RuntimeDiagnostics:
     intent: str | None = None
     supported: bool = True
     reason: str = ""
+
+    def to_dict(self):
+        return {
+            "policy_name": self.policy_name,
+            "exact": self.exact,
+            "parallel": self.parallel,
+            "cache_mode": self.cache_mode,
+            "representation": self.representation,
+            "intent": self.intent,
+            "supported": self.supported,
+            "reason": self.reason,
+        }
+
+    def to_pandas(self):
+        try:
+            import pandas as pd
+        except ModuleNotFoundError:
+            raise OptionalDependencyError(
+                "RuntimeDiagnostics.to_pandas() requires pandas. Install pandas or use to_dict()."
+            ) from None
+
+        return pd.DataFrame.from_records([self.to_dict()])
 
 
 def runtime_policy(runtime=None):

--- a/python/tests/core/test_revival_api.py
+++ b/python/tests/core/test_revival_api.py
@@ -1734,6 +1734,8 @@ class RevivalApiTest(unittest.TestCase):
 
         self.assertEqual(policy.cache_mode, "materialized")
         self.assertEqual(policy.name, "exact_materialized_parallel")
+        self.assertEqual(policy.cache.to_dict(), {"mode": "materialized"})
+        self.assertEqual(policy.to_dict()["representation_preference"], "matrix")
         self.assertEqual(runtime.materialized(runtime.parallel()).name, "exact_materialized_parallel")
         self.assertEqual(runtime.using_matrix().representation_preference, "matrix")
         self.assertEqual(runtime.using_tree().representation_preference, "exact_tree_index")
@@ -1748,6 +1750,14 @@ class RevivalApiTest(unittest.TestCase):
         self.assertEqual(diagnostics.intent, "neighbors")
         self.assertTrue(diagnostics.supported)
         self.assertEqual(diagnostics.reason, "")
+        self.assertEqual(diagnostics.to_dict()["policy_name"], "exact_materialized_parallel")
+        try:
+            diagnostics_frame = diagnostics.to_pandas()
+        except exceptions.OptionalDependencyError:
+            diagnostics_frame = None
+        if diagnostics_frame is not None:
+            self.assertEqual(diagnostics_frame.loc[0, "representation"], "matrix")
+            self.assertEqual(diagnostics_frame.loc[0, "intent"], "neighbors")
         space_diagnostics = space.runtime_diagnostics(
             representation=space.to_matrix(),
             runtime=policy,


### PR DESCRIPTION
## Summary
- Add `to_dict()` helpers for `CachePolicy` and `RuntimePolicy`.
- Add `RuntimeDiagnostics.to_dict()` and optional `to_pandas()` helpers.
- Document the structured runtime metadata surface and update revival status.

## Verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`