### PR TITLE
Add Python user path documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Document Python `KOC` and `DSPCC` strategy objects consistently as roadmap-only strategies in the API stability docs.
 - Document the roadmap-only C++ KOC mapping adapter surface in the engine mapping docs.
 - Add a CI-tested C++ engine flagship demo for mixed structured records with a composed domain metric and runtime diagnostics.
+- Add the Python user-path docs for `Space`, intent methods, result objects, expert strategy overrides, errors, and real-data examples.
 
 ## [0.3.3] - 2026-06-20
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -4,13 +4,19 @@ The current Python core API exposes metric constructors, a minimal `Space` facad
 
 The stable entry point is `Space`: a finite record set plus a metric with cached pairwise distances and intent-named helpers for neighbors, groups, embedding, outliers, denoising, representatives, reduction, compression, deterministic mapping, cross-space comparison, and structure diagnostics. `FiniteMetricSpace` and `MatrixSpace` remain available for explicit representation vocabulary, and `Space.to_matrix()` returns an explicit finite matrix-space view.
 
+For the user-facing learning path, start with [Python Space](../python/space.md),
+[Python Intent Methods](../python/intents.md), [Python Result Objects](../python/results.md),
+[Python Strategy Overrides](../python/strategies.md), and
+[Python Errors](../python/errors.md). This page remains the API reference.
+
 ## Basic Use
 
 ```python
-from metric import Edit, Space
+from metric import Space
+from metric.metrics import Edit
 
 records = ["cat", "cot", "coat", "dog"]
-space = Space(records, Edit())
+space = Space(records, metric=Edit())
 
 print(space.distance(0, 1))
 print(space.pairwise())

--- a/docs/examples/python-compare-spaces.md
+++ b/docs/examples/python-compare-spaces.md
@@ -1,0 +1,56 @@
+# Python Compare Spaces
+
+`Space.compare(...)` measures dependency between two finite metric spaces by
+comparing their distance profiles.
+
+```python
+from metric import Space
+
+sample_ids = ["a", "b", "c", "d", "e"]
+process_values = [0.0, 1.0, 2.0, 3.0, 4.0]
+quality_values = [0.0, 1.0, 4.0, 9.0, 16.0]
+
+
+def absolute_distance(lhs, rhs):
+    return abs(lhs - rhs)
+
+
+process_space = Space(process_values, metric=absolute_distance, ids=sample_ids)
+quality_space = Space(quality_values, metric=absolute_distance, ids=sample_ids)
+
+comparison = process_space.compare(quality_space, align="ids")
+
+print(comparison.statistic_name)
+print(round(comparison.value, 3))
+print(comparison.matched_ids)
+```
+
+Use `align="ids"` when both spaces use the same stable record IDs. Use
+`align="position"` for compatibility with older positional workflows.
+
+Raw right-hand records are accepted when an explicit `other_metric` is passed:
+
+```python
+from metric import Space
+
+process_values = [0.0, 1.0, 2.0, 3.0]
+quality_values = [0.0, 1.0, 4.0, 9.0]
+
+
+def absolute_distance(lhs, rhs):
+    return abs(lhs - rhs)
+
+
+process_space = Space(process_values, metric=absolute_distance)
+comparison = process_space.compare(
+    quality_values,
+    other_metric=absolute_distance,
+    align="position",
+)
+
+print(comparison.to_dict())
+```
+
+The promoted strategy is exact distance-profile correlation. P-values and
+permutation workflows should remain explicit strategy/runtime work until they
+have promoted release gates.

--- a/docs/examples/python-custom-metric.md
+++ b/docs/examples/python-custom-metric.md
@@ -1,0 +1,58 @@
+# Python Custom Metric
+
+Custom metrics are ordinary Python callables. They let users define geometry for
+strings, rows, histograms, curves, descriptors, or domain objects.
+
+## String Records
+
+```python
+from metric import Space
+
+
+def padded_hamming(lhs, rhs):
+    width = max(len(lhs), len(rhs))
+    distance = 0
+    for index in range(width):
+        left = lhs[index] if index < len(lhs) else None
+        right = rhs[index] if index < len(rhs) else None
+        distance += left != right
+    return distance
+
+
+space = Space(["red", "reed", "road", "blue"], metric=padded_hamming)
+neighbors = space.neighbors("read", count=2)
+
+for item in neighbors.neighbors:
+    print(item.record, item.distance)
+```
+
+The result uses named `Neighbor` objects, so examples can read fields instead of
+unpacking tuples.
+
+## Structured Rows
+
+```python
+from metric import Space
+
+records = [
+    {"name": "warmup", "temperature": 20.0, "status": "ok"},
+    {"name": "drift", "temperature": 22.0, "status": "ok"},
+    {"name": "spike", "temperature": 38.0, "status": "stop"},
+]
+
+
+def process_distance(lhs, rhs):
+    temperature = abs(lhs["temperature"] - rhs["temperature"])
+    status = 8.0 if lhs["status"] != rhs["status"] else 0.0
+    return temperature + status
+
+
+space = Space(records, metric=process_distance)
+groups = space.groups(count=2)
+
+print(groups.assignments)
+print(groups.to_dict())
+```
+
+The metric can combine numeric, categorical, and domain-specific penalties in a
+single finite-space geometry.

--- a/docs/examples/python-real-data.md
+++ b/docs/examples/python-real-data.md
@@ -1,0 +1,67 @@
+# Python Real-Data Records
+
+Python spaces can start from real record shapes. The metric defines geometry;
+METRIC does not require an embedding step before users can ask intent questions.
+
+## DataFrame Rows
+
+```python
+from metric import Space
+import pandas as pd
+
+df = pd.DataFrame(
+    [
+        {"sample_id": "s0", "temperature": 20.0, "pressure": 1.00, "status": "ok"},
+        {"sample_id": "s1", "temperature": 21.0, "pressure": 1.03, "status": "ok"},
+        {"sample_id": "s2", "temperature": 35.0, "pressure": 1.40, "status": "warn"},
+    ]
+)
+
+
+def row_distance(lhs, rhs):
+    numeric = abs(lhs["temperature"] - rhs["temperature"]) + 10.0 * abs(
+        lhs["pressure"] - rhs["pressure"]
+    )
+    status = 5.0 if lhs["status"] != rhs["status"] else 0.0
+    return numeric + status
+
+
+space = Space.from_dataframe(df, metric=row_distance, id_column="sample_id")
+
+neighbors = space.neighbors(space.record("s0"), count=2)
+outliers = space.outliers(count=1)
+
+print(neighbors.to_dict())
+print(outliers.to_dict())
+```
+
+`id_column` becomes the stable ID set. The row dictionaries passed to
+`row_distance` do not include that ID field.
+
+## NumPy Time-Series Records
+
+```python
+from metric import Space
+import numpy as np
+
+records = np.array(
+    [
+        [0.0, 0.1, 0.2, 0.3],
+        [0.0, 0.2, 0.4, 0.6],
+        [2.0, 2.1, 1.9, 2.2],
+    ]
+)
+
+
+def aligned_curve_distance(lhs, rhs):
+    return float(np.mean(np.abs(lhs - rhs)))
+
+
+space = Space(records, metric=aligned_curve_distance)
+embedding = space.embed(dimensions=2)
+
+print(embedding.coordinates)
+```
+
+NumPy records are preserved as records. The metric callable receives the row
+objects and decides how the distance should be computed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,9 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Revival Status](revival-status.md)
 - [C++ API](api/cpp.md)
 - [Python API](api/python.md)
+- [Python Space](python/space.md)
+- [Python Intent Methods](python/intents.md)
+- [Python Result Objects](python/results.md)
 - [Finite Metric Spaces](concepts/finite-metric-space.md)
 - [Vector Space as a Special Case](concepts/vector-space-as-special-case.md)
 
@@ -30,10 +33,11 @@ This docs tree is the canonical home for concepts, API references, engine archit
 6. Read [Explicit Representations](concepts/explicit-representations.md) to understand matrix, graph, and tree execution forms.
 7. Read [Graph Representation Terminology](concepts/graph-representations.md) before promoting sparse graph construction.
 8. Use the [Python API](api/python.md) or [C++ API](api/cpp.md) for implementation.
-9. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
-10. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
-11. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
-12. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
+9. For Python, read [Python Space](python/space.md), [Python Intent Methods](python/intents.md), and [Python Result Objects](python/results.md) before strategy overrides.
+10. Use [API Surface](stability.md) to understand core, expert, compatibility, extension APIs, and the module status matrix.
+11. Use [Testing and CI Scope](testing-and-ci.md) to understand release gates versus historical coverage.
+12. Use [Research Roadmap](research-roadmap.md) to understand which research directions can be promoted after deterministic fixtures and release gates exist.
+13. Use [Revival Status](revival-status.md) to distinguish local revival completion from external release actions.
 
 ## Concepts
 
@@ -53,9 +57,21 @@ This docs tree is the canonical home for concepts, API references, engine archit
 - [Explicit Representations](concepts/explicit-representations.md)
 - [Graph Representation Terminology](concepts/graph-representations.md)
 
+## Python User Path
+
+- [Space Constructor And Records](python/space.md)
+- [Intent Methods](python/intents.md)
+- [Result Objects](python/results.md)
+- [Expert Strategy Overrides](python/strategies.md)
+- [Errors And Troubleshooting](python/errors.md)
+- [Python API Reference](api/python.md)
+
 ## Examples
 
 - [Custom Metric Example](examples/custom-metric.md)
+- [Python Custom Metric](examples/python-custom-metric.md)
+- [Python Real-Data Records](examples/python-real-data.md)
+- [Python Compare Spaces](examples/python-compare-spaces.md)
 - [Structured Data](examples/structured-data.md)
 - [Time-Series Space With TWED](examples/time-series-twed.md)
 - [Histogram Space With EMD](examples/histogram-emd.md)

--- a/docs/python/errors.md
+++ b/docs/python/errors.md
@@ -1,0 +1,114 @@
+# Python Errors
+
+Python public methods raise METRIC exceptions with actionable messages. They
+should not expose pybind11 overload details, generated template names, or
+private `_impl` modules.
+
+## Hierarchy
+
+```text
+MetricError
+  MissingMetricError
+  MetricInputError
+  MetricContractError
+  MetricComputationError
+  AmbiguousIntentError
+  IncompatibleSpaceError
+  StrategyError
+    StrategyUnavailableError
+    StrategyParameterError
+  RepresentationError
+    StaleRepresentationError
+  OptionalDependencyError
+  NotFittedError
+  UnsupportedOperationError
+```
+
+All classes live in `metric.exceptions` and are re-exported from `metric`.
+
+## Missing Metrics
+
+```python
+from metric import Space
+from metric import MissingMetricError
+
+try:
+    Space(["cat", "cot"])
+except MissingMetricError as error:
+    print(error)
+```
+
+`Space(records)` without a metric raises `MissingMetricError`. Use
+`Space(records, metric=...)` for arbitrary records or `Space.vectors(...)` for
+the vector-specific Euclidean convenience.
+
+## Metric Contract Errors
+
+```python
+from metric import Space
+from metric import MetricContractError
+
+
+def bad_distance(lhs, rhs):
+    return -1.0
+
+
+try:
+    Space(["a", "b"], metric=bad_distance, validate="strict")
+except MetricContractError as error:
+    print(error)
+```
+
+Validation checks that distances are real, finite, and non-negative. It does
+not prove every metric axiom unless user code asks for separate contract tests.
+
+## Unsupported Strategies
+
+```python
+from metric import Space
+from metric import StrategyUnavailableError
+from metric.metrics import Edit
+from metric.strategies import DSPCC
+
+space = Space(["cat", "cot", "coat"], metric=Edit())
+
+try:
+    space.map(strategy=DSPCC(dimensions=2))
+except StrategyUnavailableError as error:
+    print(error)
+```
+
+Roadmap strategies fail explicitly instead of falling through to partial or
+legacy behavior.
+
+## Stale Representations
+
+```python
+from metric import Space
+from metric import StaleRepresentationError
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat"], metric=Edit())
+matrix = space.to_matrix()
+space.touch()
+
+try:
+    space.groups(count=2, representation=matrix)
+except StaleRepresentationError as error:
+    print(error)
+```
+
+Representation errors include source and representation version information so
+callers know to rebuild the representation.
+
+## Optional Dependencies
+
+`to_pandas()` helpers raise `OptionalDependencyError` when pandas is not
+installed. Use `to_dict()` or `to_numpy()` for dependency-light code paths.
+
+## Unsupported Inverse Reconstruction
+
+Lossy reduction, compression, deterministic mapping, and denoise results expose
+`inverse_supported=False`. Calling `inverse_transform(...)` raises
+`UnsupportedOperationError` until a strategy with a promoted inverse contract is
+available.

--- a/docs/python/intents.md
+++ b/docs/python/intents.md
@@ -1,0 +1,161 @@
+# Python Intent Methods
+
+The Python facade is organized around user intent. Start with records and a
+metric, then ask what you want to know about the finite metric space.
+
+## Neighbors
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+neighbors = space.neighbors("cut", count=2)
+
+for item in neighbors.neighbors:
+    print(item.record, item.distance)
+```
+
+Use `count` for nearest-neighbor queries and `radius` for range-neighbor
+queries. Calling `space.neighbors(count=...)` without a query returns one
+neighbor row per source record in `result.rows`.
+
+## Groups
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+groups = space.groups(count=2)
+
+print(groups.assignments)
+print(groups.medoids)
+```
+
+`count` selects deterministic k-medoids grouping. `radius` selects a DBSCAN
+style density grouping with explicit noise records.
+
+## Embed
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+embedding = space.embed(dimensions=2)
+
+print(embedding.coordinates)
+print(embedding.diagnostics.to_dict())
+```
+
+Embedding creates a derived coordinate view for visualization and diagnostics.
+It does not change the source records and does not make vectors the primary
+model.
+
+## Map
+
+```python
+from metric import Space
+
+records = [
+    {"id": "a", "temperature": 21.0, "pressure": 1.0},
+    {"id": "b", "temperature": 22.5, "pressure": 1.1},
+    {"id": "c", "temperature": 36.0, "pressure": 2.0},
+]
+
+
+def row_distance(lhs, rhs):
+    return abs(lhs["temperature"] - rhs["temperature"]) + abs(
+        lhs["pressure"] - rhs["pressure"]
+    )
+
+
+def temperature(record):
+    return record["temperature"]
+
+
+mapped = Space(records, metric=row_distance).map(
+    transform=temperature,
+    metric=lambda lhs, rhs: abs(lhs - rhs),
+)
+```
+
+The promoted mapping path is deterministic `transform=...` plus a target metric.
+No-argument mapping, learned `target=...` mapping, and strategy-driven mapping
+raise explicit METRIC errors until those contracts are promoted.
+
+## Outliers
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "doggggg"], metric=Edit())
+outliers = space.outliers(count=1)
+
+print(outliers.outliers[0].record_id)
+print(outliers.outliers[0].score)
+```
+
+The strategy-free default ranks records by nearest-neighbor distance. Pass a
+promoted DBSCAN strategy in expert code for density-noise behavior.
+
+## Denoise
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "doggggg"], metric=Edit())
+clean = space.denoise(count=1)
+
+print(clean.source_record_ids)
+print(len(clean.space))
+```
+
+Denoising returns a derived space and keeps source-record lineage. It does not
+mutate the source space.
+
+## Compare
+
+```python
+from metric import Space
+
+records = ["a", "b", "c", "d"]
+process = [0.0, 1.0, 2.0, 3.0]
+quality = [0.0, 1.0, 4.0, 9.0]
+
+
+def absolute_distance(lhs, rhs):
+    return abs(lhs - rhs)
+
+
+process_space = Space(process, metric=absolute_distance, ids=records)
+quality_space = Space(quality, metric=absolute_distance, ids=records)
+
+comparison = process_space.compare(quality_space, align="ids")
+print(comparison.value)
+```
+
+Comparison uses distance-profile correlation for the promoted exact path.
+Use `align="ids"` when both spaces share stable IDs. The compatibility default
+is positional alignment.
+
+## Representations And Runtime
+
+```python
+from metric import Space
+from metric import RuntimePolicy
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+policy = RuntimePolicy(exact=True, cache="materialized")
+
+neighbors = space.neighbors("cut", count=2, runtime=policy)
+diagnostics = space.runtime_diagnostics(runtime=policy, intent="neighbors")
+```
+
+Current Python intent methods execute exact deterministic paths. Passing
+`RuntimePolicy(exact=False)` raises `StrategyUnavailableError` instead of
+silently returning approximate results.

