### PR TITLE
Add C++ mixed structured records demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add a C++ include-smoke test and docs for the engine graph sparsification operator header.
 - Document Python `KOC` and `DSPCC` strategy objects consistently as roadmap-only strategies in the API stability docs.
 - Document the roadmap-only C++ KOC mapping adapter surface in the engine mapping docs.
+- Add a CI-tested C++ engine flagship demo for mixed structured records with a composed domain metric and runtime diagnostics.
 
 ## [0.3.3] - 2026-06-20
 

--- a/docs/engine/index.md
+++ b/docs/engine/index.md
@@ -30,6 +30,7 @@ They use the engine vocabulary directly across native metric spaces and the vect
 - process curves with an alignment metric, representative selection, and graph construction
 - vectors with Euclidean distance as one record type among others
 - histograms with cumulative transport distance, matrix materialization, and grouping
+- mixed industrial-style records with a composed domain metric and matrix-cache runtime diagnostics
 - cross-space dependency over two aligned finite metric spaces
 
 ## Core Idea

--- a/docs/examples/industrial-anomaly-workflow.md
+++ b/docs/examples/industrial-anomaly-workflow.md
@@ -37,3 +37,5 @@ latent = mapper.transform(new_curve_windows)
 ```
 
 The first three calls are current Python core intent methods. The `map` calls show the target mapping shape: mapping and embedding remain optional downstream representations. The primary model is the metric space.
+
+The CI-tested C++ engine fixture [mixed_structured_records.cpp](../../examples/engine/mixed_structured_records.cpp) uses the same workflow shape over mixed industrial-style records. Its metric combines numeric summaries, status categories, maintenance-message edit distance, histogram transport, and aligned curve distance before running `find_neighbors`, `find_groups`, and `find_outliers` with explicit matrix-cache runtime diagnostics.

--- a/docs/examples/structured-data.md
+++ b/docs/examples/structured-data.md
@@ -12,6 +12,7 @@ Promoted examples that currently run in the core CI path:
 - [custom_metric_space.cpp](../../examples/core/custom_metric_space.cpp): strings compared with a custom padded Hamming metric
 - [time_series_twed_space.cpp](../../examples/core/time_series_twed_space.cpp): process curves compared with TWED
 - [histogram_emd_space.cpp](../../examples/core/histogram_emd_space.cpp): histograms compared with Earth mover distance
+- [mixed_structured_records.cpp](../../examples/engine/mixed_structured_records.cpp): C++ engine demo for mixed industrial records with a composed domain metric, matrix-cache runtime diagnostics, grouping, and outlier detection
 - [explicit_space_representations.cpp](../../examples/core/explicit_space_representations.cpp): one finite metric space represented as matrix, tree, and graph structures
 - [metric_space_entropy.cpp](../../examples/core/metric_space_entropy.cpp): entropy diagnostics over numeric and string records
 - [metric_space_intrinsic_dimension.cpp](../../examples/core/metric_space_intrinsic_dimension.cpp): expansion-dimension diagnostic over a finite line metric

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -86,6 +86,7 @@ The current local tree implements the first revival slice:
 - CI-tested Python engine representation-swap example covering implicit search, matrix materialization, exact tree-style lookup, exact kNN graph adjacency, runtime diagnostics, and stale representation checks
 - CI-tested Python engine clustered-space mapping example covering `ClusteringResult` to derived `Space` lineage
 - CI-tested Python engine flagship example for mixed structured records with a custom composite metric
+- CI-tested C++ engine flagship example for mixed structured records with a composed domain metric, materialized runtime diagnostics, grouping, and DBSCAN-noise outlier detection
 - promoted Python metric-space and engine examples demonstrate named `Neighbor` / `NeighborResult` fields instead of teaching tuple-indexed neighbor access
 - native C++ DNN baseline smoke coverage for RegressionMSE, RMSProp, row-as-observation network training, dense Autoencoder train/encode/decode/save/load, and fully connected parameter serialization round trips
 - native C++ DNN `Network` training hooks for forward activation capture, anchored layer-output backpropagation, and explicit optimizer updates

--- a/examples/engine/CMakeLists.txt
+++ b/examples/engine/CMakeLists.txt
@@ -10,6 +10,9 @@ target_link_libraries(engine_vector_space_special_case PRIVATE ${METRIC_TARGET_N
 add_executable(engine_histogram_transport_space histogram_transport_space.cpp)
 target_link_libraries(engine_histogram_transport_space PRIVATE ${METRIC_TARGET_NAME})
 
+add_executable(engine_mixed_structured_records mixed_structured_records.cpp)
+target_link_libraries(engine_mixed_structured_records PRIVATE ${METRIC_TARGET_NAME})
+
 add_executable(engine_cross_space_mgc cross_space_mgc.cpp)
 target_link_libraries(engine_cross_space_mgc PRIVATE ${METRIC_TARGET_NAME})
 
@@ -24,6 +27,7 @@ if (BUILD_TESTING)
     add_test(NAME example_engine_process_curves_space COMMAND engine_process_curves_space)
     add_test(NAME example_engine_vector_space_special_case COMMAND engine_vector_space_special_case)
     add_test(NAME example_engine_histogram_transport_space COMMAND engine_histogram_transport_space)
+    add_test(NAME example_engine_mixed_structured_records COMMAND engine_mixed_structured_records)
     add_test(NAME example_engine_cross_space_mgc COMMAND engine_cross_space_mgc)
     add_test(NAME example_engine_representation_swap COMMAND engine_representation_swap)
     add_test(NAME example_engine_phate_autoencoder_map COMMAND engine_phate_autoencoder_map)

--- a/examples/engine/mixed_structured_records.cpp
+++ b/examples/engine/mixed_structured_records.cpp
@@ -1,0 +1,188 @@
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <metric/engine.hpp>
+
+namespace {
+
+struct IndustrialRecord {
+	std::array<double, 3> temperature_summary{};
+	std::string status;
+	std::string message;
+	std::array<double, 4> spectrum{};
+	std::vector<double> curve;
+};
+
+struct MixedRecordDistance {
+	auto operator()(const IndustrialRecord &lhs, const IndustrialRecord &rhs) const -> double
+	{
+		const auto fields = contributions(lhs, rhs);
+		return std::accumulate(fields.begin(), fields.end(), 0.0,
+							   [](double total, const auto &entry) { return total + entry.second; });
+	}
+
+	auto contributions(const IndustrialRecord &lhs, const IndustrialRecord &rhs) const
+		-> std::map<std::string, double>
+	{
+		const auto message_scale = static_cast<double>(std::max({lhs.message.size(), rhs.message.size(), std::size_t{1}}));
+		const auto curve_scale = static_cast<double>(std::max({lhs.curve.size(), rhs.curve.size(), std::size_t{1}}));
+
+		return {
+			{"temperature_summary", 0.20 * euclidean(lhs.temperature_summary, rhs.temperature_summary)},
+			{"status", 0.15 * (lhs.status == rhs.status ? 0.0 : 2.0)},
+			{"message", 0.15 * static_cast<double>(edit_distance(lhs.message, rhs.message)) / message_scale},
+			{"spectrum", 0.25 * transport_distance(lhs.spectrum, rhs.spectrum)},
+			{"curve", 0.25 * aligned_curve_distance(lhs.curve, rhs.curve) / curve_scale},
+		};
+	}
+
+  private:
+	static auto euclidean(const std::array<double, 3> &lhs, const std::array<double, 3> &rhs) -> double
+	{
+		double squared = 0.0;
+		for (std::size_t index = 0; index < lhs.size(); ++index) {
+			const auto delta = lhs[index] - rhs[index];
+			squared += delta * delta;
+		}
+		return std::sqrt(squared);
+	}
+
+	static auto edit_distance(const std::string &lhs, const std::string &rhs) -> std::size_t
+	{
+		std::vector<std::size_t> previous(rhs.size() + 1);
+		std::iota(previous.begin(), previous.end(), std::size_t{0});
+		for (std::size_t lhs_index = 1; lhs_index <= lhs.size(); ++lhs_index) {
+			std::vector<std::size_t> current(rhs.size() + 1);
+			current[0] = lhs_index;
+			for (std::size_t rhs_index = 1; rhs_index <= rhs.size(); ++rhs_index) {
+				const auto substitute =
+					previous[rhs_index - 1] + (lhs[lhs_index - 1] == rhs[rhs_index - 1] ? 0 : 1);
+				const auto deletion = previous[rhs_index] + 1;
+				const auto insertion = current[rhs_index - 1] + 1;
+				current[rhs_index] = std::min({substitute, deletion, insertion});
+			}
+			previous = std::move(current);
+		}
+		return previous.back();
+	}
+
+	static auto transport_distance(const std::array<double, 4> &lhs, const std::array<double, 4> &rhs) -> double
+	{
+		double cumulative_delta = 0.0;
+		double distance = 0.0;
+		for (std::size_t index = 0; index < lhs.size(); ++index) {
+			cumulative_delta += lhs[index] - rhs[index];
+			distance += std::abs(cumulative_delta);
+		}
+		return distance;
+	}
+
+	static auto aligned_curve_distance(const std::vector<double> &lhs, const std::vector<double> &rhs) -> double
+	{
+		constexpr double gap_cost = 2.0;
+		std::vector<double> previous(rhs.size() + 1);
+		for (std::size_t index = 0; index < previous.size(); ++index) {
+			previous[index] = static_cast<double>(index) * gap_cost;
+		}
+
+		for (std::size_t lhs_index = 1; lhs_index <= lhs.size(); ++lhs_index) {
+			std::vector<double> current(rhs.size() + 1);
+			current[0] = static_cast<double>(lhs_index) * gap_cost;
+			for (std::size_t rhs_index = 1; rhs_index <= rhs.size(); ++rhs_index) {
+				const auto substitute =
+					previous[rhs_index - 1] + std::min(std::abs(lhs[lhs_index - 1] - rhs[rhs_index - 1]), 2 * gap_cost);
+				const auto deletion = previous[rhs_index] + gap_cost;
+				const auto insertion = current[rhs_index - 1] + gap_cost;
+				current[rhs_index] = std::min({substitute, deletion, insertion});
+			}
+			previous = std::move(current);
+		}
+		return previous.back();
+	}
+};
+
+auto make_records() -> std::vector<IndustrialRecord>
+{
+	return {
+		{{68.0, 69.0, 70.0}, "stable", "nominal flow", {0.6, 0.3, 0.1, 0.0}, {1.0, 1.0, 1.1, 1.0}},
+		{{72.0, 73.0, 75.0}, "warmup", "valve drift warning", {0.1, 0.3, 0.4, 0.2}, {1.0, 1.2, 1.5, 1.4, 1.2}},
+		{{72.5, 73.2, 74.5}, "warmup", "valve drift alert", {0.1, 0.25, 0.45, 0.2}, {1.0, 1.2, 1.4, 1.4, 1.3}},
+		{{64.0, 63.5, 63.0}, "cooldown", "pump normal", {0.0, 0.2, 0.5, 0.3}, {2.0, 1.7, 1.4, 1.1}},
+		{{91.0, 96.0, 101.0}, "alert", "pressure spike stop", {0.0, 0.0, 0.2, 0.8}, {1.0, 6.5, 1.0, 6.0, 1.0}},
+	};
+}
+
+auto make_query() -> IndustrialRecord
+{
+	return {{72.2, 73.1, 75.1},
+			"warmup",
+			"valve drift warning",
+			{0.1, 0.3, 0.4, 0.2},
+			{1.0, 1.2, 1.5, 1.4, 1.3}};
+}
+
+auto close_to(double lhs, double rhs) -> bool
+{
+	return std::abs(lhs - rhs) < 1.0e-9;
+}
+
+} // namespace
+
+int main()
+{
+	const std::vector<std::string> names = {"stable-flow", "warmup-drift", "warmup-alert", "cooldown", "spike-stop"};
+	const auto records = make_records();
+	const auto query = make_query();
+	const MixedRecordDistance metric;
+	auto space = metric::make_space(records, metric);
+
+	metric::representations::MatrixCache<decltype(space)> matrix(space);
+	const auto warmup_distance = matrix.distance(space.id(1), space.id(2));
+	assert(warmup_distance < matrix.distance(space.id(1), space.id(4)));
+
+	const auto neighbors = metric::find_neighbors(space, query, metric::count{2});
+	assert(neighbors.representation == "metric_space");
+	assert(neighbors.size() == 2);
+	assert(names[neighbors[0].id.index()] == "warmup-drift");
+	assert(names[neighbors[1].id.index()] == "warmup-alert");
+
+	const auto explanation = metric.contributions(query, space.record(neighbors[0].id));
+	assert(close_to(explanation.at("status"), 0.0));
+	assert(explanation.at("curve") < 0.01);
+
+	const auto materialized_policy = metric::runtime::materialized(metric::runtime::exact());
+	const auto groups = metric::find_groups(space, metric::strategies::k_medoids(2), materialized_policy);
+	assert(groups.algorithm == "kmedoids");
+	assert(groups.cluster_count == 2);
+	assert(groups.representation == "matrix_cache");
+
+	const auto outliers = metric::find_outliers(space, metric::strategies::dbscan(8.0, 2), materialized_policy);
+	assert(outliers.strategy == "dbscan_noise");
+	assert(outliers.representation == "matrix_cache");
+	assert(outliers.size() == 1);
+	assert(names[outliers[0].id.index()] == "spike-stop");
+
+	const auto diagnostics =
+		metric::runtime::diagnostics_for_space(space, materialized_policy, "matrix_cache", "mixed_record_demo");
+	assert(diagnostics.policy_name == "exact_materialized_serial");
+	assert(diagnostics.representation == "matrix_cache");
+	assert(diagnostics.supported);
+
+	std::cout << "nearest mixed records = " << names[neighbors[0].id.index()] << ", "
+			  << names[neighbors[1].id.index()] << "\n";
+	std::cout << "warmup distance = " << warmup_distance << "\n";
+	std::cout << "message contribution = " << explanation.at("message") << "\n";
+	std::cout << "mixed record groups = " << groups.cluster_count << " via " << groups.representation << "\n";
+	std::cout << "mixed record outlier = " << names[outliers[0].id.index()] << "\n";
+	std::cout << "runtime policy = " << diagnostics.policy_name << " via " << diagnostics.representation << "\n";
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- add a CI-tested C++ engine flagship demo for mixed industrial-style records with a composed domain metric
- cover neighbor search, k-medoids grouping, DBSCAN-noise outlier detection, matrix-cache runtime diagnostics, and per-field metric contribution checks
- link the demo from structured-data, industrial workflow, engine overview, revival status, and changelog docs

## Verification
- `cmake --preset core`
- `cmake --build --preset core --target engine_mixed_structured_records --parallel 2`
- `build/core/examples/engine/engine_mixed_structured_records`
- `ctest --test-dir build/core --output-on-failure -R 'example_engine_mixed_structured_records'`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `git diff --check`
- `cmake --build --preset core --parallel 2 && ctest --preset core --output-on-failure`