### PR TITLE
Prepare v0.3.3 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+No unreleased changes yet.
+
+## [0.3.3] - 2026-06-20
+
 ### API Changes
 
 - Add the first C++ engine core skeleton with `metric::MetricSpace`, `RecordId`, `Neighbor`, metric traits, engine concept traits, and `make_space`.
@@ -79,6 +83,15 @@
 - Add engine documentation chapters for metric spaces, representations, intents, strategies, operators, mappings, runtime policies, and migration.
 - Update the README quickstart to show the C++ engine path, strategy selection, representation swap, and mapping-derived spaces.
 - Update API and stability docs for the promoted C++ and Python outlier intent surface.
+
+### Packaging and Build
+
+- Prepare Python and C++ package metadata for `0.3.3`.
+- Run PyPI publish dry-run `27862071672` on current `master` with `publish=false`; the source distribution and CPython 3.10 through 3.14 wheels for Linux, macOS, and Windows were built and checked successfully.
+
+### Known Limitations
+
+- PyPI publishing for `metric-space` remains blocked until repository PyPI credentials are replaced or PyPI Trusted Publishing is configured for `metric-space-ai/metric`.
 
 ## [0.3.2] - 2026-06-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.19)
 #endif()
 #cmake_policy(SET CMP0076 NEW)
 
-project(panda_metric VERSION 0.3.2 LANGUAGES CXX)
+project(panda_metric VERSION 0.3.3 LANGUAGES CXX)
 
 # CCache
 # set(METRIC_USE_CCACHE ON)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -88,11 +88,11 @@ PyPI publishing workflow:
 ```shell
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
-  -f ref=v0.3.2 \
+  -f ref=v0.3.3 \
   -f publish=false
 ```
 
-Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.2` and `publish=true`.
+Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.3` and `publish=true`.
 
 For Trusted Publishing, configure PyPI with:
 
@@ -106,7 +106,7 @@ Then run:
 ```shell
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
-  -f ref=v0.3.2 \
+  -f ref=v0.3.3 \
   -f publish=true \
   -f auth_method=trusted-publishing
 ```

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -294,6 +294,7 @@ The following revival improvements landed on `master` after the `v0.3.2` tag and
 - PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` after the master dry-run, so no visible `metric-space` release has been published
 - PyPI was rechecked on 2026-06-20 with the official JSON API and still returned 404 for `https://pypi.org/pypi/metric-space/json`; GitHub release `v0.3.2` remains published as a non-draft, non-prerelease release
 - PyPI publish dry-run `27862071672` completed successfully on `master` commit `9d72264bfed0c6553390e6d9510e0adec6ac817f` with one source distribution artifact and checked wheel artifact sets for CPython 3.10 through 3.14 on Linux, macOS, and Windows; the publish job was skipped because `publish=false`
+- `v0.3.3` release metadata prepares the Python and C++ package versions for the post-`v0.3.2` engine and Python facade work
 - promotion-gated research roadmap for diagnostics, representative selection, sparse graphs, cross-space dependency discovery, denoising, vector-database adapters, and benchmarks, merged as `b80eaba438a6a45f327951c87f74d88c4af37ed3`
 - Python representative-selection helpers using deterministic farthest-first traversal, merged as `78d9d4cdb065555541e10131698452c6d713a257`
 - promoted Python representative-selection example and wheel-gate coverage, merged as `78d9d4cdb065555541e10131698452c6d713a257`

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -14,7 +14,7 @@ The revived core API is organized around explicit finite metric spaces:
 Legacy compiled extension names remain available when their modules are present.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 try:
     from metric._impl.metric import *

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metric-space"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python bindings and helpers for finite metric-space numerics"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump C++ and Python package versions from 0.3.2 to 0.3.3
- move current changelog entries under `[0.3.3] - 2026-06-20` and reset Unreleased
- update release checklist examples and revival status for the v0.3.3 release slice

## Local verification
- `build/python-venv/bin/python -m pip install ./python --force-reinstall --no-deps`
- `build/python-venv/bin/python - <<'PY'\nimport metric\nprint(metric.__version__)\nPY` -> `0.3.3`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --preset core`