### PR TITLE
Prepare mtrc Python package release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - Add expected diagnostic output snippets for the CI-tested C++ engine flagship demos.
 - Document the `v0.3.3` PyPI publish attempts and the remaining external PyPI authentication blocker.
 
+### Packaging and Build
+
+- Rename the public Python distribution from `metric-space` to the short PyPI
+  package name `mtrc` after PyPI rejected `metric-space` as too similar to an
+  existing project; the import package remains `metric`.
+
 ## [0.3.3] - 2026-06-20
 
 ### API Changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.19)
 #endif()
 #cmake_policy(SET CMP0076 NEW)
 
-project(panda_metric VERSION 0.3.3 LANGUAGES CXX)
+project(panda_metric VERSION 0.3.4 LANGUAGES CXX)
 
 # CCache
 # set(METRIC_USE_CCACHE ON)

--- a/REVIVAL_PLAN.md
+++ b/REVIVAL_PLAN.md
@@ -172,6 +172,7 @@ Tasks:
 
 Potential package names:
 
+- `mtrc`
 - `metric-space`
 - `metric-space-numerics`
 - `metric-py` only if ownership and continuity are intentional
@@ -427,11 +428,12 @@ should move from restoration into framework development.
 
 As of 2026-06-20, the local code, documentation, CI, GitHub release, engine
 layer, and follow-up plan work have reached that transition point. The remaining
-public relaunch blocker is external package-index state: `metric-space` is not
-yet visible on PyPI because both configured publish paths need PyPI-side
-authorization to be fixed. That PyPI task blocks final public package
-availability, but it should not block continued framework development on the
-engine, capability, mapping, demo, and validation plans below.
+public relaunch blocker is external package-index state: the original
+`metric-space` package name was rejected by PyPI name retention, and the short
+replacement name `mtrc` still needs a successful first publish. That PyPI task
+blocks final public package availability, but it should not block continued
+framework development on the engine, capability, mapping, demo, and validation
+plans below.
 
 The following detail plans are the reference set for the next development
 phase:
@@ -485,7 +487,7 @@ lands a meaningful implementation slice. Use these status meanings:
 | [Python User Experience Plan](PYTHON_USER_EXPERIENCE_PLAN.md) | Baseline complete; active roadmap | Python `Space`, named result objects, conversion helpers, runtime policies, strategy docs, error docs, and real-data examples are present. Update when Python becomes the source of a new public workflow or deprecation path. |
 | [Flagship Demos Plan](FLAGSHIP_DEMOS_PLAN.md) | Baseline complete; active roadmap | CI-tested C++ and Python engine demos cover strings, process curves, histograms, vector special case, cross-space dependency, representation swaps, mixed structured records, and PHATE-AE mapping. Update when a new demo becomes canonical or gallery-ready. |
 | [Test And Validation Plan](TEST_AND_VALIDATION_PLAN.md) | Baseline complete; active roadmap | Core, Python, docs, release, fast, extended, nightly, and benchmark validation paths are documented, with core engine smoke and Python revival tests in place. Update when new gates become required or benchmark thresholds are promoted. |
-| PyPI package availability | External blocker | `metric-space` remains unpublished until repository PyPI credentials are replaced or a matching PyPI Trusted Publisher is configured. Update after a successful real publish run and PyPI JSON visibility check. |
+| PyPI package availability | External blocker | `mtrc` has a matching pending PyPI Trusted Publisher, but remains unpublished until a real publish run succeeds and PyPI JSON visibility is confirmed. Update after that publish check. |
 
 These plans should now be treated as the working backlog for the real
 framework-development phase. New work should be planned against the most

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -88,14 +88,15 @@ PyPI publishing workflow:
 ```shell
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
-  -f ref=v0.3.3 \
+  -f ref=v0.3.4 \
   -f publish=false
 ```
 
-Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.3` and `publish=true`.
+Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.4` and `publish=true`.
 
 For Trusted Publishing, configure PyPI with:
 
+- project name: `mtrc`
 - owner: `metric-space-ai`
 - repository: `metric`
 - workflow: `publish-python.yml`
@@ -106,7 +107,7 @@ Then run:
 ```shell
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
-  -f ref=v0.3.3 \
+  -f ref=v0.3.4 \
   -f publish=true \
   -f auth_method=trusted-publishing
 ```

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -204,17 +204,23 @@ git diff --check
 
 The Python package currently uses `pyproject.toml` for the PEP 517 build-system declaration and PEP 621 project metadata. `setup.py` registers the CMake extension build hook and the source-distribution hook that includes the required C++ metric headers in the Python sdist. `scikit-build-core` remains a candidate for a later packaging simplification, but it is not adopted in this revival slice because the current bridge already builds the core wheel and preserves the existing extension layout.
 
-The public Python distribution name is `metric-space`. The import package remains `metric`.
+The public Python distribution name is `mtrc`. The import package remains `metric`.
 
 PyPI name availability was checked on 2026-06-19 with the official PyPI JSON API:
 
 - `metric` exists on PyPI and should not be used for this relaunch.
 - `metric-py` exists on PyPI as version `0.0.6`, points at the historical `panda-official/metric` repository, and should not be reused unless package ownership and continuity are deliberately restored.
