### PR TITLE
Record mtrc PyPI publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+No changes yet.
+
+## [0.3.4] - 2026-06-20
+
 ### API Changes
 
 - Add the dedicated C++ `<metric/operators/sparsify.hpp>` include path for exact graph construction, graph diagnostics, graph symmetrization, and out-degree pruning helpers.
@@ -23,6 +27,9 @@
 - Rename the public Python distribution from `metric-space` to the short PyPI
   package name `mtrc` after PyPI rejected `metric-space` as too similar to an
   existing project; the import package remains `metric`.
+- Publish `mtrc==0.3.4` to PyPI with Trusted Publishing, one source
+  distribution, and 15 CPython wheels for Linux, macOS, and Windows; a fresh
+  install of `mtrc==0.3.4` imports `metric` version `0.3.4`.
 
 ## [0.3.3] - 2026-06-20
 

--- a/REVIVAL_PLAN.md
+++ b/REVIVAL_PLAN.md
@@ -170,12 +170,16 @@ Tasks:
 - remove TestPyPI install instructions from the main path
 - publish a modern package under a deliberate name
 
-Potential package names:
+Selected public package name:
 
 - `mtrc`
-- `metric-space`
-- `metric-space-numerics`
-- `metric-py` only if ownership and continuity are intentional
+
+Rejected or non-selected package names:
+
+- `metric-space` was rejected by PyPI name retention during pending Trusted
+  Publisher setup
+- `metric-space-numerics` was available but replaced by the shorter `mtrc`
+- `metric-py` should only be reused if ownership and continuity are intentional
 
 Acceptance criteria:
 
@@ -427,13 +431,11 @@ understandable, buildable, tested, documented, and releasable, further work
 should move from restoration into framework development.
 
 As of 2026-06-20, the local code, documentation, CI, GitHub release, engine
-layer, and follow-up plan work have reached that transition point. The remaining
-public relaunch blocker is external package-index state: the original
-`metric-space` package name was rejected by PyPI name retention, and the short
-replacement name `mtrc` still needs a successful first publish. That PyPI task
-blocks final public package availability, but it should not block continued
-framework development on the engine, capability, mapping, demo, and validation
-plans below.
+layer, follow-up plan work, and public PyPI package availability have reached
+that transition point. The original `metric-space` package name was rejected by
+PyPI name retention, so the short replacement name `mtrc` was selected and
+published from release `v0.3.4`. Framework development should now continue on
+the engine, capability, mapping, demo, and validation plans below.
 
 The following detail plans are the reference set for the next development
 phase:
@@ -487,7 +489,7 @@ lands a meaningful implementation slice. Use these status meanings:
 | [Python User Experience Plan](PYTHON_USER_EXPERIENCE_PLAN.md) | Baseline complete; active roadmap | Python `Space`, named result objects, conversion helpers, runtime policies, strategy docs, error docs, and real-data examples are present. Update when Python becomes the source of a new public workflow or deprecation path. |
 | [Flagship Demos Plan](FLAGSHIP_DEMOS_PLAN.md) | Baseline complete; active roadmap | CI-tested C++ and Python engine demos cover strings, process curves, histograms, vector special case, cross-space dependency, representation swaps, mixed structured records, and PHATE-AE mapping. Update when a new demo becomes canonical or gallery-ready. |
 | [Test And Validation Plan](TEST_AND_VALIDATION_PLAN.md) | Baseline complete; active roadmap | Core, Python, docs, release, fast, extended, nightly, and benchmark validation paths are documented, with core engine smoke and Python revival tests in place. Update when new gates become required or benchmark thresholds are promoted. |
-| PyPI package availability | External blocker | `mtrc` has a matching pending PyPI Trusted Publisher, but remains unpublished until a real publish run succeeds and PyPI JSON visibility is confirmed. Update after that publish check. |
+| PyPI package availability | Baseline complete | `mtrc` `0.3.4` is visible on PyPI after Trusted Publishing run `27867187603`; PyPI JSON reports 16 release files, and a fresh local venv installed `mtrc==0.3.4` and imported `metric` version `0.3.4`. Update when the package name, supported wheel matrix, or publishing workflow changes. |
 
 These plans should now be treated as the working backlog for the real
 framework-development phase. New work should be planned against the most

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -89,7 +89,8 @@ PyPI publishing workflow:
 gh workflow run publish-python.yml \
   --repo metric-space-ai/metric \
   -f ref=v0.3.4 \