--- a/docs/python/results.md
+++ b/docs/python/results.md
@@ -1,0 +1,98 @@
+# Python Result Objects
+
+Python intent methods return named result objects. Compatibility iteration is
+kept where older APIs returned tuples, but new code should use fields and
+conversion helpers.
+
+## Common Pattern
+
+Most promoted result objects expose:
+
+| Field Or Method | Meaning |
+|---|---|
+| `exact` | Whether the result came from the exact promoted path. |
+| `strategy` or `algorithm` | Strategy metadata selected by the facade. |
+| `representation` | Representation metadata such as `"metric_space"` or `"matrix"`. |
+| `diagnostics` | Structured diagnostics when the operation produces them. |
+| `to_dict()` | Plain Python data suitable for serialization. |
+| `to_numpy()` | Numeric array where the result has numeric payloads. |
+| `to_pandas()` | DataFrame conversion when pandas is installed. |
+
+If pandas is missing, `to_pandas()` raises `OptionalDependencyError` with
+guidance to install pandas or use `to_dict()`.
+
+## Neighbors
+
+`space.neighbors(query, count=...)` returns `NeighborResult`.
+
+Important fields:
+
+| Field | Meaning |
+|---|---|
+| `query` | Query record for single-query calls. |
+| `query_id` | Query ID when available. |
+| `neighbors` | Tuple of `Neighbor` objects for a single query. |
+| `rows` | Per-source rows for queryless all-record neighbor calls. |
+| `distances` | Ordered distances used by `to_numpy()`. |
+
+Each `Neighbor` has `id`, `record`, `distance`, and `rank`. It also remains
+tuple-compatible as `(id, distance)` for older code.
+
+## Groups
+
+`space.groups(...)` returns `ClusteringResult`.
+
+Key fields include `assignments`, `medoids`, `core_records`, `noise_records`,
+`cluster_sizes`, `record_count`, `cluster_count`, `noise_count`, `iterations`,
+`converged`, `algorithm`, and `representation`.
+
+Labels and medoids are source-record identifiers in the current finite space.
+DBSCAN noise uses `noise_label == -1`.
+
+## Embeddings
+
+`space.embed(...)` returns `EmbeddingResult`.
+
+Key fields include `coordinates`, `embedded_space`, `source_space`, `model`,
+`source_record_ids`, `dimensions`, `stress`, `trustworthiness`, `strategy`,
+`representation`, and `diagnostics`.
+
+The embedded space is a derived `Space` over coordinate records with an explicit
+Euclidean metric. The source space remains available through `source_space`.
+
+## Mapping, Denoise, Reduce, And Compress
+
+`space.map(...)` and `space.denoise(...)` return `MappingResult`.
+`space.reduce(...)` returns `ReductionResult`. `space.compress(...)` returns
+`CompressionResult`.
+
+These result objects preserve lineage through fields such as
+`source_record_ids`, `source_record_count`, `target_record_count`,
+`assignments`, and `nearest_representative_distances`. Current deterministic
+map, denoise, reduction, and compression paths are lossy where reconstruction
+would require a learned inverse, so `inverse_supported` is `False` and
+`inverse_transform(...)` raises `UnsupportedOperationError`.
+
+## Outliers
+
+`space.outliers(...)` returns `OutlierResult`.
+
+Important fields include `outliers`, `record_count`, `cluster_count`,
+`noise_count`, `operator_name`, `strategy`, and `representation`. Each
+`Outlier` has `record_id` and `score`.
+
+## Compare
+
+`space.compare(...)` and `space.correlate(...)` return `CorrelationResult`.
+
+Important fields include `value`, `statistic_name`, `p_value`, `matched_ids`,
+`dropped_left_ids`, `dropped_right_ids`, `align`, `local_scores`,
+`left_representation`, and `right_representation`. The default promoted
+strategy is distance-profile correlation over exact pairwise distance profiles.
+
+## Structure Diagnostics
+
+`space.describe()` returns `StructureDescription` with finite-space diagnostics:
+record count, pair count, zero-distance pair count, minimum nonzero distance,
+maximum distance, average distance, intrinsic-dimension estimate, exactness,
+strategy, and representation metadata.