-- `metric-space` had no matching visible distribution.
+- `metric-space` had no matching visible distribution, but PyPI later rejected
+  it as too similar to an existing project during pending Trusted Publisher
+  setup.
 - `metric-space-numerics` had no matching visible distribution.
 - `panda-metric` and `panda_metric` had no matching visible distribution.
+- `mtrc` had no matching visible distribution and was accepted by PyPI as a
+  pending Trusted Publisher project name on 2026-06-20.
 
-The release metadata therefore uses `metric-space` to avoid colliding with both the unrelated `metric` project and the historical `metric-py` distribution.
+The release metadata therefore uses `mtrc` to avoid colliding with both the
+unrelated `metric` project, the historical `metric-py` distribution, and PyPI's
+name-retention rejection for `metric-space`.
 
 ## External State Checked
 
@@ -299,7 +305,9 @@ The post-`v0.3.2` revival work listed below was released as `v0.3.3` on 2026-06-
 - PyPI publish run `27864470653` rebuilt and checked the same distribution set successfully with `auth_method=trusted-publishing`, but the final Trusted Publishing token exchange failed with `invalid-publisher` for repository `metric-space-ai/metric`, workflow `publish-python.yml`, ref `refs/heads/master`, and environment `pypi`
 - PyPI publish run `27864755237` rebuilt and checked the same distribution set successfully with `auth_method=password`, but the first Twine upload failed with `HTTPError: 403 Forbidden` from `https://upload.pypi.org/legacy/`
 - PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` on 2026-06-20 after the `v0.3.3` dry-run and both real publish attempts, so no visible `metric-space` release has been published
-- the remaining external release action is still to update repository PyPI credentials or configure a matching PyPI Trusted Publisher before rerunning `.github/workflows/publish-python.yml` with `ref=v0.3.3`, `publish=true`, and the matching `auth_method`
+- the next release action is to publish the renamed `mtrc` package from the
+  `v0.3.4` release with `.github/workflows/publish-python.yml`,
+  `publish=true`, and `auth_method=trusted-publishing`
 
 The `v0.3.3` release includes the following revival improvements that landed on `master` after the `v0.3.2` tag:
 
@@ -466,6 +474,12 @@ PyPI release after the `v0.3.3` dry-run and both real upload paths. The
 Trusted Publishing path failed because PyPI has no matching publisher for the
 workflow claims, and the repository-secret password path reached PyPI but was
 rejected with `403 Forbidden`.
+
+After that failure, PyPI rejected pending Trusted Publisher setup for
+`metric-space` because the name is too similar to an existing project. The short
+package name `mtrc` was selected instead and accepted as a pending Trusted
+Publisher for owner `metric-space-ai`, repository `metric`, workflow
+`publish-python.yml`, and environment `pypi`.
 
 ## Historical Code Policy
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,7 @@
 
 Python bindings for METRIC metric-space numerics.
 
-The public Python distribution name is `metric-space`. The import package remains
+The public Python distribution name is `mtrc`. The import package remains
 `metric`.
 
 The revived core package exposes the project concepts explicitly:
@@ -23,7 +23,7 @@ The Python package is in revival. The current supported CPython targets for the 
 After the package is published to PyPI, install the core package with:
 
 ```shell
-python -m pip install metric-space
+python -m pip install mtrc
 ```
 
 Until PyPI publishing is completed, build from source with the instructions below.

--- a/python/pkg/metric/__init__.py
+++ b/python/pkg/metric/__init__.py
@@ -14,7 +14,7 @@ The revived core API is organized around explicit finite metric spaces:
 Legacy compiled extension names remain available when their modules are present.
 """
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 try:
     from metric._impl.metric import *

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,8 +9,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "metric-space"
-version = "0.3.3"
+name = "mtrc"
+version = "0.3.4"
 description = "Python bindings and helpers for finite metric-space numerics"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,6 +22,7 @@ keywords = [
   "distance-metrics",
   "finite-metric-space",
   "metric-space",
+  "mtrc",
   "numerical-computing"
 ]
 classifiers = [


### PR DESCRIPTION
## Summary
- rename the public Python distribution from `metric-space` to short PyPI package name `mtrc`
- bump package/CMake version metadata to `0.3.4` while keeping the import package as `metric`
- update release checklist, revival plan, and revival status with the PyPI name-retention result and accepted pending Trusted Publisher

## Verification
- `git diff --check`
- `ruby scripts/check_revival_whitespace.rb`
- `ruby scripts/check_revival_format.rb`
- `ruby scripts/check_markdown_links.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path) }; puts "workflow YAML parsed"'`\n- `PYTHONDONTWRITEBYTECODE=1 build/python-venv/bin/python -m unittest python/tests/core/test_revival_api.py -v`\n- `build/python-venv/bin/python -m build ./python --sdist --outdir build/wheelhouse-mtrc`\n- `METRIC_PYTHON_USE_BLAS=OFF build/python-venv/bin/python -m pip wheel build/wheelhouse-mtrc/*.tar.gz --no-deps -w build/wheelhouse-mtrc`\n- `build/python-venv/bin/python -m twine check build/wheelhouse-mtrc/*`