-  -f publish=false
+  -f publish=false \
+  -f auth_method=trusted-publishing
 ```
 
 Use `publish=true` only after confirming the target package index, credentials, and package ownership. If PyPI returns `403 Forbidden`, rotate the repository PyPI credentials or configure PyPI Trusted Publishing, confirm the package name is still available, and rerun the same workflow with `ref=v0.3.4` and `publish=true`.
@@ -111,6 +112,29 @@ gh workflow run publish-python.yml \
   -f publish=true \
   -f auth_method=trusted-publishing
 ```
+
+After a successful publish, verify PyPI visibility and installability:
+
+```shell
+python - <<'PY'
+import json, urllib.request
+with urllib.request.urlopen("https://pypi.org/pypi/mtrc/json", timeout=30) as response:
+    data = json.load(response)
+print(data["info"]["name"])
+print(data["info"]["version"])
+print(len(data["releases"].get("0.3.4", [])))
+PY
+
+python -m venv /tmp/metric-pypi-verify
+/tmp/metric-pypi-verify/bin/python -m pip install --upgrade pip
+/tmp/metric-pypi-verify/bin/python -m pip install mtrc==0.3.4
+/tmp/metric-pypi-verify/bin/python -c "import metric; print(metric.__version__)"
+```
+
+Current `v0.3.4` evidence: publish workflow run `27867187603` completed with
+Trusted Publishing, PyPI JSON reports `mtrc` version `0.3.4` with 16 release
+files, and a fresh local virtual environment installed `mtrc==0.3.4` and
+imported `metric` version `0.3.4`.
 
 ## Artifacts
 

--- a/docs/revival-status.md
+++ b/docs/revival-status.md
@@ -215,12 +215,13 @@ PyPI name availability was checked on 2026-06-19 with the official PyPI JSON API
   setup.
 - `metric-space-numerics` had no matching visible distribution.
 - `panda-metric` and `panda_metric` had no matching visible distribution.
-- `mtrc` had no matching visible distribution and was accepted by PyPI as a
-  pending Trusted Publisher project name on 2026-06-20.
+- `mtrc` had no matching visible distribution, was accepted by PyPI as a
+  pending Trusted Publisher project name on 2026-06-20, and is now published on
+  PyPI as version `0.3.4`.
 
-The release metadata therefore uses `mtrc` to avoid colliding with both the
-unrelated `metric` project, the historical `metric-py` distribution, and PyPI's
-name-retention rejection for `metric-space`.
+The release metadata and PyPI project therefore use `mtrc` to avoid colliding
+with both the unrelated `metric` project, the historical `metric-py`
+distribution, and PyPI's name-retention rejection for `metric-space`.
 
 ## External State Checked
 
@@ -305,9 +306,31 @@ The post-`v0.3.2` revival work listed below was released as `v0.3.3` on 2026-06-
 - PyPI publish run `27864470653` rebuilt and checked the same distribution set successfully with `auth_method=trusted-publishing`, but the final Trusted Publishing token exchange failed with `invalid-publisher` for repository `metric-space-ai/metric`, workflow `publish-python.yml`, ref `refs/heads/master`, and environment `pypi`
 - PyPI publish run `27864755237` rebuilt and checked the same distribution set successfully with `auth_method=password`, but the first Twine upload failed with `HTTPError: 403 Forbidden` from `https://upload.pypi.org/legacy/`
 - PyPI still returned 404 for `https://pypi.org/pypi/metric-space/json` on 2026-06-20 after the `v0.3.3` dry-run and both real publish attempts, so no visible `metric-space` release has been published