--- a/docs/python/space.md
+++ b/docs/python/space.md
@@ -1,0 +1,123 @@
+# Python Space
+
+`Space` is the Python entry point for finite metric-space work. It stores a
+finite set of records, an explicit metric callable, stable record IDs, and
+small runtime preferences for validation and distance caching.
+
+## Constructor
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+records = ["cat", "cot", "coat", "dog"]
+space = Space(
+    records,
+    metric=Edit(),
+    ids=None,
+    name="words",
+    metadata={"source": "demo"},
+    validate="sample",
+    copy=False,
+    cache="auto",
+)
+```
+
+`records` may be strings, dictionaries, NumPy rows, time-series records, or
+domain objects. `metric` is required for arbitrary records and must be callable
+as `metric(lhs, rhs)`. `ids` defaults to generated `RecordId` values in input
+order. IDs are stable user-facing identifiers, not physical row positions.
+
+`validate` accepts:
+
+| Value | Behavior |
+|---|---|
+| `"none"` | Skip constructor distance checks. |
+| `"sample"` | Check a small prefix for finite, real, non-negative distances. |
+| `"strict"` | Check every pair during construction. |
+
+`cache` accepts `"auto"`, `"none"`, `"lazy"`, `"materialized"`, or a
+`metric.runtime.CachePolicy`. The default `"auto"` materializes the exact
+pairwise matrix for the current Python finite-space representation.
+
+## Records And IDs
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["alpha", "alfa", "omega"], metric=Edit(), ids=["a", "b", "c"])
+
+assert space.record("a") == "alpha"
+assert space.ids == ["a", "b", "c"]
+assert space.distance(0, 1) == 2
+```
+
+`space.record(record_id)` resolves through stable IDs. Distance and pairwise
+operations use physical positions today, while result objects report stable
+source IDs where the promoted result contract exposes them.
+
+## DataFrame Rows
+
+```python
+from metric import Space
+import pandas as pd
+
+df = pd.DataFrame(
+    [
+        {"sample_id": "a", "temperature": 21.0, "pressure": 1.0},
+        {"sample_id": "b", "temperature": 22.5, "pressure": 1.1},
+        {"sample_id": "c", "temperature": 36.0, "pressure": 2.0},
+    ]
+)
+
+
+def row_distance(lhs, rhs):
+    return abs(lhs["temperature"] - rhs["temperature"]) + 8.0 * abs(
+        lhs["pressure"] - rhs["pressure"]
+    )
+
+
+space = Space.from_dataframe(df, metric=row_distance, id_column="sample_id")
+outliers = space.outliers(count=1)
+```
+
+`Space.from_dataframe(...)` reads rows with `to_dict("records")`. When
+`id_column` is provided, that column becomes the stable ID set and is removed
+from the row dictionaries passed to the metric.
+
+## Vector Convenience
+
+```python
+from metric import Space
+import numpy as np
+
+vectors = np.array([[0.0, 0.0], [3.0, 4.0], [6.0, 8.0]])
+space = Space.vectors(vectors)
+
+assert space.distance(0, 1) == 5.0
+```
+
+`Space.vectors(...)` is a vector-specific convenience with a pure Python
+Euclidean default. Use `Space(records, metric=...)` for arbitrary records and
+for vector records that need a domain-specific metric.
+
+## Representations
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+matrix = space.to_matrix()
+tree = space.to_tree()
+graph = space.to_graph(count=2)
+
+neighbors = space.neighbors("cut", count=2, representation=tree)
+```
+
+`to_matrix()` returns an explicit finite matrix-space view. `to_tree()` and
+`to_graph(count=...)` expose exact deterministic representation vocabulary for
+neighbor and local-structure workflows. Representations capture the source
+space version. After `space.touch()`, old representations fail with
+`StaleRepresentationError` until rebuilt.

--- a/docs/python/strategies.md
+++ b/docs/python/strategies.md
@@ -1,0 +1,78 @@
+# Python Strategy Overrides
+
+Normal Python examples should start with records, a metric, and intent methods.
+Strategy objects are expert controls under `metric.strategies`; they are not
+exported as top-level algorithm names.
+
+## Promoted Strategies
+
+| Strategy | Intent Path | Notes |
+|---|---|---|
+| `MDS` / `ClassicMDS` | `space.embed(...)` | Deterministic classical MDS over the exact finite distance matrix. |
+| `KMedoids` | `space.groups(...)`, `space.reduce(...)`, `space.compress(...)` | Deterministic representative grouping and reduction. |
+| `DBSCAN` | `space.groups(...)`, `space.outliers(...)`, `space.denoise(...)` | Deterministic density grouping and noise filtering. |
+| `FarthestFirst` | `space.representatives(...)`, `space.reduce(...)`, `space.compress(...)` | Deterministic representative selection. |
+| `DistanceProfileCorrelation` | `space.compare(...)` | Pearson correlation of exact pairwise distance profiles. |
+
+```python
+from metric import Space
+from metric.metrics import Edit
+from metric.strategies import KMedoids
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+groups = space.groups(strategy=KMedoids(groups=2, max_iterations=50))
+```
+
+Use strategy objects only when the default intent behavior is not explicit
+enough for the workflow.
+
+## Representation Overrides
+
+```python
+from metric import Space
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+matrix = space.to_matrix()
+
+groups = space.groups(count=2, representation=matrix)
+```
+
+Representations make execution metadata explicit. A stale representation raises
+`StaleRepresentationError` and must be rebuilt from the source space.
+
+## Runtime Overrides
+
+```python
+from metric import Space
+from metric import RuntimePolicy
+from metric.metrics import Edit
+
+space = Space(["cat", "cot", "coat", "dog"], metric=Edit())
+policy = RuntimePolicy(exact=True, cache="materialized", parallel=True)
+
+neighbors = space.neighbors("cut", count=2, runtime=policy)
+```
+
+Runtime policy objects live in `metric.runtime` and are also re-exported from
+`metric`. The promoted Python facade is exact-first. Approximate runtime
+requests fail explicitly until approximate result contracts are promoted.
+
+## Roadmap Strategies
+
+The following strategy objects are importable from `metric.strategies` so users
+can write stable engine vocabulary, but execution raises
+`StrategyUnavailableError` until deterministic fixtures, diagnostics, and
+release gates are promoted:
+
+| Strategy | Roadmap Area |
+|---|---|
+| `DiffusionEmbedding` | Diffusion and PHATE-style embedding. |
+| `PCFA` | PCFA reduction or mapping. |
+| `SOM` | Self-organizing-map reduction or mapping. |
+| `KOC` | Kohonen outlier chart reduction or mapping. |
+| `DSPCC` | DSPCC reduction or dependency-preserving mapping. |
+| `PhateAE` | PHATE autoencoder style learned mapping. |
+
+Roadmap strategy imports are acceptable in expert documentation, but examples
+must show that they are not promoted execution paths yet.


### PR DESCRIPTION
## Summary
- add the Python user-path docs required by `PYTHON_USER_EXPERIENCE_PLAN.md`: `Space`, intent methods, result objects, strategy overrides, and errors
- add real-data, custom-metric, and compare-spaces Python example docs
- link the new Python path from the docs index and Python API reference

## Local verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`