-- the next release action is to publish the renamed `mtrc` package from the
-  `v0.3.4` release with `.github/workflows/publish-python.yml`,
-  `publish=true`, and `auth_method=trusted-publishing`
+- the renamed `mtrc` package was published from the follow-up `v0.3.4` release
+  state below
+
+## v0.3.4 Release State
+
+The PyPI package rename and first successful public package publication were
+released as `v0.3.4` on 2026-06-20:
+
+- the `mtrc` release metadata update landed through [pull request #624](https://github.com/metric-space-ai/metric/pull/624), merged into `master` as commit `6bb809b3268ad14b2c593d118634cf480882bd9d`
+- tag `v0.3.4` points at commit `6bb809b3268ad14b2c593d118634cf480882bd9d`
+- [GitHub release `v0.3.4`](https://github.com/metric-space-ai/metric/releases/tag/v0.3.4) is published as a non-draft, non-prerelease release
+- release artifact workflow run `27866843882` completed successfully from tag
+  `v0.3.4`
+- PyPI publish dry-run `27866853174` completed successfully on tag `v0.3.4`
+  with one source distribution artifact and checked wheel artifact sets for
+  CPython 3.10 through 3.14 on Linux, macOS, and Windows; the publish job was
+  skipped because `publish=false`
+- PyPI publish run `27867187603` completed successfully on tag `v0.3.4` with
+  `auth_method=trusted-publishing`, checked one source distribution and 15
+  wheels, uploaded the package to PyPI, and generated digital attestations
+- PyPI JSON for `https://pypi.org/pypi/mtrc/json` returned project name
+  `mtrc`, version `0.3.4`, project URL `https://pypi.org/project/mtrc/`, and 16
+  release files
+- a fresh local virtual environment installed `mtrc==0.3.4` from PyPI and
+  `import metric` reported `metric.__version__ == "0.3.4"`
 
 The `v0.3.3` release includes the following revival improvements that landed on `master` after the `v0.3.2` tag:
 
@@ -469,17 +492,12 @@ The following follow-up-plan work landed on `master` after the `v0.3.3` tag:
 - validation-plan CI grouping documentation for fast, extended, nightly, and benchmark paths, merged through [pull request #619](https://github.com/metric-space-ai/metric/pull/619) as `dcc56fbe957216b31abe9d2f34eb0e682720937f`
 - expected diagnostic-output snippets for the C++ engine flagship demos, merged through [pull request #620](https://github.com/metric-space-ai/metric/pull/620) as `fa8bd2e91805987c4a2787914f8be5e936b788ae`
 
-The PyPI publish blocker remains external: `metric-space` still has no visible
-PyPI release after the `v0.3.3` dry-run and both real upload paths. The
-Trusted Publishing path failed because PyPI has no matching publisher for the
-workflow claims, and the repository-secret password path reached PyPI but was
-rejected with `403 Forbidden`.
-
-After that failure, PyPI rejected pending Trusted Publisher setup for
-`metric-space` because the name is too similar to an existing project. The short
-package name `mtrc` was selected instead and accepted as a pending Trusted
-Publisher for owner `metric-space-ai`, repository `metric`, workflow
-`publish-python.yml`, and environment `pypi`.
+The PyPI publish blocker is resolved by the `v0.3.4` release. PyPI rejected
+pending Trusted Publisher setup for `metric-space` because the name is too
+similar to an existing project, so the short package name `mtrc` was selected
+instead. PyPI accepted `mtrc` for owner `metric-space-ai`, repository `metric`,
+workflow `publish-python.yml`, and environment `pypi`; Trusted Publishing run
+`27867187603` then published `mtrc==0.3.4` successfully.
 
 ## Historical Code Policy
 


### PR DESCRIPTION
## Summary\n- mark PyPI package availability as complete in the revival plan\n- record v0.3.4 release, Trusted Publishing, PyPI JSON, and fresh install evidence\n- move the current changelog entries into the v0.3.4 release section\n\n## Verification\n- git diff --check\n- ruby scripts/check_revival_whitespace.rb\n- ruby scripts/check_revival_format.rb\n- ruby scripts/check_markdown_links.rb\n- PyPI JSON: mtrc 0.3.4 with 16 release files\n- fresh venv: pip install mtrc==0.3.4; import metric => 0.3.4